### PR TITLE
close #76 add product type with enum

### DIFF
--- a/app/models/concerns/spree_cm_commissioner/product_type.rb
+++ b/app/models/concerns/spree_cm_commissioner/product_type.rb
@@ -1,0 +1,15 @@
+# :spree_vendors
+# :spree_products, :spree_prototypes
+
+module SpreeCmCommissioner
+  module ProductType
+    extend ActiveSupport::Concern
+
+    PRODUCT_TYPES = %i[accommodation service ecommerce]
+
+    included do
+      enum product_type: PRODUCT_TYPES if column_names.include?("product_type")
+      enum primary_product_type: PRODUCT_TYPES if column_names.include?("primary_product_type")
+    end
+  end
+end

--- a/app/models/spree/prototype_decorator.rb
+++ b/app/models/spree/prototype_decorator.rb
@@ -1,0 +1,9 @@
+module Spree
+  module PrototypeDecorator
+    def self.prepended(base)
+      base.include SpreeCmCommissioner::ProductType
+    end
+  end
+end
+
+Spree::Prototype.prepend Spree::PrototypeDecorator

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -12,7 +12,7 @@
     private
 
     def update_vendor_price
-      if product_type&.name == 'Property'
+      if product&.product_type == vendor.primary_product_type
         vendor.update(min_price: price) if price < vendor.min_price
         vendor.update(max_price: price) if price > vendor.max_price
       end

--- a/app/models/spree/vendor_decorator.rb
+++ b/app/models/spree/vendor_decorator.rb
@@ -1,6 +1,8 @@
 module Spree
   module VendorDecorator
     def self.prepended(base)
+      base.include SpreeCmCommissioner::ProductType
+
       base.has_many :photos, -> { order(:position) }, as: :viewable, dependent: :destroy, class_name: 'SpreeCmCommissioner::VendorPhoto'
       base.has_many :option_values, through: :products
       base.has_one  :logo, as: :viewable, dependent: :destroy, class_name: 'SpreeCmCommissioner::VendorLogo'

--- a/app/overrides/spree/admin/products/_form/product_types.html.erb.deface
+++ b/app/overrides/spree/admin/products/_form/product_types.html.erb.deface
@@ -1,0 +1,5 @@
+<!-- insert_before "[data-hook='admin_product_form_taxons']" -->
+
+<div data-hook="admin_product_form_product_types">
+  <%= render 'shared/product_type_field', field: :product_type, f: f, disabled: !f.object.product_type.nil? %>
+</div>

--- a/app/overrides/spree/admin/products/new/product_from_prototype.html.erb.deface
+++ b/app/overrides/spree/admin/products/new/product_from_prototype.html.erb.deface
@@ -1,0 +1,6 @@
+<!-- replace "[data-hook='product-from-prototype']" -->
+
+<div data-hook="product-from-prototype" id="product-from-prototype">
+  <% @prototype = @prototype || Spree::Prototype.new(option_types: []) %>
+  <%= render template: 'spree/admin/prototypes/show' %>
+</div>

--- a/app/overrides/spree/admin/prototypes/_form/product_type.html.erb.deface
+++ b/app/overrides/spree/admin/prototypes/_form/product_type.html.erb.deface
@@ -1,0 +1,3 @@
+<!-- insert_bottom "[data-hook='admin_prototype_form_fields']" -->
+
+<%= render 'shared/product_type_field', field: :product_type, f: f %>

--- a/app/overrides/spree/admin/prototypes/show/product_type.html.erb.deface
+++ b/app/overrides/spree/admin/prototypes/show/product_type.html.erb.deface
@@ -1,0 +1,15 @@
+<!-- insert_before "erb[silent]:contains('if @prototype.option_types.present?')" -->
+
+<% initial_type = @prototype&.product_type || SpreeCmCommissioner::ProductType::PRODUCT_TYPES[0] %>
+
+<div class="form-group mb-4">
+  <%= label_tag :product_type, Spree.t(:product_type) %>
+  <% SpreeCmCommissioner::ProductType::PRODUCT_TYPES.each do |product_type| %>
+    <div class="radio" data-id="<%= product_type.to_s %>">
+      <label data-hook="product_type_field">
+        <%= radio_button_tag 'product[product_type]', product_type.to_s, product_type.to_s == initial_type.to_s, { class: "product_types_radios" } %>
+        <%= product_type.capitalize %>
+      </label>
+    </div>
+  <% end %>
+</div>

--- a/app/overrides/spree/admin/vendors/_form/product_type.html.erb.deface
+++ b/app/overrides/spree/admin/vendors/_form/product_type.html.erb.deface
@@ -1,0 +1,3 @@
+<!-- insert_before "erb[loud]:contains('field_container :state')" -->
+
+<%= render 'shared/product_type_field', field: :primary_product_type, f: f %>

--- a/app/views/shared/_product_type_field.erb
+++ b/app/views/shared/_product_type_field.erb
@@ -1,0 +1,10 @@
+<%# :field, eg. :product_type or :primary_product_type %>
+<%# :disabled, optional %>
+
+<%= f.field_container field, :class => ['form-group'] do %>
+  <%= f.label field, Spree.t(field) %><br />
+  <%= f.collection_select field, SpreeCmCommissioner::ProductType::PRODUCT_TYPES, :to_s, :capitalize, 
+    {:include_blank => true}, 
+    {:class => 'select2 fullwidth', :disabled => defined?(disabled) && disabled == true ? 'disable' : nil }.compact 
+  %>
+<% end %>

--- a/db/migrate/20221229075014_add_product_type.rb
+++ b/db/migrate/20221229075014_add_product_type.rb
@@ -1,0 +1,7 @@
+class AddProductType < ActiveRecord::Migration[6.1]
+  def change
+    add_column :spree_vendors, :primary_product_type, :integer
+    add_column :spree_products, :product_type, :integer
+    add_column :spree_prototypes, :product_type, :integer
+  end
+end

--- a/spec/interactors/spree_cm_commissioner/vendor_updater_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/vendor_updater_spec.rb
@@ -1,19 +1,21 @@
 require 'spec_helper'
 
 RSpec.describe SpreeCmCommissioner::VendorUpdater do
-  let(:vendor) { create(:active_vendor, name: 'Angkor Hotel') }
+  let(:accommodation) { Spree::Product::product_types[:accommodation] }
+  let(:service) { Spree::Product::product_types[:ecommerce] }
+
+  let(:vendor) { create(:active_vendor, name: 'Angkor Hotel', primary_product_type: accommodation ) }
   let(:state) { create(:state, name: 'Siemreap') }
   let!(:option_type) { create(:option_type, name: 'location', presentation: 'Location', attr_type: 'state_selection') }
   let!(:option_value) { create(:option_value, option_type: option_type, presentation: state.id) }
   let!(:stock_location) { vendor.stock_locations.first.update(state: state) }
-  let(:product_type) { create(:product_type, name: 'property', presentation: 'Property', enabled: true) }
   let(:shipping_category) { create(:shipping_category, name: 'Digital') }
-  let!(:product1) { create(:product, name: 'Bedroom 1', vendor: vendor, product_type: product_type, price: 10, shipping_category: shipping_category ) }
-  let!(:product2) { create(:product, name: 'Bedroom 2', vendor: vendor, product_type: product_type, price: 20, shipping_category: shipping_category ) }
-  let!(:product3) { create(:product, name: 'Bedroom 3', vendor: vendor, product_type: product_type, price: 30, shipping_category: shipping_category ) }
 
   describe '.call' do
     context 'without product variants' do
+      let!(:product1) { create(:product, name: 'Bedroom 1', vendor: vendor, product_type: accommodation, price: 10, shipping_category: shipping_category ) }
+      let!(:product3) { create(:product, name: 'Bedroom 3', vendor: vendor, product_type: accommodation, price: 20, shipping_category: shipping_category ) }
+
       it 'update min and max price' do
         context = SpreeCmCommissioner::VendorUpdater.call(vendor: vendor)
 
@@ -25,16 +27,48 @@ RSpec.describe SpreeCmCommissioner::VendorUpdater do
     end
 
     context 'with product variants' do
-      let!(:variant_product1) { create(:base_variant, product: product1, price: 8 ) }
-      let!(:variant_product3) { create(:base_variant, product: product1, price: 35 ) }
+      it 'update vendor min and max price if [variant product_type] is primary_product_type' do
+        product1 = create(:product, name: 'Bedroom', vendor: vendor, product_type: accommodation, price: 13, shipping_category: shipping_category )
+        product2 = create(:product, name: 'Breakfast', vendor: vendor, product_type: service, price: 14, shipping_category: shipping_category )
 
-      it 'update min and max price' do
+        variant1 = create(:base_variant, product: product1, price: 10 )
+        variant2 = create(:base_variant, product: product1, price: 20 )
+        variant3 = create(:base_variant, product: product2, price: 30 )
+
         context = SpreeCmCommissioner::VendorUpdater.call(vendor: vendor)
-
         vendor.reload
 
-        expect(vendor.min_price).to eq variant_product1.price
-        expect(vendor.max_price).to eq variant_product3.price
+        expect(vendor.min_price).to eq 10
+        expect(vendor.max_price).to eq 20
+
+        expect(vendor.min_price).to eq variant1.price
+        expect(vendor.max_price).to eq variant2.price
+      end
+
+      it 'update min and max price even base on master variant price' do
+        product = create(:product, name: 'Breakfast', vendor: vendor, product_type: accommodation, price: 5, shipping_category: shipping_category )
+
+        variant1 = create(:base_variant, product: product, price: 10 )
+        variant2 = create(:base_variant, product: product, price: 30 )
+
+        context = SpreeCmCommissioner::VendorUpdater.call(vendor: vendor)
+        vendor.reload
+
+        expect(vendor.min_price).to eq 5
+        expect(vendor.max_price).to eq 30
+
+        expect(vendor.min_price).to eq product.master.price
+        expect(vendor.max_price).to eq variant2.price
+      end
+
+      it "return min, max price zero if vendor couldn't find primary_product_type variants" do
+        product = create(:product, name: 'Breakfast', vendor: vendor, product_type: service, price: 5, shipping_category: shipping_category )
+
+        context = SpreeCmCommissioner::VendorUpdater.call(vendor: vendor)
+        vendor.reload
+
+        expect(vendor.min_price).to eq 0
+        expect(vendor.max_price).to eq 0
       end
     end
   end

--- a/spec/models/spree/prototype_spec.rb
+++ b/spec/models/spree/prototype_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Prototype, type: :model do
+  describe '#product_type' do
+    it 'raise error on enter invalid product_type' do
+      expect{create(:prototype, product_type: :fake)}
+        .to raise_error(ArgumentError)
+        .with_message("'fake' is not a valid product_type")
+    end
+
+    it 'raise error when input primary_product_type instead of product_type' do
+      expect{create(:prototype, primary_product_type: described_class.product_types[0])}.to raise_error { |error|
+        expect(error).to be_a(NoMethodError)
+        expect(error.message).to include('undefined method `primary_product_type=')
+      }
+    end
+
+    it 'save on input valid product_type' do
+      prototype = build(:prototype, product_type: described_class.product_types[0])
+      expect(prototype.save!).to be true
+    end
+  end
+end

--- a/spec/models/spree/vendor_spec.rb
+++ b/spec/models/spree/vendor_spec.rb
@@ -25,4 +25,24 @@ RSpec.describe Spree::Vendor, type: :model do
       end
     end
   end
+
+  describe '#primary_product_type' do
+    it 'raise error on enter invalid primary_product_type' do
+      expect{create(:vendor, primary_product_type: :fake)}
+        .to raise_error(ArgumentError)
+        .with_message("'fake' is not a valid primary_product_type")
+    end
+
+    it 'raise error when input product_type instead of primary_product_type' do
+      expect{create(:vendor, product_type: :fake)}.to raise_error { |error|
+        expect(error).to be_a(NoMethodError)
+        expect(error.message).to include('undefined method `product_type=')
+      }
+    end
+
+    it 'save on input valid primary_product_type' do
+      vendor = build(:vendor, primary_product_type: described_class.primary_product_types[0])
+      expect(vendor.save!).to be true
+    end
+  end
 end


### PR DESCRIPTION
## Migrations
- [x] Added primary_product_type to vendor
- [x] Added product_type to product
- [x] Added product_type to prototype

## Logic changes
- Min/max vendor price will be updated based on `primary_product_type`.
  For example, if vendor.primary_product_type is `property`, then only variants with product_type `property` will trigger the update.

## Views
- [x] Added **product_types** collection_select to vendor view
- [x] Added **product_type** collection_select to prototype
- [x] Added **product_types** collection_select product view 
  - On `/edit`, This field is read only
  - On `/new`, product type will be has initial value base on `prototype.product_type`

<img width="1165" alt="image" src="https://user-images.githubusercontent.com/29684683/210038782-766ef62b-805b-49ff-8eb2-b8ad4c84f073.png">

