### PR TITLE
close #216 improve require dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,24 +5,6 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-spree_opts = '~> 4.5.0'
-gem 'spree', spree_opts
-gem 'spree_api', spree_opts
-gem 'spree_auth_devise'
-gem 'spree_backend', spree_opts
-gem 'spree_multi_vendor'
-# latest spree_multi_vendor 2.4.0 still depends on the Spree v1 API
-gem 'spree_api_v1'
-
-gem 'elasticsearch', '~> 8.5'
-gem 'searchkick',    '~> 5.1'
-
-gem 'interactor', '~> 3.1'
-gem 'jwt'
-
-# Google libphonenumber library
-gem 'phonelib', '~> 0.5.4'
-
 group :development do
   gem 'brakeman'
 end
@@ -38,7 +20,6 @@ group :development, :test do
 end
 
 group :test do
-  gem 'byebug'
   gem 'shoulda-matchers', '~> 5.0'
   gem 'terminal-table', '~> 3.0.1'
   # ActionMailer, Net::SMTP

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,10 +35,19 @@ PATH
   remote: .
   specs:
     spree_cm_commissioner (0.0.1)
+      byebug
       elasticsearch (~> 8.5)
       interactor (~> 3.1)
+      jwt (>= 2.5.0)
+      phonelib
       rails (~> 7.0.4)
       searchkick (~> 5.1)
+      spree (>= 4.5.0)
+      spree_api_v1 (>= 4.5.0)
+      spree_auth_devise (>= 4.5.0)
+      spree_backend (>= 4.5.0)
+      spree_extension
+      spree_multi_vendor (>= 2.4.0)
 
 GEM
   remote: https://rubygems.org/
@@ -633,27 +642,15 @@ PLATFORMS
 
 DEPENDENCIES
   brakeman
-  byebug
-  elasticsearch (~> 8.5)
-  interactor (~> 3.1)
-  jwt
   net-smtp
   pg
-  phonelib (~> 0.5.4)
   rails-controller-testing
   rubocop (~> 1.45)
   rubocop-performance (~> 1.16)
   rubocop-rails (~> 2.17)
-  searchkick (~> 5.1)
   shoulda-matchers (~> 5.0)
-  spree (~> 4.5.0)
-  spree_api (~> 4.5.0)
-  spree_api_v1
-  spree_auth_devise
-  spree_backend (~> 4.5.0)
   spree_cm_commissioner!
   spree_dev_tools!
-  spree_multi_vendor
   terminal-table (~> 3.0.1)
   vcr
   webmock

--- a/db/migrate/20221017132636_add_lat_lon_to_spree_stock_locations.rb
+++ b/db/migrate/20221017132636_add_lat_lon_to_spree_stock_locations.rb
@@ -2,10 +2,10 @@ class AddLatLonToSpreeStockLocations < ActiveRecord::Migration[6.1]
   def change
     # 90 to -90:
     # 00.00000000
-    add_column :spree_stock_locations, :lat, :decimal, precision: 10, scale: 8
+    add_column :spree_stock_locations, :lat, :decimal, precision: 10, scale: 8, if_not_exists: true
 
     # 180 to -180:
     # 000.00000000
-    add_column :spree_stock_locations, :lon, :decimal, precision: 11, scale: 8
+    add_column :spree_stock_locations, :lon, :decimal, precision: 11, scale: 8, if_not_exists: true
   end
 end

--- a/db/migrate/20221021043620_create_user_identity_providers.rb
+++ b/db/migrate/20221021043620_create_user_identity_providers.rb
@@ -1,6 +1,6 @@
 class CreateUserIdentityProviders < ActiveRecord::Migration[6.1]
   def change
-    create_table :cm_user_identity_providers do |t|
+    create_table :cm_user_identity_providers, if_not_exists: true do |t|
       t.integer :user_id
       t.integer :identity_type
       t.string :sub
@@ -9,8 +9,8 @@ class CreateUserIdentityProviders < ActiveRecord::Migration[6.1]
       t.timestamps
     end
 
-    add_index :cm_user_identity_providers, [:user_id, :identity_type], unique: true
-    add_index :cm_user_identity_providers, [:identity_type, :sub], unique: true
-    add_foreign_key :cm_user_identity_providers, :"#{Spree.user_class.table_name}", column: :user_id
+    add_index :cm_user_identity_providers, [:user_id, :identity_type], unique: true, if_not_exists: true
+    add_index :cm_user_identity_providers, [:identity_type, :sub], unique: true, if_not_exists: true
+    add_foreign_key :cm_user_identity_providers, :"#{Spree.user_class.table_name}", column: :user_id, if_not_exists: true
   end
 end

--- a/db/migrate/20221111013544_add_min_max_price_to_spree_vendors.rb
+++ b/db/migrate/20221111013544_add_min_max_price_to_spree_vendors.rb
@@ -1,6 +1,6 @@
 class AddMinMaxPriceToSpreeVendors < ActiveRecord::Migration[6.1]
   def change
-    add_column :spree_vendors, :min_price, :decimal, precision: 10, scale: 2, default: "0.0"
-    add_column :spree_vendors, :max_price, :decimal, precision: 10, scale: 2, default: "0.0"
+    add_column :spree_vendors, :min_price, :decimal, precision: 10, scale: 2, default: "0.0", if_not_exists: true
+    add_column :spree_vendors, :max_price, :decimal, precision: 10, scale: 2, default: "0.0", if_not_exists: true
   end
 end

--- a/db/migrate/20221227084456_add_permanent_stock_to_spree_variants.rb
+++ b/db/migrate/20221227084456_add_permanent_stock_to_spree_variants.rb
@@ -1,5 +1,5 @@
 class AddPermanentStockToSpreeVariants < ActiveRecord::Migration[6.1]
   def change
-    add_column :spree_variants, :permanent_stock, :integer, default: 1
+    add_column :spree_variants, :permanent_stock, :integer, default: 1, if_not_exists: true
   end
 end

--- a/db/migrate/20230102035446_add_kind_to_spree_option_types.rb
+++ b/db/migrate/20230102035446_add_kind_to_spree_option_types.rb
@@ -1,5 +1,5 @@
 class AddKindToSpreeOptionTypes < ActiveRecord::Migration[6.1]
   def change
-    add_column :spree_option_types, :kind, :integer, null: false, default: 0
+    add_column :spree_option_types, :kind, :integer, null: false, default: 0, if_not_exists: true
   end
 end

--- a/db/migrate/20230105074914_add_fields_to_spree_line_items.rb
+++ b/db/migrate/20230105074914_add_fields_to_spree_line_items.rb
@@ -1,6 +1,6 @@
 class AddFieldsToSpreeLineItems < ActiveRecord::Migration[6.1]
   def change
-    change_table :spree_line_items, bulk: true do |t|
+    change_table :spree_line_items, bulk: true, if_not_exists: true do |t|
       t.datetime :from_date
       t.datetime :to_date
       t.integer :vendor_id

--- a/db/migrate/20230109062713_add_total_inventory_and_state_id_to_spree_vendors.rb
+++ b/db/migrate/20230109062713_add_total_inventory_and_state_id_to_spree_vendors.rb
@@ -1,6 +1,6 @@
 class AddTotalInventoryAndStateIdToSpreeVendors < ActiveRecord::Migration[6.1]
   def change
-    change_table :spree_vendors, bulk: true do |t|
+    change_table :spree_vendors, bulk: true, if_not_exists: true do |t|
       t.integer :total_inventory
       t.integer :state_id
       t.index :state_id

--- a/db/migrate/20230111022259_create_spree_cm_commissioner_vendor_option_types.rb
+++ b/db/migrate/20230111022259_create_spree_cm_commissioner_vendor_option_types.rb
@@ -1,6 +1,6 @@
 class CreateSpreeCmCommissionerVendorOptionTypes < ActiveRecord::Migration[6.1]
   def change
-    create_table :cm_vendor_option_types do |t|
+    create_table :cm_vendor_option_types, if_not_exists: true do |t|
       t.references :vendor
       t.references :option_type
 

--- a/db/migrate/20230117021850_create_spree_cm_commissioner_option_value_vendors.rb
+++ b/db/migrate/20230117021850_create_spree_cm_commissioner_option_value_vendors.rb
@@ -1,6 +1,6 @@
 class CreateSpreeCmCommissionerOptionValueVendors < ActiveRecord::Migration[6.1]
   def change
-    create_table :cm_option_value_vendors do |t|
+    create_table :cm_option_value_vendors, if_not_exists: true do |t|
       t.references :vendor
       t.references :option_value
 

--- a/db/migrate/20230119100844_add_star_rating_to_spree_vendor.rb
+++ b/db/migrate/20230119100844_add_star_rating_to_spree_vendor.rb
@@ -1,5 +1,5 @@
 class AddStarRatingToSpreeVendor < ActiveRecord::Migration[6.1]
   def change
-    add_column :spree_vendors, :star_rating, :integer
+    add_column :spree_vendors, :star_rating, :integer, if_not_exists: true
   end
 end

--- a/db/migrate/20230120091001_add_short_description_to_spree_vendor.rb
+++ b/db/migrate/20230120091001_add_short_description_to_spree_vendor.rb
@@ -1,5 +1,5 @@
 class AddShortDescriptionToSpreeVendor < ActiveRecord::Migration[6.1]
   def change
-    add_column :spree_vendors, :short_description, :text
+    add_column :spree_vendors, :short_description, :text, if_not_exists: true
   end
 end

--- a/db/migrate/20230120115157_add_total_inventory_to_spree_states.rb
+++ b/db/migrate/20230120115157_add_total_inventory_to_spree_states.rb
@@ -1,5 +1,5 @@
 class AddTotalInventoryToSpreeStates < ActiveRecord::Migration[6.1]
   def change
-    add_column :spree_states, :total_inventory, :integer
+    add_column :spree_states, :total_inventory, :integer, if_not_exists: true
   end
 end

--- a/db/migrate/20230125131429_add_promoted_to_spree_option_type.rb
+++ b/db/migrate/20230125131429_add_promoted_to_spree_option_type.rb
@@ -1,6 +1,6 @@
 class AddPromotedToSpreeOptionType < ActiveRecord::Migration[6.1]
   def change
-    add_column :spree_option_types, :promoted, :boolean, default: false
+    add_column :spree_option_types, :promoted, :boolean, default: false, if_not_exists: true
   end
 end
 

--- a/lib/generators/spree_cm_commissioner/install/install_generator.rb
+++ b/lib/generators/spree_cm_commissioner/install/install_generator.rb
@@ -4,7 +4,14 @@ module SpreeCmCommissioner
       class_option :migrate, type: :boolean, default: true
 
       def add_migrations
-        run 'bundle exec rake railties:install:migrations FROM=spree_cm_commissioner'
+        gems = %i[
+          spree_multi_vendor
+          spree_cm_commissioner
+        ]
+
+        gems.each do |gem|
+          run "bundle exec rake railties:install:migrations FROM=#{gem}"
+        end
       end
 
       def run_migrations

--- a/lib/spree_cm_commissioner.rb
+++ b/lib/spree_cm_commissioner.rb
@@ -1,8 +1,18 @@
-require 'spree_core'
+require 'spree'
+require 'spree_api_v1'
+require 'spree_backend'
+require 'spree_auth_devise'
+require 'spree_multi_vendor'
 require 'spree_extension'
+
 require 'spree_cm_commissioner/engine'
 require 'spree_cm_commissioner/version'
 require 'spree_cm_commissioner/passenger_option'
+
 require 'searchkick'
 require 'elasticsearch'
 require 'interactor'
+require 'phonelib'
+require 'jwt'
+
+require 'byebug' if Rails.env.development? || Rails.env.test?

--- a/spree_cm_commissioner.gemspec
+++ b/spree_cm_commissioner.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
   s.version     = SpreeCmCommissioner.version
   s.summary     = 'Add extension summary here'
   s.description = 'Add (optional) extension description here'
+  s.required_ruby_version = '>= 2.7'
 
   s.author    = 'You'
   s.email     = 'you@example.com'
@@ -19,10 +20,21 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'elasticsearch',    '~> 8.5'
-  s.add_dependency 'interactor',       '~> 3.1'
-  s.add_dependency 'rails',            '~> 7.0.4'
-  s.add_dependency 'searchkick',       '~> 5.1'
+  spree_opts = '>= 4.5.0'
+  s.add_dependency 'spree', spree_opts
+  s.add_dependency 'spree_api_v1', spree_opts # latest spree_multi_vendor 2.4.0 still depends on the Spree v1 API
+  s.add_dependency 'spree_auth_devise', spree_opts
+  s.add_dependency 'spree_backend', spree_opts
+  s.add_dependency 'spree_multi_vendor', '>= 2.4.0'
+  s.add_dependency 'spree_extension'
+
+  s.add_dependency 'phonelib'
+  s.add_dependency 'jwt', '>= 2.5.0'
+  s.add_dependency 'elasticsearch', '~> 8.5'
+  s.add_dependency 'interactor', '~> 3.1'
+  s.add_dependency 'rails', '~> 7.0.4'
+  s.add_dependency 'searchkick', '~> 5.1'
+  s.add_dependency 'byebug'
 
   s.add_development_dependency 'pg'
   s.add_development_dependency 'spree_dev_tools'


### PR DESCRIPTION
# Improve required dependencies
With these new update, commissioner gem user don't have to install gem like phonelib, spree_multi_vendor, interactor...

- [x] Move require gems to gemspec
- [x] Add require gems to lib/spree_cm_commissioner.rb
- [x] Add spree_multi_vendor migration generator to commissioner generator
- [x] Add if not exist to each migrations

## Related PR on server
- https://github.com/bookmebus/cm-market-server/pull/39