### PR TITLE
close #69 implement spree travel core

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ gem "net-smtp", require: false
 group :test do
   gem 'byebug'
   gem 'shoulda-matchers', '~> 5.0'
-  gem 'spree_travel_core', github: 'channainfo/spree_travel_core'
 
   # ActionMailer, Net::SMTP
   gem 'net-smtp'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,3 @@
-GIT
-  remote: https://github.com/channainfo/spree_travel_core.git
-  revision: 0d9489602a70327fbf2a657abbcda5cef40421e9
-  specs:
-    spree_travel_core (4.0.0)
-      deface (~> 1.0)
-      rails (~> 6.1.4)
-      spree_api
-      spree_backend
-      spree_core
-      spree_extension
-
 PATH
   remote: .
   specs:
@@ -532,7 +520,6 @@ GEM
     tilt (2.0.11)
     timecop (0.9.5)
     timeout (0.3.1)
-    timers (4.3.5)
     tinymce-rails (6.3.0)
       railties (>= 3.1.1)
     turbo-rails (1.3.2)
@@ -580,7 +567,6 @@ DEPENDENCIES
   spree_cm_commissioner!
   spree_dev_tools
   spree_multi_vendor
-  spree_travel_core!
 
 BUNDLED WITH
    2.3.26

--- a/app/controllers/spree/admin/product_types_controller.rb
+++ b/app/controllers/spree/admin/product_types_controller.rb
@@ -1,0 +1,25 @@
+module Spree
+  module Admin
+    class ProductTypesController < Spree::Admin::ResourceController
+      # @overrided
+      def collection
+        @collection ||= SpreeCmCommissioner::ProductType.unscoped.all
+      end
+
+      # @overrided
+      def model_class
+        SpreeCmCommissioner::ProductType
+      end
+
+      # @overrided
+      def object_name
+        'spree_cm_commissioner_product_type'
+      end
+
+      # @overrided
+      def collection_url(options = {})
+        admin_product_types_url(options)
+      end
+    end
+  end
+end

--- a/app/models/spree/option_type_decorator.rb
+++ b/app/models/spree/option_type_decorator.rb
@@ -1,11 +1,21 @@
 module Spree
   module OptionTypeDecorator
     def self.prepended(base)
+      base.validates_uniqueness_of :name
+      base.validates :attr_type, presence: true, if: :travel?
+
       base.validate :is_master_has_updated, on: :update, if: :is_master_changed?
+
+      base.after_create :create_default_option_value
     end
 
     def is_master_has_updated
       errors.add(:is_master, I18n.t("option_type.is_master_validation", option_type_name: self.name))
+    end
+
+    def create_default_option_value
+      return unless attr_type != 'selection' && option_values.empty? && travel
+      Spree::OptionValue.create(name: name, presentation: presentation, option_type_id: id)
     end
   end
 end

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,6 +1,8 @@
 module Spree
   module ProductDecorator
     def self.prepended(base)
+      base.belongs_to :product_type, class_name: 'SpreeCmCommissioner::ProductType'
+
       base.has_many :master_option_types, -> { where(is_master: true).order(:position) }, 
         through: :product_option_types, source: :option_type
 

--- a/app/models/spree/prototype_decorator.rb
+++ b/app/models/spree/prototype_decorator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Spree
+  module PrototypeDecorator
+    def self.prepended(base)
+      base.belongs_to :product_type, class_name: 'Spree::ProductType', foreign_key: 'product_type_id'
+    end
+  end
+end
+
+Spree::Prototype.prepend Spree::PrototypeDecorator

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -1,6 +1,8 @@
  module Spree
   module VariantDecorator
     def self.prepended(base)
+      base.has_one :product_type, class_name: 'SpreeCmCommissioner::ProductType', through: :product
+
       base.after_commit :update_vendor_price
       base.validate :validate_option_types
     end

--- a/app/models/spree_cm_commissioner/product_type.rb
+++ b/app/models/spree_cm_commissioner/product_type.rb
@@ -1,0 +1,15 @@
+require_dependency 'spree_cm_commissioner'
+
+module SpreeCmCommissioner
+  class ProductType < ApplicationRecord
+    default_scope { where(enabled: true) }
+
+    validates_presence_of :name, :presentation
+    validates_uniqueness_of :name
+
+    # Modified enabled definition, to exclude product product_type, for lacking of relevance
+    def self.enabled
+      where(enabled: true)
+    end
+  end
+end

--- a/app/overrides/spree/admin/option_types/_form/attr_type.html.erb.deface
+++ b/app/overrides/spree/admin/option_types/_form/attr_type.html.erb.deface
@@ -1,0 +1,17 @@
+<!-- insert_bottom "[data-hook='admin_option_type_form_fields']" -->
+
+<div class="col-12 col-md-6">
+  <% if @option_type.new_record? %>
+    <%= f.field_container :attr_type, class: ['form-group'] do %>
+      <%= f.label :attr_type, Spree.t(:attr_type) %> <span class="required">*</span>
+      <%= f.select :attr_type, ['selection', 'float', 'string', 'integer', 'date', 'boolean', 'amenity'], {}, :class => "fullwidth select2" %>
+      <%= f.error_message_on :attr_type %>
+    <% end %>
+  <% else %>
+    <%= f.field_container :attr_type, class: ['form-group'] do %>
+      <%= f.label :attr_type, Spree.t(:attr_type) %> <span class="required">*</span>
+      <%= f.text_field :attr_type, disabled: true, class: "form-control" %>
+      <%= f.error_message_on :attr_type %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/overrides/spree/admin/option_types/_form/travel.html.erb.deface
+++ b/app/overrides/spree/admin/option_types/_form/travel.html.erb.deface
@@ -1,0 +1,10 @@
+<!-- insert_bottom "[data-hook='admin_option_type_form_fields']" -->
+
+<div class="col-12">
+  <%= f.field_container :travel do %>
+    <%= f.label :travel do %>
+      <%= f.check_box :travel %>
+      <%= Spree.t(:travel) %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/overrides/spree/admin/prototypes/_form/product_type.html.erb.deface
+++ b/app/overrides/spree/admin/prototypes/_form/product_type.html.erb.deface
@@ -1,0 +1,6 @@
+<!-- insert_bottom "[data-hook='admin_prototype_form_fields']" -->
+
+<%= f.field_container :product_type, :class => ['form-group'] do %>
+  <%= f.label :product_type_id, Spree.t(:product_type) %><br />
+  <%= f.collection_select :product_type_id, SpreeCmCommissioner::ProductType.all, :id, :presentation, {:include_blank => true}, {:class => 'select2 fullwidth'} %>
+<% end %>

--- a/app/overrides/spree/admin/prototypes/show/product_types.html.erb.deface
+++ b/app/overrides/spree/admin/prototypes/show/product_types.html.erb.deface
@@ -1,0 +1,20 @@
+<!-- insert_before "h2" -->
+
+<%= @prototype %>
+<%= if false %>
+
+<div class="col-md-6" data-hook="new_product_type">
+  <% if @prototype&.product_type.nil? %>
+    <%= f.field_container :product_type, :class => ['form-group'] do %>
+      <%= f.label :product_type_id, Spree.t(:product_type) %><br />
+      <%= f.collection_select :product_type_id, SpreeCmCommissioner::ProductType.all, :id, :presentation, {:include_blank => true}, {:class => 'select2 fullwidth'} %>
+    <% end %>
+  <% else %>
+    <%= f.field_container :product_type, :class => ['form-group'] do %>
+      <%= f.label :product_type_id, Spree.t(:product_type) %><br />
+      <%= f.collection_select :product_type_id, SpreeCmCommissioner::ProductType.all, :id, :presentation, {:include_blank => true, :selected => @prototype.product_type}, {:class => 'select2 fullwidth'} %>
+    <% end %>
+  <% end %>
+</div>
+
+<% end %>

--- a/app/overrides/spree/admin/shared/sub_menu/_configuration/product_types.html.erb.deface
+++ b/app/overrides/spree/admin/shared/sub_menu/_configuration/product_types.html.erb.deface
@@ -1,0 +1,3 @@
+<!-- insert_top "[data-hook='admin_configurations_sidebar_menu']" -->
+
+<%= configurations_sidebar_menu_item(Spree.t(:product_types), spree.admin_product_types_path) if can? :manage, SpreeCmCommissioner::ProductType %>

--- a/app/views/spree/admin/product_types/_form.html.erb
+++ b/app/views/spree/admin/product_types/_form.html.erb
@@ -1,0 +1,26 @@
+<div data-hook="admin_product_types_form_fields" class="align-center row">
+  <div class="col-md-6">
+    <%= f.field_container :name, class: ['form-group'] do %>
+      <%= f.label :name, Spree.t(:name) %>
+      <%= f.text_field :name, class: 'form-control' %>
+        <%= f.error_message_on :name %>
+    <% end %>
+  </div>
+
+  <div class="col-md-6">
+    <%= f.field_container :presentation, class: ['form-group'] do %>
+      <%= f.label :presentation, Spree.t(:presentation) %>
+      <%= f.text_field :presentation, class: 'form-control' %>
+      <%= f.error_message_on :presentation %>
+  <% end %>
+  </div>
+
+  <div class="col-md-2">
+    <%= f.field_container :enabled, class: ['form-group'] do %>
+      <%= f.check_box :enabled  %>
+      <%= f.label :enabled, Spree.t(:enabled) %>
+      <%= f.error_message_on :enabled %>
+  <% end %>
+  </div>
+
+</div>

--- a/app/views/spree/admin/product_types/edit.html.erb
+++ b/app/views/spree/admin/product_types/edit.html.erb
@@ -1,0 +1,13 @@
+<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @object } %>
+
+<% content_for :page_title do %>
+  <%= Spree.t(:product_types) %>
+<% end %>
+
+<%= form_with model: @object, url: { action: 'update' } do |f| %>
+  <fieldset class="no-border-top">
+    <%= render :partial => 'form', :locals => { :f => f } %>
+    <%= render :partial => 'spree/admin/shared/edit_resource_links' %>
+  </fieldset>
+<% end %>
+

--- a/app/views/spree/admin/product_types/index.html.erb
+++ b/app/views/spree/admin/product_types/index.html.erb
@@ -1,0 +1,45 @@
+<% content_for :page_title do %>
+  <%= Spree.t(:product_types) %>
+<% end %>
+
+<% content_for :page_actions do %>
+  <%= yield :page_actions %>
+  <%= button_link_to(Spree.t(:new_product_type), new_admin_product_type_url, { class: "btn-success", icon: 'add.svg', id: 'new_product_type_link' }) if can? :create, SpreeCmCommissioner::ProductType %>
+<% end %>
+
+<% if @product_types.any? %>
+  <table class="table index" id='listing_product_types' data-hook>
+    <colgroup>
+      <col style="width: 30%" />
+      <col style="width: 25%" />
+      <col style="width: 10%" />
+      <col style="width: 15%" />
+    </colgroup>
+    <thead>
+    <tr data-hook="product_type_header">
+      <th><%= Spree.t(:name) %></th>
+      <th><%= Spree.t(:presentation) %></th>
+      <th><%= Spree.t(:enabled) %></th>
+      <th class="actions"></th>
+    </tr>
+    </thead>
+    <tbody>
+    <% @product_types.each do |product_type| %>
+      <tr id="<%= spree_dom_id product_type %>" data-hook="listing_product_type_row" class="<%= cycle('odd', 'even')%>">
+        <td style="padding-left:1em"><%= product_type.name %></td>
+        <td style="padding-left:1em"><%= product_type.presentation %></td>
+        <td><%= active_badge(product_type.enabled) %></td>
+        <td class="actions">
+          <%= link_to_with_icon('edit.svg', Spree.t(:edit), edit_admin_product_type_url(product_type), class: 'btn btn-primary btn-sm', no_text: true, data: { action: 'edit' }) if can? :edit, product_type %>
+          <%= link_to_delete(product_type, { url: admin_product_type_url(product_type), no_text: true }) if can? :destroy, product_type %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class="alert alert-info no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(SpreeCmCommissioner::ProductType)) %>,
+    <%= link_to Spree.t(:add_one), new_admin_product_type_url %>!
+  </div>
+<% end %>

--- a/app/views/spree/admin/product_types/new.html.erb
+++ b/app/views/spree/admin/product_types/new.html.erb
@@ -1,0 +1,12 @@
+<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @object } %>
+
+<% content_for :page_title do %>
+  <%= Spree.t(:product_types) %>
+<% end %>
+
+<%= form_with model: @object, url: { action: 'create' } do |f| %>
+  <fieldset class="no-border-top" >
+    <%= render :partial => 'form', :locals => { :f => f } %>
+    <%= render :partial => 'spree/admin/shared/new_resource_links' %>
+  </fieldset>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,8 @@ Spree::Core::Engine.add_routes do
         end
       end
     end
+
+    resources :product_types
   end
 
   namespace :api, defaults: { format: 'json' } do

--- a/db/migrate/20221222094940_create_spree_cm_commissioner_product_types.rb
+++ b/db/migrate/20221222094940_create_spree_cm_commissioner_product_types.rb
@@ -1,0 +1,17 @@
+class CreateSpreeCmCommissionerProductTypes < ActiveRecord::Migration[6.1]
+  def change
+    create_table :cm_product_types, if_not_exists: true do |t|
+      t.string :name
+      t.string :presentation
+      t.boolean :enabled, :default => true
+
+      t.timestamps
+    end
+
+    remove_reference :spree_products, :product_type, if_exists: true
+    remove_reference :spree_prototypes, :product_type, if_exists: true
+
+    add_reference :spree_products, :product_type, index: true, foreign_key: { to_table: :cm_product_types }
+    add_reference :spree_prototypes, :product_type, foreign_key: { to_table: :cm_product_types }
+  end
+end

--- a/db/migrate/20221223035257_add_attr_type_to_spree_option_types.rb
+++ b/db/migrate/20221223035257_add_attr_type_to_spree_option_types.rb
@@ -1,0 +1,5 @@
+class AddAttrTypeToSpreeOptionTypes < ActiveRecord::Migration[6.1]
+  def change
+    add_column :spree_option_types, :attr_type, :string, :default => 'selection', if_not_exists: true
+  end
+end

--- a/db/migrate/20221223035937_add_travel_bool_to_spree_option_types.rb
+++ b/db/migrate/20221223035937_add_travel_bool_to_spree_option_types.rb
@@ -1,0 +1,5 @@
+class AddTravelBoolToSpreeOptionTypes < ActiveRecord::Migration[6.1]
+  def change
+    add_column :spree_option_types, :travel, :boolean, default: false, if_not_exists: true
+  end
+end

--- a/lib/spree_cm_commissioner/test_helper/factories/product_type_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/product_type_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :product_type, class: SpreeCmCommissioner::ProductType do
+    sequence(:name)         { |n| "product_type_##{n}" }
+    sequence(:presentation) { |n| "Product Type ##{n}"}
+    enabled                       { true }
+  end
+end

--- a/spec/models/spree_cm_commissioner/product_type_spec.rb
+++ b/spec/models/spree_cm_commissioner/product_type_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::ProductType, type: :model do
+  let(:product_type) { create(:product_type) }
+
+  describe 'validation' do
+    it 'does not allow duplicate names' do
+      product_type = create(:product_type, name: "Service")
+      expect(build(:product_type, name: "Service")).not_to be_valid
+    end
+  end
+end

--- a/spec/serializers/spree/v2/storefront/option_value_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/option_value_serializer_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 
 describe Spree::V2::Storefront::OptionValueSerializer, type: :serializer do
   context 'for display_icon' do
+    before(:each) do
+      ActionController::Base.asset_host = nil
+    end
+
     it 'returns attributes with compiled icon' do
       option_value_with_icon = create(:option_value, icon: "/assets/cm-box.svg")
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@ require File.expand_path('../dummy/config/environment.rb', __FILE__)
 
 require 'spree_dev_tools/rspec/spec_helper'
 require 'spree_multi_vendor/factories'
-require 'spree_travel_core/factories'
 require 'spree_cm_commissioner/factories'
 require 'interactor'
 


### PR DESCRIPTION
# Spree Travel Core
To remove `spree_travel_core`. So we need to add its important feature to `commissioner`. Those features are **product_type** & **attr_type**. Other features from `spree_travel_core` will be removed for now.

## Scope
The following are scope that we copy from spree_travel_core:

- [x] Option Type Attribute Type
  - [x] add `attr_type` to option type, migration + view
- [ ] ProductType Model
  - [x] generate SpreeCmCommissioner::ProductType model, add references to spree_products, spree_prototypes
  - [x] add admin/product_types page
  - [ ] add product_type to product filter view, other PR
  - [ ] add product_type to prototype, other PR
- [x] Improve `spree_travel_core` code

## References
- Credit to: https://github.com/SpreeTravel/spree_travel_core
- The related issue on the server: https://github.com/bookmebus/cm-market-server/pull/31