### PR TITLE
close #205 add phone number to order

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,9 @@ gem 'searchkick',    '~> 5.1'
 gem 'interactor', '~> 3.1'
 gem 'jwt'
 
+# Google libphonenumber library
+gem 'phonelib', '~> 0.5.4'
+
 group :development do
   gem 'brakeman'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -342,6 +342,7 @@ GEM
     parser (3.2.1.0)
       ast (~> 2.4.1)
     pg (1.4.5)
+    phonelib (0.5.6)
     polyglot (0.3.5)
     popper_js (1.16.1)
     protocol-hpack (1.4.2)
@@ -638,6 +639,7 @@ DEPENDENCIES
   jwt
   net-smtp
   pg
+  phonelib (~> 0.5.4)
   rails-controller-testing
   rubocop (~> 1.45)
   rubocop-performance (~> 1.16)

--- a/app/interactors/spree_cm_commissioner/phone_number_parser.rb
+++ b/app/interactors/spree_cm_commissioner/phone_number_parser.rb
@@ -1,0 +1,24 @@
+module SpreeCmCommissioner
+  class PhoneNumberParser < BaseInteractor
+    # :phone_number, :country_code
+    def call
+      sanitize_phone_number
+    end
+
+    def sanitize_phone_number
+      phone_parser = Phonelib.parse(phone_number, country_code)
+      return if phone_parser.international.blank?
+
+      context.intel_phone_number = phone_parser.international.gsub!(/[() -]/, '')
+      context.national_phone_number = phone_parser.national.gsub!(/[() -]/, '')
+    end
+
+    def phone_number
+      context.phone_number&.strip
+    end
+
+    def country_code
+      context.country_code ||= Phonelib.default_country
+    end
+  end
+end

--- a/app/models/concerns/spree_cm_commissioner/phone_number_sanitizer.rb
+++ b/app/models/concerns/spree_cm_commissioner/phone_number_sanitizer.rb
@@ -1,0 +1,25 @@
+# required table to have :phone_number, :intel_phone_number, :country_code column
+module SpreeCmCommissioner
+  module PhoneNumberSanitizer
+    extend ActiveSupport::Concern
+
+    included do
+      before_save :sanitize_phone_number
+    end
+
+    private
+
+    def sanitize_phone_number
+      return if phone_number.blank?
+
+      parser = PhoneNumberParser.call(
+        phone_number: phone_number,
+        country_code: country_code
+      )
+
+      self.country_code = parser.country_code
+      self.phone_number = parser.national_phone_number
+      self.intel_phone_number = parser.intel_phone_number
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/order_decorator.rb
+++ b/app/models/spree_cm_commissioner/order_decorator.rb
@@ -1,5 +1,13 @@
 module SpreeCmCommissioner
   module OrderDecorator
+    def self.prepended(base)
+      base.include SpreeCmCommissioner::PhoneNumberSanitizer
+
+      base.before_create :link_by_phone_number
+
+      base.validates :phone_number, presence: true, if: :require_phone_number
+    end
+
     # required only in one case,
     # some of line_items are ecommerce & not digital.
     def delivery_required?
@@ -8,6 +16,28 @@ module SpreeCmCommissioner
 
     def contain_non_digital_ecommerce?
       line_items.select { |item| item.ecommerce? && !item.digital? }.size.positive?
+    end
+
+    private
+
+    def link_by_phone_number
+      return if phone_number.present?
+
+      self.phone_number = user.phone_number if user
+    end
+
+    def require_phone_number
+      require_contact
+    end
+
+    def require_email
+      require_contact
+    end
+
+    def require_contact
+      return false if phone_number.present? || email.present?
+
+      true unless new_record? || %w[cart address].include?(state)
     end
   end
 end

--- a/app/models/spree_cm_commissioner/user_decorator.rb
+++ b/app/models/spree_cm_commissioner/user_decorator.rb
@@ -1,6 +1,8 @@
 module SpreeCmCommissioner
   module UserDecorator
     def self.prepended(base)
+      base.include SpreeCmCommissioner::PhoneNumberSanitizer
+
       base.enum gender: %i[male female other]
       base.has_many :user_identity_providers, dependent: :destroy, class_name: 'SpreeCmCommissioner::UserIdentityProvider'
       base.has_one :profile, as: :viewable, dependent: :destroy, class_name: 'SpreeCmCommissioner::UserProfile'

--- a/app/serializers/spree/v2/storefront/cart_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/cart_serializer_decorator.rb
@@ -1,0 +1,13 @@
+module Spree
+  module V2
+    module Storefront
+      module CartSerializerDecorator
+        def self.prepended(base)
+          base.attributes :phone_number, :intel_phone_number, :country_code
+        end
+      end
+    end
+  end
+end
+
+Spree::V2::Storefront::CartSerializer.prepend Spree::V2::Storefront::CartSerializerDecorator

--- a/app/serializers/spree/v2/storefront/user_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/user_serializer_decorator.rb
@@ -3,7 +3,7 @@ module Spree
     module Storefront
       module UserSerializerDecorator
         def self.prepended(base)
-          base.attributes :first_name, :last_name
+          base.attributes :first_name, :last_name, :phone_number, :intel_phone_number, :country_code
           base.has_one :profile, serializer: :user_profile
         end
       end

--- a/config/initializers/phonelib.rb
+++ b/config/initializers/phonelib.rb
@@ -1,0 +1,2 @@
+# https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+Phonelib.default_country = 'KH'

--- a/config/initializers/spree_permitted_attributes.rb
+++ b/config/initializers/spree_permitted_attributes.rb
@@ -4,5 +4,6 @@ module Spree
     @@line_item_attributes += %i[from_date to_date]
     @@user_attributes      += %i[first_name last_name dob gender profile]
     @@taxon_attributes     += %i[category_icon]
+    @@checkout_attributes  += %i[phone_number country_code]
   end
 end

--- a/db/migrate/20230228032325_add_phone_number_to_spree_order.rb
+++ b/db/migrate/20230228032325_add_phone_number_to_spree_order.rb
@@ -1,0 +1,7 @@
+class AddPhoneNumberToSpreeOrder < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_orders, :phone_number, :string, limit: 50, if_not_exists: true
+    add_column :spree_orders, :intel_phone_number, :string, limit: 50, index: true, if_not_exists: true
+    add_column :spree_orders, :country_code, :string, limit: 5, if_not_exists: true
+  end
+end

--- a/db/migrate/20230228083928_add_phone_number_to_spree_user.rb
+++ b/db/migrate/20230228083928_add_phone_number_to_spree_user.rb
@@ -1,0 +1,7 @@
+class AddPhoneNumberToSpreeUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_users, :phone_number, :string, limit: 50, if_not_exists: true
+    add_column :spree_users, :intel_phone_number, :string, limit: 50, index: true, if_not_exists: true
+    add_column :spree_users, :country_code, :string, limit: 5, if_not_exists: true
+  end
+end

--- a/spec/interactors/spree_cm_commissioner/phone_number_parser_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/phone_number_parser_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::PhoneNumberParser do
+  context 'valid phone number' do
+    before(:each) do
+      Phonelib.default_country = "KH"
+    end
+
+    it 'extracted phone number formats on intl phone_number' do
+      parser = described_class.call(phone_number: '+855964103875')
+
+      expect(parser.intel_phone_number).to eq "+855964103875"
+      expect(parser.national_phone_number).to eq "0964103875"
+    end
+
+    it 'extracted phone number formats on intl phone_number without +' do
+      parser = described_class.call(phone_number: '855964103875')
+
+      expect(parser.intel_phone_number).to eq "+855964103875"
+      expect(parser.national_phone_number).to eq "0964103875"
+    end
+
+    it 'extracted phone number formats on phone_number with prefix 0' do
+      parser = described_class.call(phone_number: '096 4103 875')
+
+      expect(parser.intel_phone_number).to eq "+855964103875"
+      expect(parser.national_phone_number).to eq "0964103875"
+    end
+
+    it 'extracted phone number formats on phone_number with prefix 0' do
+      parser = described_class.call(phone_number: '96 4103 875')
+
+      expect(parser.intel_phone_number).to eq "+855964103875"
+      expect(parser.national_phone_number).to eq "0964103875"
+    end
+  end
+
+  context 'invalid phone number' do
+    before(:each) do
+      Phonelib.default_country = "KH"
+    end
+
+    it 'return intl & national phone null on empty phone_number' do
+      parser = described_class.call(phone_number: ' ')
+
+      expect(parser.phone_number).to eq ' '
+      expect(parser.intel_phone_number).to eq nil
+      expect(parser.national_phone_number).to eq nil
+    end
+
+    it 'return intl & national phone null on incorrect length phone_number' do
+      parser = described_class.call(phone_number: '12345')
+
+      expect(parser.intel_phone_number).to eq nil
+      expect(parser.national_phone_number).to eq nil
+    end
+  end
+
+  context 'country_code' do
+    it 'return int & national phone base on specified country_code' do
+      Phonelib.default_country = "KH"
+      parser = described_class.call(phone_number: '6622549836', country_code: 'TH')
+
+      expect(parser.intel_phone_number).to eq "+6622549836"
+      expect(parser.national_phone_number).to eq "022549836"
+    end
+
+    it 'return int & national phone base on default when no country_code provided' do
+      Phonelib.default_country = "KH"
+      parser = described_class.call(phone_number: '0964103875')
+
+      expect(parser.intel_phone_number).to eq "+855964103875"
+      expect(parser.national_phone_number).to eq "0964103875"
+    end
+  end
+end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1,6 +1,50 @@
 require 'spec_helper'
 
 RSpec.describe Spree::Order, type: :model do
+  describe 'validations' do
+    context 'state is either cart or address' do
+      it 'not required present of email or phone number' do
+        order = create(:order, state: 'cart')
+
+        order.email = nil
+        order.phone_number = nil
+
+        expect(order.save).to eq true
+      end
+    end
+
+    context 'state is not either cart or address' do
+      it 'validates present of either email or phone number' do
+        order = create(:order, state: 'payment')
+
+        order.email = nil
+        order.phone_number = nil
+
+        expect { order.save! }
+          .to raise_error(ActiveRecord::RecordInvalid)
+          .with_message("Validation failed: Email can't be blank, Phone number can't be blank")
+      end
+
+      it 'not required phone number when email present' do
+        order = create(:order, state: 'payment')
+
+        order.email = 'test@gmail.com'
+        order.phone_number = nil
+
+        expect(order.save).to eq true
+      end
+
+      it 'not required email when phone number present' do
+        order = create(:order, state: 'payment')
+
+        order.email = nil
+        order.phone_number = '+855 12345678'
+
+        expect(order.save).to eq true
+      end
+    end
+  end
+
   describe '#delivery_required?' do
     let(:product1) { create(:product, name: 'Product 1') }
     let(:product2) { create(:product, name: 'Product 2') }
@@ -48,6 +92,29 @@ RSpec.describe Spree::Order, type: :model do
         allow(order.line_items[1]).to receive(:digital?).and_return(false)
 
         expect(order.delivery_required?).to eq false
+      end
+    end
+  end
+
+  context 'callbacks' do
+    describe 'before_save :sanitize_phone_number' do
+      before(:each) do
+        Phonelib.default_country = "KH"
+      end
+
+      it 'construct phone number before save' do
+        order = build(:order, phone_number: '096 4103 875')
+
+        expect(order.phone_number).to eq '096 4103 875'
+        expect(order.intel_phone_number).to eq nil
+        expect(order.country_code).to eq nil
+
+        order.save!
+        order.reload
+
+        expect(order.phone_number).to eq '0964103875'
+        expect(order.intel_phone_number).to eq '+855964103875'
+        expect(order.country_code).to eq 'KH'
       end
     end
   end

--- a/spec/serializers/spree/v2/storefront/cart_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/cart_serializer_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+RSpec.describe Spree::V2::Storefront::CartSerializer, type: :serializer do
+  describe '.serializable_hash' do
+    let(:cart) { create(:order_with_line_items) }
+
+    subject {
+      described_class.new(cart, include: [
+        :line_items,
+        :variants,
+        :promotions,
+        :payments,
+        :shipments,
+        :user,
+        :billing_address,
+        :shipping_address,
+        :vendors,
+        :vendor_totals
+      ]).serializable_hash
+    }
+
+    it 'returns exact cart attributes' do
+      expect(subject[:data][:attributes].keys).to contain_exactly(
+        :number,
+        :item_total,
+        :total,
+        :ship_total,
+        :adjustment_total,
+        :created_at,
+        :updated_at,
+        :completed_at,
+        :included_tax_total,
+        :additional_tax_total,
+        :display_additional_tax_total,
+        :display_included_tax_total,
+        :tax_total,
+        :currency,
+        :state,
+        :token,
+        :email,
+        :display_item_total,
+        :display_ship_total,
+        :display_adjustment_total,
+        :display_tax_total,
+        :promo_total,
+        :display_promo_total,
+        :item_count,
+        :special_instructions,
+        :display_total,
+        :pre_tax_item_amount,
+        :display_pre_tax_item_amount,
+        :pre_tax_total,
+        :display_pre_tax_total,
+        :shipment_state,
+        :payment_state,
+        :public_metadata,
+        :phone_number,
+        :intel_phone_number,
+        :country_code
+      )
+    end
+
+    it 'returns exact cart relationships' do
+      expect(subject[:data][:relationships].keys).to contain_exactly(
+        :line_items,
+        :variants,
+        :promotions,
+        :payments,
+        :shipments,
+        :user,
+        :billing_address,
+        :shipping_address,
+        :vendors,
+        :vendor_totals
+      )
+    end
+  end
+end

--- a/spec/serializers/spree/v2/storefront/user_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/user_serializer_spec.rb
@@ -1,22 +1,37 @@
-require 'spec_helper' 
+require 'spec_helper'
 
-describe Spree::V2::Storefront::UserSerializer, type: :serializer do 
-  let(:user) { create(:user) }
+describe Spree::V2::Storefront::UserSerializer, type: :serializer do
+  describe '.serializable_hash' do
+    let(:user) { create(:user) }
 
-  subject { described_class.new(user) }
+    subject {
+      described_class.new(user, include: [
+        :default_billing_address,
+        :default_shipping_address,
+        :profile
+      ]).serializable_hash
+    }
 
-  it 'returns right data attributes' do 
-    expect(subject.serializable_hash[:data].keys). to contain_exactly(:attributes, :id, :relationships, :type)
-  end
+    it 'returns exact user attributes' do
+      expect(subject[:data][:attributes].keys).to contain_exactly(
+        :email,
+        :first_name,
+        :last_name,
+        :public_metadata,
+        :store_credits,
+        :completed_orders,
+        :phone_number,
+        :intel_phone_number,
+        :country_code
+      )
+    end
 
-  it 'returns right user attributes' do 
-    expect(subject.serializable_hash[:data][:attributes].keys).to contain_exactly(
-      :completed_orders, 
-      :email, 
-      :first_name,
-      :last_name, 
-      :public_metadata, 
-      :store_credits
-    )
+    it 'returns exact user relationships' do
+      expect(subject[:data][:relationships].keys).to contain_exactly(
+        :default_billing_address,
+        :default_shipping_address,
+        :profile
+      )
+    end
   end
 end


### PR DESCRIPTION
## Core
- [x] Add phone number related columns to order & user
- [x] Add phone number validations to order
- [x] Initialize phone number for order from associated user on first create. 
- [x] Permit phone number attributes for update checkout

## API
- [x] Add phone number fields to user & order serializer