### PR TITLE
close #76 add product type

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,6 +1,8 @@
 module Spree
   module ProductDecorator
     def self.prepended(base)
+      base.belongs_to :product_type, class_name: 'SpreeCmCommissioner::ProductType'
+
       base.has_many :master_option_types, -> { where(is_master: true).order(:position) }, 
         through: :product_option_types, source: :option_type
 

--- a/app/models/spree/prototype_decorator.rb
+++ b/app/models/spree/prototype_decorator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Spree
+  module PrototypeDecorator
+    def self.prepended(base)
+      base.belongs_to :product_type, class_name: 'SpreeCmCommissioner::ProductType'
+    end
+  end
+end
+
+Spree::Prototype.prepend Spree::PrototypeDecorator

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -1,6 +1,8 @@
  module Spree
   module VariantDecorator
     def self.prepended(base)
+      base.has_one :product_type, class_name: 'SpreeCmCommissioner::ProductType', through: :product
+
       base.after_commit :update_vendor_price
       base.validate :validate_option_types
     end
@@ -12,7 +14,7 @@
     private
 
     def update_vendor_price
-      if product_type&.name == 'Property'
+      if product_type_id == vendor.primary_product_type_id
         vendor.update(min_price: price) if price < vendor.min_price
         vendor.update(max_price: price) if price > vendor.max_price
       end

--- a/app/models/spree/vendor_decorator.rb
+++ b/app/models/spree/vendor_decorator.rb
@@ -1,6 +1,8 @@
 module Spree
   module VendorDecorator
     def self.prepended(base)
+      base.belongs_to :primary_product_type, class_name: 'SpreeCmCommissioner::ProductType', foreign_key: 'primary_product_type_id'
+
       base.has_many :photos, -> { order(:position) }, as: :viewable, dependent: :destroy, class_name: 'SpreeCmCommissioner::VendorPhoto'
       base.has_many :option_values, through: :products
       base.has_one  :logo, as: :viewable, dependent: :destroy, class_name: 'SpreeCmCommissioner::VendorLogo'

--- a/app/models/spree_cm_commissioner/product_type.rb
+++ b/app/models/spree_cm_commissioner/product_type.rb
@@ -1,0 +1,12 @@
+require_dependency 'spree_cm_commissioner'
+
+module SpreeCmCommissioner
+  class ProductType < ApplicationRecord
+    include SpreeCmCommissioner::DashCaseName
+
+    default_scope { where(enabled: true) }
+
+    validates_presence_of :name, :presentation
+    validates_uniqueness_of :name
+  end
+end

--- a/db/migrate/20221228032046_create_spree_cm_commissioner_product_types.rb
+++ b/db/migrate/20221228032046_create_spree_cm_commissioner_product_types.rb
@@ -1,0 +1,23 @@
+class CreateSpreeCmCommissionerProductTypes < ActiveRecord::Migration[6.1]
+  def change
+    create_table :cm_product_types, if_not_exists: true do |t|
+      t.string :name
+      t.string :presentation
+      t.boolean :enabled, :default => true
+
+      t.timestamps
+    end
+
+    safety_remove_reference(:spree_vendors, :primary_product_type)
+    safety_remove_reference(:spree_products, :product_type)
+    safety_remove_reference(:spree_prototypes, :product_type)
+
+    add_reference :spree_vendors, :primary_product_type, index: true, foreign_key: { to_table: :cm_product_types }
+    add_reference :spree_products, :product_type, index: true, foreign_key: { to_table: :cm_product_types }
+    add_reference :spree_prototypes, :product_type, foreign_key: { to_table: :cm_product_types }
+  end
+
+  def safety_remove_reference(table_name, reference)
+    remove_reference table_name, reference if column_exists?(table_name, reference)
+  end
+end

--- a/lib/spree_cm_commissioner/test_helper/factories/product_type_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/product_type_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :product_type, class: SpreeCmCommissioner::ProductType do
+    sequence(:name)         { |n| "product_type_##{n}" }
+    sequence(:presentation) { |n| "Product Type ##{n}"}
+    enabled                       { true }
+  end
+end

--- a/spec/models/spree_cm_commissioner/product_type_spec.rb
+++ b/spec/models/spree_cm_commissioner/product_type_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::ProductType, type: :model do
+  let(:product_type) { create(:product_type) }
+
+  describe 'validation' do
+    it 'does not allow duplicate names' do
+      product_type = create(:product_type, name: "Service")
+      expect(build(:product_type, name: "Service")).not_to be_valid
+    end
+  end
+end


### PR DESCRIPTION
# Product Type
Since we still not clear about what are [product types] to put in **enum**, using a table may be much easier but require more resources.

In this PR, we add new table called cm_product_types instead of enum with ERD below:

|  | 
| - |
| ![image](https://user-images.githubusercontent.com/29684683/209757774-d03899d1-b27b-48c0-8c92-4fc1f6eea8f2.png) |