### PR TITLE
close #187 add taxon icon

### DIFF
--- a/app/controllers/spree/admin/taxons_controller_decorator.rb
+++ b/app/controllers/spree/admin/taxons_controller_decorator.rb
@@ -1,0 +1,29 @@
+module Spree
+  module Admin
+    module TaxonsControllerDecorator
+      def self.prepended(base)
+        base.before_action :build_category_icon, only: %i[create update]
+      end
+
+      def remove_category_icon
+        if @taxon.category_icon.destroy
+          flash[:success] = Spree.t('notice_messages.icon_removed')
+          redirect_to spree.edit_admin_taxonomy_taxon_url(@taxonomy.id, @taxon.id)
+        else
+          flash[:error] = Spree.t('errors.messages.cannot_remove_icon')
+          render :edit, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def build_category_icon
+        return unless permitted_resource_params[:category_icon]
+
+        @taxon.build_category_icon(attachment: permitted_resource_params.delete(:category_icon))
+      end
+    end
+  end
+end
+
+Spree::Admin::TaxonsController.prepend(Spree::Admin::TaxonsControllerDecorator)

--- a/app/models/spree_cm_commissioner/asset.rb
+++ b/app/models/spree_cm_commissioner/asset.rb
@@ -1,0 +1,25 @@
+module SpreeCmCommissioner
+  class Asset < Spree::Asset
+    include Spree::Image::Configuration::ActiveStorage
+    include Rails.application.routes.url_helpers
+    include ::Spree::ImageMethods
+
+    def styles
+      asset_styles.map do |_, size|
+        width, height = size[/(\d+)x(\d+)/].split('x')
+
+        {
+          url: polymorphic_path(attachment.variant(resize: size), only_path: true),
+          width: width,
+          height: height
+        }
+      end
+    end
+
+    protected
+
+    def asset_styles
+      self.class.styles
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/taxon_category_icon.rb
+++ b/app/models/spree_cm_commissioner/taxon_category_icon.rb
@@ -1,0 +1,10 @@
+module SpreeCmCommissioner
+  class TaxonCategoryIcon < SpreeCmCommissioner::Asset
+    def asset_styles
+      {
+        thumb: '60x60>',
+        small: '180x180>'
+      }
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/taxon_decorator.rb
+++ b/app/models/spree_cm_commissioner/taxon_decorator.rb
@@ -1,0 +1,11 @@
+module SpreeCmCommissioner
+  module TaxonDecorator
+    def self.prepended(base)
+      base.has_one :category_icon, as: :viewable, dependent: :destroy, class_name: 'SpreeCmCommissioner::TaxonCategoryIcon'
+
+      base.validates_associated :category_icon
+    end
+  end
+end
+
+Spree::Taxon.prepend(SpreeCmCommissioner::TaxonDecorator) unless Spree::Taxon.included_modules.include?(SpreeCmCommissioner::TaxonDecorator)

--- a/app/overrides/spree/admin/taxons/_form/category_icon_field.html.erb.deface
+++ b/app/overrides/spree/admin/taxons/_form/category_icon_field.html.erb.deface
@@ -1,0 +1,17 @@
+<!-- replace "erb[loud]:contains('assets_form')" -->
+
+<%= render 'shared/asset_field', 
+  field: :category_icon,
+  label: I18n.t('category_icon.field'),
+  asset: @taxon.category_icon,
+  remove_url: remove_category_icon_admin_taxonomy_taxon_url(@taxonomy.id, @taxon.id),
+  form:f
+%>
+
+<%= render 'shared/asset_field', 
+  field: :icon,
+  label: Spree.t(:header_banner),
+  asset: @taxon.icon,
+  remove_url: remove_icon_admin_taxonomy_taxon_url(@taxonomy.id, @taxon.id),
+  form:f
+%>

--- a/app/serializers/spree/v2/storefront/taxon_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/taxon_serializer_decorator.rb
@@ -1,0 +1,13 @@
+module Spree
+  module V2
+    module Storefront
+      module TaxonSerializerDecorator
+        def self.prepended(base)
+          base.has_one :category_icon, serializer: SpreeCmCommissioner::V2::Storefront::CategoryIconSerializer
+        end
+      end
+    end
+  end
+end
+
+Spree::V2::Storefront::TaxonSerializer.prepend(Spree::V2::Storefront::TaxonSerializerDecorator)

--- a/app/serializers/spree_cm_commissioner/v2/storefront/asset_serializer.rb
+++ b/app/serializers/spree_cm_commissioner/v2/storefront/asset_serializer.rb
@@ -1,0 +1,11 @@
+module SpreeCmCommissioner
+  module V2
+    module Storefront
+      class AssetSerializer < BaseSerializer
+        include ::Spree::Api::V2::ImageTransformationConcern
+
+        attributes :styles, :position, :alt, :original_url
+      end
+    end
+  end
+end

--- a/app/serializers/spree_cm_commissioner/v2/storefront/base_serializer.rb
+++ b/app/serializers/spree_cm_commissioner/v2/storefront/base_serializer.rb
@@ -1,0 +1,8 @@
+module SpreeCmCommissioner
+  module V2
+    module Storefront
+      class BaseSerializer < Spree::V2::Storefront::BaseSerializer
+      end
+    end
+  end
+end

--- a/app/serializers/spree_cm_commissioner/v2/storefront/category_icon_serializer.rb
+++ b/app/serializers/spree_cm_commissioner/v2/storefront/category_icon_serializer.rb
@@ -1,0 +1,8 @@
+module SpreeCmCommissioner
+  module V2
+    module Storefront
+      class CategoryIconSerializer < AssetSerializer
+      end
+    end
+  end
+end

--- a/app/views/shared/_asset_field.html.erb
+++ b/app/views/shared/_asset_field.html.erb
@@ -1,0 +1,20 @@
+<%# :field, eg. :category_icon or :icon %>
+<%# :label, eg. 'Icon', Spree.t(:icon), I18n.t('icon.field') %>
+<%# :asset %>
+<%# :remove_url, optional %>
+<%# :form %>
+
+<%= form.field_container field, class: ['rounded', 'border', 'p-3'] do %>
+  <%= image_tag(main_app.rails_blob_url(asset.attachment),
+    class: 'rounded border mb-4 mw-100', 
+    style: 'max-height: 100px') if asset %>
+
+  <div data-hook="file" class="form-group">
+    <%= form.label field, label || Spree.t(field) %>
+    <%= form.file_field field %>
+  </div>
+
+  <% if asset.present? && defined?(remove_url) %>
+    <%= link_to Spree.t(:remove_image), remove_url, method: :delete %>
+  <% end %>
+<% end %>

--- a/config/initializers/spree_permitted_attributes.rb
+++ b/config/initializers/spree_permitted_attributes.rb
@@ -3,5 +3,6 @@ module Spree
     @@vendor_attributes << :logo
     @@line_item_attributes += %i[from_date to_date]
     @@user_attributes      += %i[first_name last_name dob gender profile]
+    @@taxon_attributes     += %i[category_icon]
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,9 @@ en:
 
   hello: "Hello world"
 
+  category_icon:
+    field: Category icon (Square)
+
   option_type:
     kind_info: "<b>Once set</b>, it can't be updated."
     kind_validation: "Attribute can't be updated for %{option_type_name}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,14 @@ Spree::Core::Engine.add_routes do
         end
       end
     end
+
+    resources :taxonomies do
+      resources :taxons do
+        member do
+          delete :remove_category_icon
+        end
+      end
+    end
   end
 
   namespace :api, defaults: { format: 'json' } do

--- a/lib/spree_cm_commissioner/test_helper/factories/vendor_photo_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/vendor_photo_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :cm_taxon_category_icon, class: SpreeCmCommissioner::TaxonCategoryIcon do
+    attachment { Rack::Test::UploadedFile.new(SpreeMultiVendor::Engine.root.join('spec', 'fixtures', 'thinking-cat.jpg'), 'image/jpeg') }
+  end
+end

--- a/spec/serializers/spree/v2/storefront/taxon_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/taxon_serializer_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.describe Spree::V2::Storefront::TaxonSerializer, type: :serializer do
+  describe '.serializable_hash' do
+    let(:category_icon) { create(:cm_taxon_category_icon) }
+    let(:taxon) { create(:taxon, category_icon: category_icon) }
+
+    subject {
+      described_class.new(taxon, include: [
+        :parent,
+        :taxonomy,
+        :children,
+        :image,
+        :category_icon
+      ]).serializable_hash
+    }
+
+    it 'returns exact taxon attributes' do
+      expect(subject[:data][:attributes].keys).to contain_exactly(
+        :name,
+        :pretty_name,
+        :permalink,
+        :seo_title,
+        :description,
+        :meta_title,
+        :meta_description,
+        :meta_keywords,
+        :left,
+        :right,
+        :position,
+        :depth,
+        :updated_at,
+        :public_metadata,
+        :is_root,
+        :is_child,
+        :is_leaf
+      )
+    end
+
+    it 'returns exact taxon relationships' do
+      expect(subject[:data][:relationships].keys).to contain_exactly(
+        :parent,
+        :taxonomy,
+        :children,
+        :image,
+        :category_icon
+      )
+    end
+  end
+end


### PR DESCRIPTION
# Tasks
- [x] Create SpreeCmCommissiner:Asset as base class for all asset
- [x] Create SpreeCmCommissiner:TaxonCategoryIcon
- [x] Add shared view: asset_field
- [x] Add icon field view by using asset_field
- [x] Replace old head banner view asset_field

![image](https://user-images.githubusercontent.com/29684683/219276036-5f306c09-36a8-48e5-8ce9-1ce64c5d75f7.png)
