### PR TITLE
close #178 require delivery only on product type ecommerce digital

### DIFF
--- a/app/models/spree_cm_commissioner/line_item_decorator.rb
+++ b/app/models/spree_cm_commissioner/line_item_decorator.rb
@@ -2,6 +2,8 @@
   module LineItemDecorator
     def self.prepended(base)
       base.before_save :update_vendor_id
+
+      base.delegate :product_type, :accommodation?, :service?, :ecommerce?, to: :product
     end
 
     private

--- a/app/models/spree_cm_commissioner/order_decorator.rb
+++ b/app/models/spree_cm_commissioner/order_decorator.rb
@@ -1,0 +1,17 @@
+module SpreeCmCommissioner
+  module OrderDecorator
+    # required only in one case, 
+    # some of line_items are ecommerce & not digital.
+    def delivery_required?
+      contain_non_digital_ecommerce?
+    end
+
+    def contain_non_digital_ecommerce?
+      line_items.select {|item| item.ecommerce? && !item.digital? }.size > 0
+    end
+  end
+end
+
+unless Spree::Order.included_modules.include?(SpreeCmCommissioner::OrderDecorator)
+  Spree::Order.prepend(SpreeCmCommissioner::OrderDecorator)
+end

--- a/app/models/spree_cm_commissioner/variant_decorator.rb
+++ b/app/models/spree_cm_commissioner/variant_decorator.rb
@@ -13,7 +13,7 @@ module SpreeCmCommissioner
     private
 
     def update_vendor_price
-      if product&.product_type == vendor.primary_product_type
+      if vendor.present? && product&.product_type == vendor&.primary_product_type
         vendor.update(min_price: price) if price < vendor.min_price
         vendor.update(max_price: price) if price > vendor.max_price
       end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Order, type: :model do
+  describe '#delivery_required?' do
+    let(:product1) { create(:product, name: 'Product 1') }
+    let(:product2) { create(:product, name: 'Product 2') }
+
+    let(:line_item1) { create(:line_item, variant: product1.master) }
+    let(:line_item2) { create(:line_item, variant: product2.master) }
+
+    let(:order) { create(:order, line_items: [line_item1, line_item2]) }
+
+    context 'required delivery' do
+      it 'required delivery when all products are :ecommerce & not digital' do
+        order.line_items[0].product.update_columns(product_type: :ecommerce)
+        order.line_items[1].product.update_columns(product_type: :ecommerce)
+
+        allow(order.line_items[0]).to receive(:digital?).and_return(false)
+        allow(order.line_items[1]).to receive(:digital?).and_return(false)
+
+        expect(order.delivery_required?).to eq true
+      end
+
+      it 'required delivery when some of products are :ecommerce & not digital' do
+        order.line_items[0].product.update_columns(product_type: :ecommerce)
+        order.line_items[1].product.update_columns(product_type: :service)
+
+        allow(order.line_items[0]).to receive(:digital?).and_return(false)
+        allow(order.line_items[1]).to receive(:digital?).and_return(false)
+
+        expect(order.delivery_required?).to eq true
+      end
+    end
+
+    context 'not required delivery' do
+      it 'not required delivery when products are not :ecommerce (digital? are ignored this case)' do
+        order.line_items[0].product.update_columns(product_type: :accommodation)
+        order.line_items[1].product.update_columns(product_type: :service)
+
+        expect(order.delivery_required?).to eq false
+      end
+
+      it 'not required delivery when some of products are :ecommerce & it is digital' do
+        order.line_items[0].product.update_columns(product_type: :ecommerce)
+        order.line_items[1].product.update_columns(product_type: :service)
+
+        allow(order.line_items[0]).to receive(:digital?).and_return(true)
+        allow(order.line_items[1]).to receive(:digital?).and_return(false)
+
+        expect(order.delivery_required?).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
To get order.required_delivery?, we select only ecommece items and each of them is not digital. So, other product type such as accommodation & service will required delivery by default.