### PR TITLE
close #228 setup spree backend js & stylesheet decorator

### DIFF
--- a/app/assets/javascripts/spree_cm_commissioner/backend.js
+++ b/app/assets/javascripts/spree_cm_commissioner/backend.js
@@ -1,0 +1,2 @@
+//= require map/map-control-button
+//= require map/map-picker

--- a/app/assets/stylesheets/spree_cm_commissioner/backend.css
+++ b/app/assets/stylesheets/spree_cm_commissioner/backend.css
@@ -1,0 +1,7 @@
+/*
+ * This is a manifest file that'll automatically include all the stylesheets available in this directory
+ * and any sub-directories. You're free to add application-wide styles to this file and they'll appear at
+ * the top of the compiled file, but it's generally better to create a new file per style scope.
+ *
+ *= require spree_cm_commissioner/backend/commissioner_admin
+*/

--- a/lib/generators/spree_cm_commissioner/install/install_generator.rb
+++ b/lib/generators/spree_cm_commissioner/install/install_generator.rb
@@ -2,6 +2,7 @@ module SpreeCmCommissioner
   module Generators
     class InstallGenerator < Rails::Generators::Base
       class_option :migrate, type: :boolean, default: true
+      source_root File.expand_path('../../../../spree/templates', __dir__)
 
       def add_migrations
         gems = %i[
@@ -21,6 +22,16 @@ module SpreeCmCommissioner
         else
           Rails.logger.debug 'Skipping rails db:migrate, don\'t forget to run it!'
         end
+      end
+
+      def install_admin
+        return unless Spree::Core::Engine.backend_available?
+
+        inject_into_file 'vendor/assets/stylesheets/spree/backend/all.css', "\n *= require spree_cm_commissioner/backend",
+                         after: %r{ *= require spree/backend}, verbose: true
+
+        inject_into_file 'vendor/assets/javascripts/spree/backend/all.js', "\n//= require spree_cm_commissioner/backend",
+                         after: %r{//= require spree/backend}, verbose: true
       end
     end
   end


### PR DESCRIPTION
## Scope
- Make sure it is easier to add custom style & additional scripts.

- Inject all.js & all.css to import our styles & scripts for the backend. Run the command below to load them to server.

  ```s
  bundle exec rails g spree_cm_commissioner:install
  ```

## Sample
all.css

```css
/*
 * This is a manifest file that'll automatically include all the stylesheets available in this directory
 * and any sub-directories. You're free to add application-wide styles to this file and they'll appear at
 * the top of the compiled file, but it's generally better to create a new file per style scope.
 *
 *= require spree/backend
 *= require spree_cm_commissioner/backend
 *= require_self
 *= require_tree .
*/
```

all.js

```js
// This is a manifest file that'll be compiled into including all the files listed below.
// Add new JavaScript/Coffee code in separate files in this directory and they'll automatically
// be included in the compiled file accessible from http://example.com/assets/application.js
// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
// the compiled file.
//
//= require spree/backend
//= require spree_cm_commissioner/backend
//= require_tree .
```

## Reference
- https://github.com/spree-contrib/spree_editor/blob/master/lib/generators/spree_editor/install/install_generator.rb