### PR TITLE
close #172 migrate commissioner to fit spree 4.5 ui

### DIFF
--- a/app/overrides/spree/admin/shared/_main_menu/sidebar_organizations.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_main_menu/sidebar_organizations.html.erb.deface
@@ -1,0 +1,6 @@
+<!-- remove "#sidebarOrganizations" -->
+
+# TODO:
+
+# Remove as we don't need organizations side bar yet because spree_multi_vendor still has it.
+# Once spree_multi_vendor remove its side bar, we can remove this file.

--- a/app/overrides/spree/admin/shared/_product_tabs/master_variant.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/master_variant.html.erb.deface
@@ -1,6 +1,6 @@
-<!-- insert_bottom "[data-hook='admin_product_tabs']" -->
+<!-- insert_after "erb[silent]:contains('Spree::Digital')" -->
 
-<%= content_tag :li do %>
+<%= content_tag :li, class: 'nav-item' do %>
   <%= link_to_with_icon 'adjust.svg',
     Spree.t(:master_variant),
     admin_product_master_variant_index_url(@product),

--- a/app/overrides/spree/admin/vendors/edit/vendor_tabs.html.erb.deface
+++ b/app/overrides/spree/admin/vendors/edit/vendor_tabs.html.erb.deface
@@ -1,2 +1,3 @@
-<!-- insert_before "erb[silent]:contains('content_for :page_title')" -->
+<!-- replace "erb[silent]:contains('content_for :page_title')" closing_selector "erb[silent]:contains('end')" -->
+
 <%= render partial: 'spree/admin/shared/vendor_tabs', locals: { current: :details } %>

--- a/app/views/spree/admin/nearby_places/index.html.erb
+++ b/app/views/spree/admin/nearby_places/index.html.erb
@@ -1,15 +1,11 @@
 <%= render partial: 'spree/admin/shared/vendor_tabs', locals: {current: :nearby_places} %>
 
-<% content_for :page_title do %>
-  <%= link_to plural_resource_name(Spree::Vendor), spree.admin_vendors_url %> /
-  <%= @vendor.name %>
-<% end %>
-
 <% content_for :page_actions do %>
   <%= yield :page_actions %>
   <%= button_link_to(Spree.t(:new_nearby_place), new_admin_vendor_nearby_place_url(@vendor), { class: "btn-success", icon: 'add.svg', id: 'new_nearby_place_link' }) if can? :create, SpreeCmCommissioner::VendorPlace %>
 <% end %>
 
+<% unless @nearby_places.empty? %>
 <div class="table-responsive">
   <table class="table sortable" data-hook="images_table" data-sortable-link="<%= update_positions_admin_vendor_nearby_places_url(@vendor) %>">
     <thead>
@@ -49,3 +45,8 @@
     </tbody>
   </table>
 </div>
+<% else %>
+<small class="form-text text-muted">
+  <%= raw I18n.t('nearby_place.empty_info') %>
+</small>
+<% end %>

--- a/app/views/spree/admin/nearby_places/new.html.erb
+++ b/app/views/spree/admin/nearby_places/new.html.erb
@@ -1,13 +1,6 @@
 <%= render partial: 'spree/admin/shared/vendor_tabs', locals: { current: :nearby_places } %>
 <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @object } %>
 
-<% content_for :page_title do %>
-  <%= link_to plural_resource_name(Spree::Vendor), spree.admin_vendors_url %> /
-  <%= @vendor.name %> /
-  <%= link_to Spree.t(:nearby_places), admin_vendor_nearby_places_url %> /
-  <%= Spree.t(:new) %>
-<% end %>
-
 <%= form_with model: @object, url: { action: 'create' }, html: { multipart: true } do |f| %>
   <fieldset data-hook="new_nearby_place">
     <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/spree/admin/shared/_vendor_tabs.html.erb
+++ b/app/views/spree/admin/shared/_vendor_tabs.html.erb
@@ -1,5 +1,9 @@
-<% content_for :sidebar do %>
-  <ul class="nav flex-column nav-pills" data-hook="admin_vendor_tabs">
+<% content_for :page_title do %>
+  <%= page_header_back_button admin_vendors_url %>
+  <%= @vendor.name %>
+<% end %>
+
+<% content_for :page_tabs do %>
 
     <%= content_tag :li do %>
       <%= link_to_with_icon 'edit.svg',
@@ -32,6 +36,4 @@
         class: "nav-link #{'active' if current == :nearby_places}"
       %>
     <% end if can?(:admin, SpreeCmCommissioner::VendorPlace) %>
-
-  </ul>
 <% end %>

--- a/app/views/spree/admin/vectors/icons/index.html.erb
+++ b/app/views/spree/admin/vectors/icons/index.html.erb
@@ -6,11 +6,11 @@
 
 <small class="form-text text-muted">
   <ul>
-    <li><%= raw I18n.t('vectors.icons.info_vendors.first') %></li>
-    <li><%= raw I18n.t('vectors.icons.info_vendors.second') %>
+    <li><%= raw I18n.t('vectors.icons.info_rules.first') %></li>
+    <li><%= raw I18n.t('vectors.icons.info_rules.second') %>
       <ul>
-        <li><%= raw I18n.t('vectors.icons.info_vendors.second_eg') %></li>
-        <li><%= raw I18n.t('vectors.icons.info_vendors.second_set_creation_info') %></li>
+        <li><%= raw I18n.t('vectors.icons.info_rules.second_eg') %></li>
+        <li><%= raw I18n.t('vectors.icons.info_rules.second_set_creation_info') %></li>
       </ul>
     </li>
   </ul>

--- a/app/views/spree/admin/vendor_kind_option_types/index.html.erb
+++ b/app/views/spree/admin/vendor_kind_option_types/index.html.erb
@@ -1,9 +1,4 @@
-<%= render partial: 'spree/admin/shared/vendor_tabs', locals: { current: :vendor_rules } %>
-
-<% content_for :page_title do %>
-  <%= link_to plural_resource_name(Spree::Vendor), spree.admin_vendors_url %> /
-  <%= @vendor.name %>
-<% end %>
+<%= render partial: 'spree/admin/shared/vendor_tabs', locals: { current: :vendor_option_types } %>
 
 <% content_for :page_actions do %>
   <%= button_link_to Spree.t(:edit_icons), 
@@ -24,5 +19,3 @@
     </small>
   <% end %>
 <% end %>
-
-

--- a/app/views/spree/admin/vendor_photos/edit.html.erb
+++ b/app/views/spree/admin/vendor_photos/edit.html.erb
@@ -1,13 +1,6 @@
 <%= render partial: 'spree/admin/shared/vendor_tabs', locals: { current: :photos } %>
 <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @object } %>
 
-<% content_for :page_title do %>
-  <%= link_to plural_resource_name(Spree::Vendor), spree.admin_vendors_url %> /
-  <%= @vendor.name %> /
-  <%= link_to Spree.t(:photos), admin_vendor_vendor_photos_url %> /
-  <%= @object.id %>
-<% end %>
-
 <%= form_with model: @object, url: { action: 'update' }, html: { multipart: true } do |f| %>
   <fieldset data-hook="edit_image">
     <%= render partial: 'form', locals: { f: f, preview: true } %>

--- a/app/views/spree/admin/vendor_photos/index.html.erb
+++ b/app/views/spree/admin/vendor_photos/index.html.erb
@@ -1,15 +1,11 @@
 <%= render partial: 'spree/admin/shared/vendor_tabs', locals: {current: :photos} %>
 
-<% content_for :page_title do %>
-  <%= link_to plural_resource_name(Spree::Vendor), spree.admin_vendors_url %> /
-  <%= @vendor.name %>
-<% end %>
-
 <% content_for :page_actions do %>
   <%= yield :page_actions %>
   <%= button_link_to(Spree.t(:new_photo), new_admin_vendor_vendor_photo_url(@vendor), { class: "btn-success", icon: 'add.svg', id: 'new_image_link' }) if can? :create, Spree::Image %>
 <% end %>
 
+<% unless @objects.empty? %>
 <div class="table-responsive">
   <table class="table sortable" data-hook="images_table" data-sortable-link="<%= update_positions_admin_vendor_vendor_photos_url(@vendor) %>">
     <thead>
@@ -53,3 +49,8 @@
     </tbody>
   </table>
 </div>
+<% else %>
+<small class="form-text text-muted">
+  <%= raw I18n.t('photo.empty_info') %>
+</small>
+<% end %>

--- a/app/views/spree/admin/vendor_photos/new.html.erb
+++ b/app/views/spree/admin/vendor_photos/new.html.erb
@@ -1,13 +1,6 @@
 <%= render partial: 'spree/admin/shared/vendor_tabs', locals: { current: :photos } %>
 <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @object } %>
 
-<% content_for :page_title do %>
-  <%= link_to plural_resource_name(Spree::Vendor), spree.admin_vendors_url %> /
-  <%= @vendor.name %> /
-  <%= link_to Spree.t(:photos), admin_vendor_vendor_photos_url %> /
-  <%= Spree.t(:new_photo) %>
-<% end %>
-
 <%= form_with model: @object, url: { action: 'create' }, html: { multipart: true } do |f| %>
   <fieldset data-hook="new_photo">
     <%= render partial: 'form', locals: { f: f } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,9 +39,14 @@ en:
         second: "Icons will be separated into [set] based on prefix:"
         second_eg: "For example, backend-adjust.svg will automatically be marked as BACKEND set."
         second_set_creation_info: "Currently, only [backend] & [cm] are supported, eg. backend-adjust.svg or cm-adjust.svg"
-  
+
+  photo:
+    empty_info: "No <b>Photos</b> found."
+
+  nearby_place:
+    empty_info: "No <b>Nearby places</b> found."
+
   vendor:
     validation:
       vendor_kind_option_types:
         empty_info: "<b>Note:</b> Set vendor option types to vendor first. To edit, go to <b>Details</b> tab > <b>Option Types</b>"
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Spree::Core::Engine.add_routes do
       end
       resources :vendor_kind_option_types, only: [:index, :update] do
         collection do
+          patch :update
           patch :update_positions
         end
       end


### PR DESCRIPTION
# Fit Spree 4.5 UI
- [x] Removed organization side bar
- [x] Migrate master_variant page `right side tab` to `top tab`
- [x] Add empty state info to photo & nearby index page
- [x] Migrate vendor side bar tab to top tab bar.
- [x] Add missing update vendor option_type route in route.rb

| |
| - |
| ![image](https://user-images.githubusercontent.com/29684683/218442580-47ffbfc0-eb3e-498e-9d6a-b7363ff08746.png) |
| ![image](https://user-images.githubusercontent.com/29684683/218442529-5329c4f3-94ea-490e-af6b-2bf9646c5c7d.png) |