### PR TITLE
close #56 add is_master to option type

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-spree_opts = '>= 4.4.0'
+spree_opts = '~> 4.4.0'
 gem 'spree', spree_opts
 gem 'spree_api', spree_opts
 gem 'spree_backend', spree_opts
@@ -26,6 +26,9 @@ group :test do
   gem 'byebug'
   gem 'shoulda-matchers', '~> 5.0'
   gem 'spree_travel_core', github: 'channainfo/spree_travel_core'
+
+  # ActionMailer, Net::SMTP
+  gem 'net-smtp'
 end
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,25 +99,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    async (1.30.3)
-      console (~> 1.10)
-      nio4r (~> 2.3)
-      timers (~> 4.1)
-    async-http (0.59.3)
-      async (>= 1.25)
-      async-io (>= 1.28)
-      async-pool (>= 0.2)
-      protocol-http (~> 0.23.1)
-      protocol-http1 (~> 0.14.0)
-      protocol-http2 (~> 0.14.0)
-      traces (>= 0.8.0)
-    async-http-faraday (0.11.0)
-      async-http (~> 0.42)
-      faraday
-    async-io (1.34.0)
-      async
-    async-pool (0.3.12)
-      async (>= 1.25)
     auto_strip_attributes (2.6.0)
       activerecord (>= 4.0)
     autoprefixer-rails (10.4.7.0)
@@ -137,7 +118,7 @@ GEM
     builder (3.2.4)
     byebug (11.1.3)
     cancancan (3.4.0)
-    capybara (3.38.0)
+    capybara (3.36.0)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -155,8 +136,6 @@ GEM
     childprocess (4.1.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
-    console (1.16.2)
-      fiber-local
     crass (1.0.6)
     database_cleaner (2.0.1)
       database_cleaner-active_record (~> 2.0.0)
@@ -180,7 +159,7 @@ GEM
       devise (>= 2.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    doorkeeper (5.6.0)
+    doorkeeper (5.6.2)
       railties (>= 5)
     elastic-transport (8.1.0)
       faraday (< 3)
@@ -202,20 +181,18 @@ GEM
     faraday-net_http (3.0.2)
     ffaker (2.21.0)
     ffi (1.15.5)
-    fiber-local (1.0.0)
     flatpickr (4.6.11.0)
     friendly_id (5.5.0)
       activerecord (>= 4.0.0)
     gem-release (2.2.2)
-    github_changelog_generator (1.16.4)
+    github_changelog_generator (1.15.2)
       activesupport
-      async (>= 1.25.0)
-      async-http-faraday
       faraday-http-cache
       multi_json
       octokit (~> 4.6)
       rainbow (>= 2.2.1)
       rake (>= 10.0)
+      retriable (~> 3.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
     glyphicons (1.0.2)
@@ -298,13 +275,6 @@ GEM
     pg (1.4.5)
     polyglot (0.3.5)
     popper_js (1.16.1)
-    protocol-hpack (1.4.2)
-    protocol-http (0.23.12)
-    protocol-http1 (0.14.6)
-      protocol-http (~> 0.22)
-    protocol-http2 (0.14.2)
-      protocol-hpack (~> 1.4)
-      protocol-http (~> 0.18)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -358,6 +328,7 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    retriable (3.1.2)
     rexml (3.2.5)
     rspec-activemodel-mocks (1.1.0)
       activemodel (>= 3.0)
@@ -368,7 +339,7 @@ GEM
     rspec-expectations (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.0)
+    rspec-mocks (3.12.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-rails (4.1.2)
@@ -418,15 +389,14 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    searchkick (5.1.0)
+    searchkick (5.1.1)
       activemodel (>= 5.2)
       hashie
     select2-rails (4.0.13)
-    selenium-webdriver (4.6.1)
+    selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2, < 3.0)
-      websocket (~> 1.0)
+      rubyzip (>= 1.2.2)
     shoulda-matchers (5.2.0)
       activesupport (>= 5.2.0)
     simplecov (0.21.2)
@@ -565,7 +535,6 @@ GEM
     timers (4.3.5)
     tinymce-rails (6.3.0)
       railties (>= 3.1.1)
-    traces (0.8.0)
     turbo-rails (1.3.2)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
@@ -581,7 +550,6 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (> 3.141, < 5.0)
-    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -593,6 +561,7 @@ PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21
+  x86_64-darwin-22
 
 DEPENDENCIES
   byebug
@@ -604,14 +573,14 @@ DEPENDENCIES
   rails-controller-testing
   searchkick (~> 5.1)
   shoulda-matchers (~> 5.0)
-  spree (>= 4.4.0)
-  spree_api (>= 4.4.0)
+  spree (~> 4.4.0)
+  spree_api (~> 4.4.0)
   spree_auth_devise
-  spree_backend (>= 4.4.0)
+  spree_backend (~> 4.4.0)
   spree_cm_commissioner!
   spree_dev_tools
   spree_multi_vendor
   spree_travel_core!
 
 BUNDLED WITH
-   2.3.24
+   2.3.26

--- a/app/models/spree/option_type_decorator.rb
+++ b/app/models/spree/option_type_decorator.rb
@@ -1,0 +1,13 @@
+module Spree
+  module OptionTypeDecorator
+    def self.prepended(base)
+      base.validate :is_master_has_updated, on: :update, if: :is_master_changed?
+    end
+
+    def is_master_has_updated
+      errors.add(:is_master, I18n.t("option_type.is_master_validation", option_type_name: self.name))
+    end
+  end
+end
+
+Spree::OptionType.prepend Spree::OptionTypeDecorator

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -2,13 +2,37 @@
   module VariantDecorator
     def self.prepended(base)
       base.after_commit :update_vendor_price
+      base.validate :validate_option_types
+    end
+
+    def selected_option_value_ids
+      option_value_variants.pluck(:option_value_id)
     end
 
     private
+
     def update_vendor_price
       if product_type&.name == 'Property'
         vendor.update(min_price: price) if price < vendor.min_price
         vendor.update(max_price: price) if price > vendor.max_price
+      end
+    end
+
+    def validate_option_types
+      variant = self
+
+      option_values.each do |option_value|
+        option_type = option_value.option_type
+
+        if variant.is_master? && !option_type.is_master?
+          message = I18n.t("variant.validation.option_type_is_not_master", option_type_name: option_type.name, option_value_name: option_value.name)
+          errors.add(:attr_type, message) 
+        end
+
+        if !variant.is_master? && option_type.is_master?
+          message = I18n.t("variant.validation.option_type_is_master", option_type_name: option_type.name, option_value_name: option_value.name)
+          errors.add(:attr_type, message)
+        end
       end
     end
   end

--- a/app/overrides/spree/admin/option_types/_form/master.html.erb.deface
+++ b/app/overrides/spree/admin/option_types/_form/master.html.erb.deface
@@ -1,0 +1,13 @@
+<!-- insert_bottom "[data-hook='admin_option_type_form_fields']" -->
+
+<div class="col-12">
+  <%= f.field_container :is_master do %>
+    <%= f.label :is_master do %>
+      <%= f.check_box :is_master, :disabled => !f.object.new_record? %>
+      <%= Spree.t(:is_master) %>
+    <% end %>
+    <small class="form-text text-muted">
+      <%= raw I18n.t('option_type.is_master_info') %>
+    </small>
+  <% end %>
+</div>

--- a/app/overrides/spree/admin/products/_form/option_types.html.erb.deface
+++ b/app/overrides/spree/admin/products/_form/option_types.html.erb.deface
@@ -1,0 +1,22 @@
+<!-- replace "[data-hook='admin_product_form_option_types']" -->
+
+<% master_option_types = @product.master_option_types %>
+<% option_types_excluding_master = @product.option_types_excluding_master %>
+
+<div data-hook="admin_product_form_option_types_excluding_master">
+  <%= render 'shared/option_type_field',
+    label: Spree.t(:option_types),
+    select: :option_types_excluding_master_ids,
+    option_types: option_types_excluding_master,
+    f:f
+  %>
+</div>
+
+<div data-hook="admin_product_form_master_option_types">
+  <%= render 'shared/option_type_field',
+    label: Spree.t(:amenities),
+    select: :master_option_type_ids,
+    option_types: master_option_types,
+    f:f
+  %>
+</div>

--- a/app/views/shared/_option_type_field.erb
+++ b/app/views/shared/_option_type_field.erb
@@ -1,0 +1,23 @@
+<div data-hook="admin_product_form_option_types">
+  <%= f.field_container :master_option_types do %>
+    <%= f.label :option_type_ids, label %>
+
+    <% if can? :modify, Spree::ProductOptionType %>
+    <%= f.select select, options_from_collection_for_select(option_types, :id, :name, option_types.pluck(:id)),
+                                    { include_hidden: true },
+                                      multiple: true,
+                                      data: { autocomplete_url_value: 'option_types_api_v2',
+                                              autocomplete_return_attr_value: 'name',
+                                              autocomplete_multiple_value: true } %>
+    <% elsif option_types.any? %>
+      <ul class="text_list">
+        <% option_types.each do |type| %>
+          <li><%= type.presentation %> (<%= type.name %>)</li>
+        <% end %>
+      </ul>
+    <% else %>
+      <div class="alert alert-info"><%= Spree.t(:no_resource_found, resource: :option_types) %></div>
+    <% end %>
+
+  <% end %>
+</div>

--- a/db/migrate/20221214033306_add_is_master_to_spree_option_types.rb
+++ b/db/migrate/20221214033306_add_is_master_to_spree_option_types.rb
@@ -1,0 +1,5 @@
+class AddIsMasterToSpreeOptionTypes < ActiveRecord::Migration[6.1]
+  def change
+    add_column :spree_option_types, :is_master, :boolean, null: false, default: false
+  end
+end

--- a/spec/models/spree/option_type_spec.rb
+++ b/spec/models/spree/option_type_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+RSpec.describe Spree::OptionType, type: :model do
+  describe 'associations' do
+    it { should have_many(:option_values).class_name('Spree::OptionValue').dependent(:destroy) }
+  end
+
+  describe 'validations' do
+    it 'raise error on update is_master after created' do
+      option_type = create(:option_type, is_master: true)
+      option_type.is_master = false
+
+      expect(option_type.is_master_changed?).to eq true
+      expect{option_type.save!}.to raise_error ActiveRecord::RecordInvalid
+    end
+  end
+end

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Spree::Product, type: :model do
   describe 'associations' do
     it { should have_many(:prices_including_master).class_name('Spree::Price').through(:variants_including_master) }
     it { should have_many(:option_values).through(:option_types) }
+    it { should have_many(:master_option_types).through(:product_option_types) }
+    it { should have_many(:option_types_excluding_master).through(:product_option_types) }
   end
 
   describe 'scope' do

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -1,6 +1,83 @@
 require 'spec_helper'
 
 RSpec.describe Spree::Variant, type: :model do
+  describe 'validations' do
+    context 'saving option values to variants' do
+      let(:master_option_type) { Spree::OptionType.create(is_master: true, presentation: "Bathroom & Toiletries", name: "bathroom-toiletries") }
+      let(:normal_option_type) { Spree::OptionType.create(is_master: false, presentation: "Capacity", name: "capacity") }
+  
+      let(:master_option_values) {[
+        Spree::OptionValue.create(option_type: master_option_type, presentation: "Accessible toilet", name: "accessible-toilet"),
+        Spree::OptionValue.create(option_type: master_option_type, presentation: "Adapted bath", name: "adapted-bath"),
+        # Spree::OptionValue.create(option_type: master_option_type, presentation: "Bathrobes", name: "bathrobes"),
+        # Spree::OptionValue.create(option_type: master_option_type, presentation: "Cleaning products", name: "cleaning-products"),
+        # Spree::OptionValue.create(option_type: master_option_type, presentation: "Hair dryer", name: "hair-dryer"),
+        # Spree::OptionValue.create(option_type: master_option_type, presentation: "Mirror", name: "mirror"),
+        # Spree::OptionValue.create(option_type: master_option_type, presentation: "Toiletries", name: "toiletries"),
+        # Spree::OptionValue.create(option_type: master_option_type, presentation: "Towels", name: "towels"),
+        # Spree::OptionValue.create(option_type: master_option_type, presentation: "Walk-in shower", name: "walk-in-shower"),
+      ]}
+  
+      let(:normal_option_values) {[
+        Spree::OptionValue.create(option_type: normal_option_type, presentation: "1 people", name: "1-people"),
+        # Spree::OptionValue.create(option_type: normal_option_type, presentation: "2 people", name: "2-people"),
+        # Spree::OptionValue.create(option_type: normal_option_type, presentation: "3 people", name: "3-people"),
+      ]}
+  
+      let(:vendor) { create(:active_vendor, stock_locations: [ create(:stock_location) ]) }
+      let(:product) {
+        product = create(:base_product, vendor: vendor, option_types: [ master_option_type, normal_option_type ])
+        product.reload
+      }
+  
+      context 'for master variant' do
+        it 'saved master option values to master_variant' do
+          master_variant = build(
+            :master_variant, 
+            product: product, 
+            option_values: master_option_values
+          )
+  
+          expect { master_variant.save! }.not_to raise_error
+        end
+    
+        # it 'raise error on saving none-master option values to master_variant' do
+        #   master_variant = build(
+        #     :master_variant,
+        #     product: product,
+        #     option_values: normal_option_values
+        #   )
+    
+        #   expect {
+        #     master_variant.save! 
+        #   }.to raise_error(ActiveRecord::RecordInvalid)
+        # end
+      end
+  
+      context 'for normal variant' do
+        it 'saved none-master option values to normal_variant' do
+          normal_variant = build(
+            :base_variant, 
+            product: product, 
+            option_values: normal_option_values
+          )
+  
+          expect { normal_variant.save! }.not_to raise_error
+        end
+    
+        # it 'raise error on saving master option values to normal_variant' do
+        #   normal_variant = build(
+        #     :base_variant,
+        #     product: product,
+        #     option_values: master_option_values
+        #   )
+  
+        #   expect { normal_variant.save! }.to raise_error(ActiveRecord::RecordInvalid)
+        # end
+      end
+    end
+  end
+
   describe 'callbacks' do
     context '#after_commit' do
       let(:vendor) { create(:active_vendor, name: 'Angkor Hotel', min_price: 10, max_price: 30) }


### PR DESCRIPTION
| Tasks | Demo |
| - | - |
| **1. In option_types/:id/edit page:**<br><br>Added `is_master` field to option type. Once set, can't be updated. | ![image](https://user-images.githubusercontent.com/29684683/207668339-067dbad0-ddd7-4ee4-bd59-39f8113f850c.png) |
| | |
| **2. In products/:slug/edit page:**<br><br>Removed option_types field and added 2 more fields.<br><br>**1st**: option types excluding master field<br><br>**2nd**: master option type field | <img width="880" alt="image" src="https://user-images.githubusercontent.com/29684683/207873113-9659c621-99d0-4473-a873-22d960704cf8.png"> |