### PR TITLE
close #225 add pricing model by extend with promotion

### DIFF
--- a/app/interactors/spree_cm_commissioner/vendor_price_rules_activator.rb
+++ b/app/interactors/spree_cm_commissioner/vendor_price_rules_activator.rb
@@ -1,0 +1,49 @@
+module SpreeCmCommissioner
+  class VendorPriceRulesActivator < BaseInteractor
+    delegate :from_date, :to_date, :vendor_id, to: :context
+
+    def call
+      load_vendor_listing_prices
+      adjust_vendor_listing_prices
+    end
+
+    # create listing prices for vendor on specific date
+    def load_vendor_listing_prices
+      context.vendor_listing_prices = (from_date..to_date).map do |date|
+        SpreeCmCommissioner::ListingPrice.first_or_initialize(
+          price_source: vendor,
+          date: date,
+          currency: Spree::Store.default.default_currency
+        ) do |vendor_listing_price|
+          vendor_listing_price.price = vendor.max_price
+        end
+      end
+    end
+
+    def adjust_vendor_listing_prices
+      context.vendor_listing_prices.each do |vendor_listing_price|
+        activate_pricing_models_to(vendor_listing_price)
+      end
+    end
+
+    def activate_pricing_models_to(modelable)
+      vendor_price_rules.each do |rule|
+        next unless eligible?(rule, modelable)
+
+        rule.pricing_model.activate(adjustable: modelable)
+      end
+    end
+
+    def eligible?(rule, modelable)
+      rule.applicable?(modelable) && rule.eligible?(modelable, {})
+    end
+
+    def vendor_price_rules
+      context.vendor_price_rules ||= vendor.price_rules
+    end
+
+    def vendor
+      context.vendor ||= Spree::Vendor.find(vendor_id)
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/adjustment_decorator.rb
+++ b/app/models/spree_cm_commissioner/adjustment_decorator.rb
@@ -1,0 +1,20 @@
+module SpreeCmCommissioner
+  module AdjustmentDecorator
+    def self.prepended(base)
+      base.validates :order, presence: true, unless: :adjustable_listing_price?
+    end
+
+    def adjustable_listing_price?
+      adjustable.is_a?(SpreeCmCommissioner::ListingPrice)
+    end
+  end
+end
+
+# override validation presence of order
+Spree::Adjustment.class_eval do
+  _validators[:order].find { |v| v.is_a? ActiveRecord::Validations::PresenceValidator }.attributes.delete(:order)
+end
+
+unless Spree::Adjustment.included_modules.include?(SpreeCmCommissioner::AdjustmentDecorator)
+  Spree::Adjustment.prepend(SpreeCmCommissioner::AdjustmentDecorator)
+end

--- a/app/models/spree_cm_commissioner/listing_price.rb
+++ b/app/models/spree_cm_commissioner/listing_price.rb
@@ -1,0 +1,17 @@
+require_dependency 'spree_cm_commissioner'
+
+module SpreeCmCommissioner
+  class ListingPrice < ApplicationRecord
+    has_many :adjustments, as: :adjustable, class_name: 'Spree::Adjustment', dependent: :destroy
+
+    belongs_to :price_source, polymorphic: true
+
+    validates :date, presence: true
+
+    extend Spree::DisplayMoney
+    money_methods :price, :adjustment_total, :additional_tax_total, :promo_total, :included_tax_total,
+                  :pre_tax_amount, :taxable_adjustment_total, :non_taxable_adjustment_total
+
+    alias_attribute :amount, :price
+  end
+end

--- a/app/models/spree_cm_commissioner/pricing_model.rb
+++ b/app/models/spree_cm_commissioner/pricing_model.rb
@@ -1,0 +1,16 @@
+module SpreeCmCommissioner
+  class PricingModel < Spree::Promotion
+    has_many :rules, autosave: true, foreign_key: :promotion_id, class_name: 'SpreeCmCommissioner::PricingModelRule', dependent: :destroy
+    has_many :actions, autosave: true, foreign_key: :promotion_id, class_name: 'SpreeCmCommissioner::PricingModelAction', dependent: :destroy
+
+    def activate(payload)
+      payload[:pricing_model] = self
+
+      results = actions.map do |action|
+        action.perform(payload)
+      end
+
+      results.include?(true)
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/pricing_model/actions/create_listing_price_adjustment.rb
+++ b/app/models/spree_cm_commissioner/pricing_model/actions/create_listing_price_adjustment.rb
@@ -1,0 +1,23 @@
+module SpreeCmCommissioner
+  class PricingModel
+    module Actions
+      class CreateListingPriceAdjustment < SpreeCmCommissioner::PricingModelAction
+        include Spree::AdjustmentSource
+        include Spree::CalculatedAdjustments
+
+        has_many :adjustments, as: :source, class_name: 'Spree::Adjustment'
+
+        before_validation -> { self.calculator ||= Calculator::FlatPercentItemTotal.new }
+
+        def perform(options = {})
+          adjustable = options[:adjustable]
+          create_unique_adjustment(nil, adjustable)
+        end
+
+        def compute_amount(adjustable)
+          compute(adjustable) * -1
+        end
+      end
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/pricing_model/rules/fixed_date.rb
+++ b/app/models/spree_cm_commissioner/pricing_model/rules/fixed_date.rb
@@ -1,0 +1,32 @@
+module SpreeCmCommissioner
+  class PricingModel
+    module Rules
+      class FixedDate < SpreeCmCommissioner::PricingModelRule
+        preference :start_date, :string
+        preference :length, :integer, default: 1
+
+        MATCH_POLICIES = %w[any none].freeze
+        preference :match_policy, :string, default: MATCH_POLICIES.first
+
+        def applicable?(modelable)
+          modelable.is_a?(SpreeCmCommissioner::ListingPrice)
+        end
+
+        def eligible?(modelable, _options = {})
+          case preferred_match_policy
+          when 'any'
+            date_eligible?(modelable.date)
+          else
+            !date_eligible?(modelable.date)
+          end
+        end
+
+        def date_eligible?(date)
+          start_rule_date = preferred_start_date.to_date
+          end_rule_date = start_rule_date + preferred_length.days - 1
+          date.to_date.between?(start_rule_date, end_rule_date)
+        end
+      end
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/pricing_model_action.rb
+++ b/app/models/spree_cm_commissioner/pricing_model_action.rb
@@ -1,0 +1,5 @@
+module SpreeCmCommissioner
+  class PricingModelAction < Spree::PromotionAction
+    belongs_to :pricing_model, class_name: 'SpreeCmCommissioner::PricingModel', foreign_key: :promotion_id, dependent: :destroy
+  end
+end

--- a/app/models/spree_cm_commissioner/pricing_model_rule.rb
+++ b/app/models/spree_cm_commissioner/pricing_model_rule.rb
@@ -1,0 +1,6 @@
+module SpreeCmCommissioner
+  class PricingModelRule < Spree::PromotionRule
+    belongs_to :vendor, class_name: 'Spree::Vendor', dependent: :destroy
+    belongs_to :pricing_model, class_name: 'SpreeCmCommissioner::PricingModel', foreign_key: :promotion_id, dependent: :destroy
+  end
+end

--- a/app/models/spree_cm_commissioner/vendor_decorator.rb
+++ b/app/models/spree_cm_commissioner/vendor_decorator.rb
@@ -32,6 +32,9 @@ module SpreeCmCommissioner
       base.has_many :promoted_option_values, -> { joins(:option_type).where('option_type.promoted' => true) },
                     through: :option_value_vendors, source: :option_value
 
+      base.has_many :listing_prices, as: :price_source, class_name: 'SpreeCmCommissioner::ListingPrice', dependent: :destroy
+      base.has_many :price_rules, class_name: 'SpreeCmCommissioner::PricingModelRule', dependent: :destroy
+
       base.accepts_nested_attributes_for :nearby_places, allow_destroy: true
 
       # TODO: we will need searchkick later

--- a/db/migrate/20230310032336_add_vendor_reference_to_spree_promotion_rule.rb
+++ b/db/migrate/20230310032336_add_vendor_reference_to_spree_promotion_rule.rb
@@ -1,0 +1,6 @@
+class AddVendorReferenceToSpreePromotionRule < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :spree_promotion_rules, :vendor, index: true, if_not_exists: true
+    add_foreign_key :spree_promotion_rules, :spree_vendors, column: :vendor_id, if_not_exists: true
+  end
+end

--- a/db/migrate/20230310100611_create_spree_cm_commissioner_listing_prices.rb
+++ b/db/migrate/20230310100611_create_spree_cm_commissioner_listing_prices.rb
@@ -1,0 +1,28 @@
+class CreateSpreeCmCommissionerListingPrices < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cm_listing_prices, if_not_exists: true do |t|
+      t.references :price_source, polymorphic: true, null: false
+
+      t.date :date, null: false
+      t.string :currency
+
+      t.decimal :price, precision: 10, scale: 2, default: 0.0, null: false
+      t.decimal :adjustment_total, precision: 10, scale: 2, default: 0.0
+      t.decimal :additional_tax_total, precision: 10, scale: 2, default: 0.0
+      t.decimal :promo_total, precision: 10, scale: 2, default: 0.0
+      t.decimal :included_tax_total, precision: 10, scale: 2, default: 0.0, null: false
+      t.decimal :pre_tax_amount, precision: 12, scale: 4, default: 0.0, null: false
+      t.decimal :taxable_adjustment_total, precision: 10, scale: 2, default: 0.0, null: false
+      t.decimal :non_taxable_adjustment_total, precision: 10, scale: 2, default: 0.0, null: false
+
+      t.timestamps
+    end
+
+    add_index :cm_listing_prices, [
+      :price_source_type,
+      :price_source_id,
+      :date,
+      :currency
+    ], unique: true, name: 'index_cm_listing_prices_uniqueness', if_not_exists: true
+  end
+end

--- a/db/migrate/20230313080741_change_column_order_null_to_spree_adjustments.rb
+++ b/db/migrate/20230313080741_change_column_order_null_to_spree_adjustments.rb
@@ -1,0 +1,5 @@
+class ChangeColumnOrderNullToSpreeAdjustments < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :spree_adjustments, :order_id, true
+  end
+end

--- a/lib/spree_cm_commissioner/test_helper/factories/listing_price_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/listing_price_factory.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :cm_listing_price, class: SpreeCmCommissioner::ListingPrice do
+    price { 10.0 }
+
+    date { '2022-12-27'.to_date }
+    currency { Spree::Store.default.default_currency }
+
+    price_source { |l| create(:product, price: l.price) }
+  end
+end

--- a/lib/spree_cm_commissioner/test_helper/factories/pricing_model_action_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/pricing_model_action_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :cm_pricing_model_action, class: SpreeCmCommissioner::PricingModel::Actions::CreateListingPriceAdjustment do
+    pricing_model { create(:cm_pricing_model) }
+    calculator { Spree::Calculator::FlatRate.new(preferred_amount: 10.0) }
+  end
+end

--- a/lib/spree_cm_commissioner/test_helper/factories/pricing_model_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/pricing_model_factory.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :cm_pricing_model, class: SpreeCmCommissioner::PricingModel do
+    name { 'New Year 2022' }
+
+    before(:create) do |pricing_model, _evaluator|
+      if pricing_model.stores.empty?
+        default_store = Spree::Store.default.persisted? ? Spree::Store.default : nil
+        store = default_store || create(:store)
+        pricing_model.stores << [store]
+      end
+    end
+  end
+end

--- a/lib/spree_cm_commissioner/test_helper/factories/pricing_model_rule_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/pricing_model_rule_factory.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :cm_pricing_model_rule, class: SpreeCmCommissioner::PricingModel::Rules::FixedDate do
+    preferred_match_policy { 'any' }
+    preferred_start_date { '2023-02-21' }
+    preferred_length { 2 }
+    vendor { create(:vendor) }
+  end
+end

--- a/spec/interactors/spree_cm_commissioner/vendor_price_rules_activator_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/vendor_price_rules_activator_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::VendorPriceRulesActivator do
+  context 'match any date' do
+    let!(:vendor) { create(:active_vendor, min_price: 20.0, max_price: 100.0) }
+
+    let(:calculator) { Spree::Calculator::FlatRate.new(preferred_amount: 10.0) } # -10 USD
+    let(:action) { SpreeCmCommissioner::PricingModel::Actions::CreateListingPriceAdjustment.new(calculator: calculator) }
+    let(:rule) {
+      SpreeCmCommissioner::PricingModel::Rules::FixedDate.new(
+        preferred_match_policy: 'any',
+        preferred_start_date: '2023-02-21',
+        preferred_length: 2,
+        vendor: vendor
+      )
+    }
+
+    let!(:pricing_model) { create(:cm_pricing_model, rules: [rule], actions: [action]) }
+
+    it 'only create and adjust vendor listing price on 2023-02-21, 2023-02-22' do
+      context = described_class.call(
+        from_date: '2023-02-20',
+        to_date: '2023-02-24',
+        vendor_id: vendor.id
+      )
+
+      listing_prices = context.vendor_listing_prices
+
+      expect(listing_prices.size).to eq 5
+      expect(listing_prices.pluck(:price).uniq).to eq [vendor.max_price]
+
+      expect(listing_prices[0].display_adjustment_total.to_s).to eq '$0.00'
+      expect(listing_prices[1].display_adjustment_total.to_s).to eq '-$10.00'
+      expect(listing_prices[2].display_adjustment_total.to_s).to eq '-$10.00'
+      expect(listing_prices[3].display_adjustment_total.to_s).to eq '$0.00'
+      expect(listing_prices[4].display_adjustment_total.to_s).to eq '$0.00'
+
+      expect(listing_prices[0].date).to eq '2023-02-20'.to_date
+      expect(listing_prices[1].date).to eq '2023-02-21'.to_date
+      expect(listing_prices[2].date).to eq '2023-02-22'.to_date
+      expect(listing_prices[3].date).to eq '2023-02-23'.to_date
+      expect(listing_prices[4].date).to eq '2023-02-24'.to_date
+
+      expect(listing_prices[0].persisted?).to be false
+      expect(listing_prices[1].persisted?).to be true
+      expect(listing_prices[2].persisted?).to be true
+      expect(listing_prices[3].persisted?).to be false
+      expect(listing_prices[4].persisted?).to be false
+    end
+  end
+end

--- a/spec/models/spree/adjustment_spec.rb
+++ b/spec/models/spree/adjustment_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Adjustment, type: :model do
+  describe 'validations' do
+    context 'presence_of :order' do
+      let(:source) { create(:tax_rate, calculator: create(:calculator)) }
+      let(:listing_price) { create(:cm_listing_price) }
+      let(:line_item) { create(:line_item) }
+
+      it 'not required order when adjustable is ListingPrice' do
+        adjustment = build(:adjustment, order: nil, adjustable: listing_price, source: source)
+
+        expect { adjustment.save! }.not_to raise_error
+      end
+
+      it 'required order when adjustable is not ListingPrice' do
+        adjustment = build(:adjustment, order: nil, adjustable: line_item, source: source)
+
+        expect { adjustment.save! }
+          .to raise_error(ActiveRecord::RecordInvalid)
+          .with_message("Validation failed: Order can't be blank")
+      end
+    end
+  end
+end

--- a/spec/models/spree/vendor_spec.rb
+++ b/spec/models/spree/vendor_spec.rb
@@ -117,5 +117,19 @@ RSpec.describe Spree::Vendor, type: :model do
         expect(vendor.state_id).to eq siem_reap.id
       end
     end
+
+    context '#price_rules' do
+      let!(:vendor) { create(:active_vendor, min_price: 10, max_price: 50) }
+      let!(:promotion_rule) { create(:promotion_rule, vendor_id: vendor.id) }
+      let!(:pricing_model_rule) { create(:cm_pricing_model_rule, vendor_id: vendor.id) }
+
+      it 'only return pricing rules' do
+        expect(vendor.price_rules.size).to eq 1
+        expect(vendor.price_rules[0].id).to eq pricing_model_rule.id
+
+        expect(SpreeCmCommissioner::PricingModelRule.all.size).to eq 1
+        expect(Spree::PromotionRule.all.size).to eq 2 # as it is base class
+      end
+    end
   end
 end

--- a/spec/models/spree_cm_commissioner/listing_price_spec.rb
+++ b/spec/models/spree_cm_commissioner/listing_price_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::ListingPrice, type: :model do
+  describe 'associations' do
+    it { should have_many(:adjustments).class_name('Spree::Adjustment').dependent(:destroy) }
+
+    it { is_expected.to belong_to(:price_source) }
+  end
+
+  describe 'validations' do
+    it { should validate_presence_of(:date) }
+  end
+end


### PR DESCRIPTION
## Scope

- [x] Add Interactor: _vendor listing price activator_:
  - Add vendor listing prices from from_date...to_date
  - Adjust eligible promotions to those vendor listing prices
- [x] Add Action: listing price adjustment action
- [x] Add Rule: fixed date rule
   - Eligible when date between rule _start date_ to _start date + length - 1_. 
- [x] Override validation of adjustment to not required order when its adjustable is `ListingPrice`.

## References
- Detail why & diagram: 
  https://github.com/channainfo/commissioner/issues/225