### PR TITLE
close #58 add page to set option values to master

### DIFF
--- a/app/controllers/spree/admin/master_variant_controller.rb
+++ b/app/controllers/spree/admin/master_variant_controller.rb
@@ -1,0 +1,50 @@
+module Spree
+  module Admin
+    class MasterVariantController < Spree::Admin::ResourceController
+      before_action :load_resource
+
+      # @overrided
+      def load_resource
+        @product ||= Spree::Product.find_by(slug: params[:product_id])
+        @object ||= @product.master
+      end
+
+      # @overrided
+      def index
+        @master_option_types = @product.master_option_types
+      end
+
+      # @overrided
+      def permitted_resource_params
+        option_values = []
+        selected_option_value_ids = params[object_name]['selected_option_value_ids']
+
+        selected_option_value_ids.each do | option_value_id |
+          option_value_id = option_value_id.to_i
+
+          unless option_value_id == 0
+            option_value = Spree::OptionValue.find(option_value_id)
+            option_values << option_value unless option_value.nil?
+          end
+        end
+
+        { 'option_values': option_values }
+      end
+
+      # @overrided
+      def model_class
+        Spree::Variant
+      end
+
+      # @overrided
+      def object_name
+        'variant'
+      end
+
+      # @overrided
+      def collection_url(options = {})
+        admin_product_master_variant_index_url(options)
+      end
+    end
+  end
+end

--- a/app/overrides/spree/admin/shared/_product_tabs/master_variant.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/master_variant.html.erb.deface
@@ -1,0 +1,9 @@
+<!-- insert_bottom "[data-hook='admin_product_tabs']" -->
+
+<%= content_tag :li do %>
+  <%= link_to_with_icon 'adjust.svg',
+    Spree.t(:master_variant),
+    admin_product_master_variant_index_url(@product),
+    class: "nav-link #{'active' if current == :master_variant}" %>
+
+<% end if can?(:admin, Spree::Variant) && !@product.deleted? %>

--- a/app/overrides/spree/admin/variants/_form/option_types_remover.html.erb.deface
+++ b/app/overrides/spree/admin/variants/_form/option_types_remover.html.erb.deface
@@ -1,0 +1,10 @@
+<!-- remove "[data-hook='presentation']" -->
+
+<% if false %>
+
+Purpose is to remove all previous option types.
+Then render again but only normal option type (exclude master)
+
+./option_types_replacer.html.erb.deface
+
+<% end %>

--- a/app/overrides/spree/admin/variants/_form/option_types_replacer.html.erb.deface
+++ b/app/overrides/spree/admin/variants/_form/option_types_replacer.html.erb.deface
@@ -1,0 +1,14 @@
+<!-- insert_top "[data-hook='variants']" -->
+
+<% @product.option_types_excluding_master.each do |option_type| %>
+  <div class="form-group" data-hook="presentation">
+    <%= label :new_variant, option_type.presentation %>
+    <% if option_type.name == 'color' %>
+      <%= f.collection_select 'option_value_ids', option_type.option_values, :id, :name,
+        { include_blank: true }, { name: 'variant[option_value_ids][]', class: 'select2-clear', id: "option_value_ids-#{option_type.id}" } %>
+    <% else %>
+      <%= f.collection_select 'option_value_ids', option_type.option_values, :id, :presentation,
+        { include_blank: true }, { name: 'variant[option_value_ids][]', class: 'select2-clear', id: "option_value_ids-#{option_type.id}"  } %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/spree/admin/master_variant/_form.html.erb
+++ b/app/views/spree/admin/master_variant/_form.html.erb
@@ -1,0 +1,32 @@
+<div class="table-responsive">
+  <table class="table">
+    <% @master_option_types.each do |option_type| %>
+
+      <thead>
+        <tr>
+          <th colspan="3">
+            <%= link_to option_type.presentation, edit_admin_option_type_path(option_type) %>
+          </th>
+        </tr>
+      </thead>
+
+      <tbody class="pb-3">
+        <% option_type.option_values.each_slice(3).each do |page| %>
+          <tr>
+            <%= form.collection_check_boxes :selected_option_value_ids, page, :id, :name do |value| %>
+              <td class="border-bottom">
+                <div class="d-flex align-items-center justify-content-left">
+                  <img class="mr-2" height="18px" src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/External_link_font_awesome.svg/2048px-External_link_font_awesome.svg.png" />
+                  <%= value.check_box %>
+                  <label class="ml-2 mr-2" ><%= value.object.presentation %></label>
+                </div>
+              </td>
+            <% end %>
+          </tr>
+        <% end %>
+        <tr><td colspan=3></td></tr>
+      </tbody>
+
+    <% end %>
+  </table>
+</div>

--- a/app/views/spree/admin/master_variant/index.html.erb
+++ b/app/views/spree/admin/master_variant/index.html.erb
@@ -1,0 +1,14 @@
+<%= render partial: 'spree/admin/shared/product_tabs', locals: { current: :master_variant } %>
+
+<%= form_with model: @object, url: { action: 'update' } do |form| %>
+  <% unless @master_option_types.empty? %>
+    <%= render partial: 'form', locals: { form: form } %>
+    <div class='form-actions' data-hook='buttons'>
+      <%= button Spree.t('actions.update'), 'save.svg', 'submit', { class: 'btn-success', data: { disable_with: "#{ Spree.t(:saving) }..." }} %>
+    </div>
+  <% else %>
+    <small class="form-text text-muted">
+      <%= raw I18n.t('variant.master_option_types.empty_info') %>
+    </small>
+  <% end %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,15 +2,16 @@
 # See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
 
 en:
-  hello: "Hello world"
-
   authenticator:
     incorrect_login: "Incorrect login"
     incorrect_password: "Incorrect password"
     invalid_or_missing_params: "Invalid or missing params"
 
-  user_identity_provider:
-    not_found: "User identity provider for %{identity_type} not found in the system"
+  hello: "Hello world"
+
+  option_type:
+    is_master_info: "When option type is set to master, it can only be used with master variants. <b>Once set</b>, it can't be updated."
+    is_master_validation: "Attribute can't be updated for %{option_type_name}"
 
   stock_location:
     lat:
@@ -19,3 +20,13 @@ en:
     lon:
       label: "Longitude"
       hint: "Enter between 180 to -180"
+
+  user_identity_provider:
+    not_found: "User identity provider for %{identity_type} not found in the system"
+
+  variant:
+    validation:
+      option_type_is_master: "%{option_type_name} / %{option_value_name} is master"
+      option_type_is_not_master: "%{option_type_name} / %{option_value_name} is not master"
+    master_option_types:
+      empty_info: "<b>Note:</b> Set master option types to product first. To edit, go to <b>Details</b> tab > <b>Option Types</b>"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,14 @@ Spree::Core::Engine.add_routes do
         end
       end
     end
+
+    resources :products do
+      resources :master_variant, only: [:index, :update] do
+        collection do
+          patch :update
+        end
+      end
+    end
   end
 
   namespace :api, defaults: { format: 'json' } do


### PR DESCRIPTION
| Task | Demo |
| - | - |
| **1.** Exclude `master option types` from variant form. | <img width="881" alt="image" src="https://user-images.githubusercontent.com/29684683/207035508-a879eeff-52ff-4f51-934a-ec6f91f5369b.png"> |
| | |
| **2.** Add `products/:slug/master_variant` page to toggle option values to master variant. | <img width="1176" alt="image" src="https://user-images.githubusercontent.com/29684683/207666949-c80efda9-f5cc-48f5-93a5-bc1c73c3b5cf.png"> |