### PR TITLE
close #238 setup calendar ui + orders calendar sample

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,7 @@ PATH
       phonelib
       rails (~> 7.0.4)
       searchkick (~> 5.1)
+      simple_calendar (~> 2.4)
       spree (>= 4.5.0)
       spree_api_v1 (>= 4.5.0)
       spree_auth_devise (>= 4.5.0)
@@ -490,6 +491,8 @@ GEM
       websocket (~> 1.0)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
+    simple_calendar (2.4.3)
+      rails (>= 3.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)

--- a/app/assets/javascripts/spree_cm_commissioner/backend.js
+++ b/app/assets/javascripts/spree_cm_commissioner/backend.js
@@ -1,2 +1,6 @@
+//= require popper
+//= require bootstrap-sprockets
 //= require map/map-control-button
 //= require map/map-picker
+//= require spree_cm_commissioner/calendar
+//= require spree_cm_commissioner/popover

--- a/app/assets/javascripts/spree_cm_commissioner/calendar.js
+++ b/app/assets/javascripts/spree_cm_commissioner/calendar.js
@@ -1,0 +1,59 @@
+const Calendar = {
+  sidebarSelector: "#c-sidebar",
+  dateSelector: ".c-date",
+  activeDateQuerySelector: "active_date",
+  initialize: function () {
+    this.url = new window.URL(document.location);
+    this.listenToDateClick();
+    this.initialSidebar();
+  },
+  initialSidebar: function () {
+    const dateSelectorId = "#c-date-" + this.activeDate();
+    const content = $(dateSelectorId).data("content");
+    this.updateDateSidebarContent(content);
+  },
+  listenToDateClick: function () {
+    self = this;
+
+    $(self.dateSelector).click(function () {
+      const content = $(this).data("content");
+      const date = $(this).data("date");
+
+      if (self.activeDate() === date) return;
+
+      self.updateDateSidebarContent(content);
+      self.updateCurrentUrlActiveDate(date);
+
+      self.renderDateAsActive(this);
+    });
+  },
+  updateCurrentUrlActiveDate: function (date) {
+    this.url.searchParams.set(this.activeDateQuerySelector, date);
+    history.pushState(null, null, this.url);
+  },
+  updateDateSidebarContent: function (content) {
+    const selector = self.sidebarSelector;
+    $(selector)
+      .fadeOut("fast", function () {
+        $(selector).html(content);
+      })
+      .fadeIn("fast");
+  },
+  renderDateAsActive: function (element) {
+    const parentSelector = ".day";
+    const parent = $(element).parent().closest(parentSelector);
+
+    $(parentSelector).removeClass("start-date");
+    parent.addClass("start-date");
+
+    // in case there is input form
+    $("#active_date").val(this.activeDate());
+  },
+  activeDate: function () {
+    return this.url.searchParams.get(this.activeDateQuerySelector);
+  },
+};
+
+document.addEventListener("spree:load", function () {
+  Calendar.initialize();
+});

--- a/app/assets/javascripts/spree_cm_commissioner/popover.js
+++ b/app/assets/javascripts/spree_cm_commissioner/popover.js
@@ -1,0 +1,3 @@
+document.addEventListener("spree:load", function () {
+  $('[data-toggle="popover"]').popover();
+});

--- a/app/assets/stylesheets/spree_cm_commissioner/backend.css
+++ b/app/assets/stylesheets/spree_cm_commissioner/backend.css
@@ -3,5 +3,6 @@
  * and any sub-directories. You're free to add application-wide styles to this file and they'll appear at
  * the top of the compiled file, but it's generally better to create a new file per style scope.
  *
+ *= require simple_calendar
  *= require spree_cm_commissioner/backend/commissioner_admin
 */

--- a/app/assets/stylesheets/spree_cm_commissioner/backend/calendar.scss
+++ b/app/assets/stylesheets/spree_cm_commissioner/backend/calendar.scss
@@ -1,0 +1,108 @@
+.simple-calendar {
+  $day-background: theme-color("light");
+
+  table {
+    @extend .table-responsive-md;
+  }
+
+  .calendar-heading {
+    @extend .border;
+
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background-color: $day-background;
+    border-bottom: none !important;
+
+    a {
+      @extend .btn;
+      @extend .btn-link;
+    }
+  }
+
+  .day {
+    background-color: $day-background;
+
+    @include hover {
+      background-color: darken($day-background, 5%);
+    }
+
+    .c-date-container {
+      display: flex;
+      flex-flow: column;
+      height: 100%;
+
+      .c-date {
+        padding: 6px;
+        cursor: pointer;
+      }
+
+      .c-events-container {
+        flex-grow: 1;
+        display: flex;
+        align-items: flex-end;
+      }
+
+      .c-events {
+        display: flex;
+        align-items: flex-end;
+
+        .c-event {
+          width: 8px;
+          height: 8px;
+          border-radius: 4px;
+          background-color: theme-color("primary");
+          margin-right: 4px;
+          cursor: pointer;
+        }
+      }
+    }
+  }
+
+  // .wday-0 {
+  // }
+
+  // .wday-1 {
+  // }
+
+  // .wday-2 {
+  // }
+
+  // .wday-3 {
+  // }
+
+  // .wday-4 {
+  // }
+
+  // .wday-5 {
+  // }
+
+  // .wday-6 {
+  // }
+
+  // .today {
+  // }
+
+  // .past {
+  // }
+
+  // .future {
+  // }
+
+  // known as active-date
+  .start-date {
+    background-color: darken($day-background, 5%);
+  }
+
+  // .prev-month {
+  // }
+
+  // .next-month {
+  // }
+
+  // .current-month {
+  // }
+
+  // .has-events {
+  // }
+}

--- a/app/assets/stylesheets/spree_cm_commissioner/backend/commissioner_admin.css.scss
+++ b/app/assets/stylesheets/spree_cm_commissioner/backend/commissioner_admin.css.scss
@@ -1,0 +1,2 @@
+@import "spree/backend/spree_admin";
+@import "spree_cm_commissioner/backend/calendar";

--- a/app/controllers/spree/admin/calendars/base_controller.rb
+++ b/app/controllers/spree/admin/calendars/base_controller.rb
@@ -1,0 +1,22 @@
+module Spree
+  module Admin
+    module Calendars
+      class BaseController < Spree::Admin::ResourceController
+        rescue_from Date::Error, with: :redirect_to_current_date
+
+        def redirect_to_current_date
+          redirect_to url_for(default_url_options)
+        end
+
+        def default_url_options
+          { active_date: Time.zone.today }
+        end
+
+        # 2023-06-05
+        def active_date
+          @active_date ||= Date.strptime(params[:active_date].to_s, '%Y-%m-%d')
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/spree/admin/calendars/orders_controller.rb
+++ b/app/controllers/spree/admin/calendars/orders_controller.rb
@@ -1,0 +1,27 @@
+module Spree
+  module Admin
+    module Calendars
+      class OrdersController < Spree::Admin::Calendars::BaseController
+        def collection
+          # for whole month calendar
+          from = active_date.beginning_of_month - 1.week
+          to = active_date.end_of_month + 1.week
+
+          @collection ||= Spree::Order.where.not(state: :cart)
+                                      .joins(:line_items)
+                                      .where(line_items: { from_date: from..to, vendor_id: params[:vendor_id] })
+        end
+
+        # @overrided
+        def model_class
+          Spree::Order
+        end
+
+        # @overrided
+        def object_name
+          'order'
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/spree/admin/base_helper_decorator.rb
+++ b/app/helpers/spree/admin/base_helper_decorator.rb
@@ -6,6 +6,10 @@ module Spree
 
         image_tag asset_path, width: '24px'
       end
+
+      def render_escape_html(render_payload)
+        Rack::Utils.escape_html(render(render_payload))
+      end
     end
   end
 end

--- a/app/overrides/spree/admin/shared/_main_menu/sidebar_calendars.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_main_menu/sidebar_calendars.html.erb.deface
@@ -1,0 +1,5 @@
+<!-- insert_after "#sidebarPromotion" -->
+
+<ul class="nav nav-sidebar" id="sidebarCalendar">
+  <%= main_menu_tree Spree.t(:calendar), icon: "calendar4-event.svg", sub_menu: "calendar", url: "#sidebar-calendar" %>
+</ul>

--- a/app/views/shared/_calendar.html.erb
+++ b/app/views/shared/_calendar.html.erb
@@ -1,0 +1,25 @@
+<%# :events, [SpreeCmCommissioner::CalendarEvent] %>
+<%# :sidebar_partial, eg. 'calendar_sidebar/orders' %>
+
+<% active_date = params[:active_date].to_date %>
+
+<% content_for :sidebar do %>
+  <div id="c-sidebar"></div>
+<% end %>
+
+<%= month_calendar(attribute: :from_date, end_attribute: :to_date, events: events, start_date_param: :active_date) do |date, _events| %>
+  <% display_day = active_date.month != date.month ? date.strftime("%b %d") : date.day %>
+  <div class="c-date-container" >
+    <div class="c-date" id="c-date-<%= date.to_s %>" data-date='<%= date.to_s %>' data-content='<%= raw render_escape_html partial: sidebar_partial, locals: { events: _events } %>'><%= display_day %></div>
+    <div class="c-events-container">
+      <div class="c-events">
+        <% _events.each do |event| %>
+          <div class="c-event <%= event.options[:classes].join(" ") %>"
+            data-toggle="popover" data-trigger="focus" role="button" tabindex="0" data-title="<%= event.title %>" data-html="true"
+            data-content="<%= raw render_escape_html partial: event.options[:popover], locals: { event: event } %>">
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/shared/calendar/_order_popover.html.erb
+++ b/app/views/shared/calendar/_order_popover.html.erb
@@ -1,0 +1,18 @@
+<% order = event.options[:order] %>
+
+<div>
+  <div>
+    <a target="_blank" href="<%= cart_admin_order_url(order.number) %>"><strong><%= order.number %></strong></a>
+    <p class="ml-1 badge badge-primary badge-pill mb-0"><%= order.state %></p>
+    <p><%= order.display_total %></p>
+  </div>
+  <ul class="list-group m-0">
+    <% order.line_items.each do |item| %>
+      <li class="list-group-item p-2">
+        <small><%= item.name %></small><br>
+        <small><%= item.display_price %> x <%= item.quantity %></small>
+        <small><strong>(<%= item.from_date&.strftime("%d") %> - <%= item.to_date&.strftime("%d") %>)</strong></small>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/shared/calendar/_orders_sidebar.html.erb
+++ b/app/views/shared/calendar/_orders_sidebar.html.erb
@@ -1,0 +1,41 @@
+<div class="w-100 h-50">
+  <% events.each do |event| %>
+    <% order = event.options[:order] %>
+
+    <div class="card mb-2">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <a class="card-title mb-0 h6" target="_blank" href="<%= cart_admin_order_url(order.number) %>"><%= order.number %></a>
+        <div>
+          <span class="state badge badge-pill badge-<%= order.state %> badge-pill text-capitalize">
+            <%= Spree.t(order.state, scope: :order_state) %>
+          </span>
+          <span class="state badge badge-pill badge-primary text-capitalize">
+            <%= order.display_total.to_s %>
+          </span>
+        </div>
+      </div>
+      <ul class="list-group list-group-flush">
+        <% if order.adjustment_total != 0.0 %>
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            <small><%= Spree.t(:adjustment) %></small>
+            <small class="text-capitalize">
+              <%= order.display_adjustment_total.to_s %>
+            </small>
+          </li>
+        <% end %>
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <small><%= Spree.t(:line_items) %></small>
+          <small class="text-capitalize">
+            <%= order.line_items.size %>
+          </small>
+        </li>
+      </ul>
+    </div>
+  <% end %>
+
+  <% if events.empty? %>
+    <small class="form-text text-muted">
+      <%= raw I18n.t('calendar.event.empty_info') %>
+    </small>
+  <% end %>
+<div>

--- a/app/views/spree/admin/calendars/orders/index.html.erb
+++ b/app/views/spree/admin/calendars/orders/index.html.erb
@@ -1,0 +1,22 @@
+<% content_for :page_title do %>
+  <%= plural_resource_name(Spree::Order) %>
+<% end %>
+
+<% content_for :page_actions do %>
+  <%= button_link_to Spree.t(:new_order), new_admin_order_url, class: "btn-success", icon: 'add.svg', id: 'admin_new_order' %>
+<% end if can? :create, Spree::Order %>
+
+<% content_for :sidebar do %>
+  <%= form_with method: :get, html: { class: 'card p-3 mb-3' } do |f| %>
+    <%= select_tag(:vendor_id,
+      options_from_collection_for_select(Spree::Vendor.active, :id, :name, params[:vendor_id]),
+      include_blank: Spree.t('match_choices.none'),
+      class: "select2") %>
+    <%= f.hidden_field :active_date, value: params[:active_date] %>
+    <div class="form-actions mt-2"><%= button Spree.t(:search), 'search.svg' %></div>
+  <% end %>
+<% end %>
+
+<%= render 'shared/calendar',
+  events: SpreeCmCommissioner::CalendarEvent.from_orders(@orders),
+  sidebar_partial: 'shared/calendar/orders_sidebar' %>

--- a/app/views/spree/admin/shared/sub_menu/_calendar.html.erb
+++ b/app/views/spree/admin/shared/sub_menu/_calendar.html.erb
@@ -1,0 +1,3 @@
+<ul id="sidebar-calendar" class="collapse nav nav-pills nav-stacked pb-2" data-hook="admin_calendar_sub_tabs">
+  <%= tab :orders, url: admin_calendars_orders_path %>
+</ul>

--- a/app/views/spree/admin/vectors/icons/index.html.erb
+++ b/app/views/spree/admin/vectors/icons/index.html.erb
@@ -7,7 +7,7 @@
     <li class="nav-item">
       <% default_params = { path_prefix: path_prefix, extension: '', page: 1, per_page: params[:per_page], query: '' } %>
       <% selected = params[:path_prefix] == path_prefix %>
-      <% overrided_params = selected ? default_params : params.merge(default_params) %>
+      <% overrided_params = selected ? default_params : params.merge(default_params).permit(default_params.keys) %>
       <%= link_to path_prefix.humanize, overrided_params, class: "nav-link #{'active' if selected}" %>
     </li>
   <% end  %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,10 @@ en:
   category_icon:
     field: Category icon (Square)
 
+  calendar:
+    event:
+      empty_info:  "No <b>Events</b> found."
+
   option_type:
     kind_info: "<b>Once set</b>, it can't be updated."
     kind_validation: "Attribute can't be updated for %{option_type_name}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,10 @@ Spree::Core::Engine.add_routes do
       end
     end
 
+    namespace :calendars do
+      resources :orders, only: %i[index]
+    end
+
     resources :taxonomies do
       resources :taxons do
         member do

--- a/lib/spree_cm_commissioner.rb
+++ b/lib/spree_cm_commissioner.rb
@@ -8,11 +8,14 @@ require 'spree_extension'
 require 'spree_cm_commissioner/engine'
 require 'spree_cm_commissioner/version'
 require 'spree_cm_commissioner/passenger_option'
+require 'spree_cm_commissioner/calendar_event'
 
 require 'searchkick'
 require 'elasticsearch'
 require 'interactor'
 require 'phonelib'
 require 'jwt'
+
+require 'simple_calendar'
 
 require 'byebug' if Rails.env.development? || Rails.env.test?

--- a/lib/spree_cm_commissioner/calendar_event.rb
+++ b/lib/spree_cm_commissioner/calendar_event.rb
@@ -1,0 +1,27 @@
+module SpreeCmCommissioner
+  class CalendarEvent
+    attr_reader :from_date, :to_date, :title, :options
+
+    def initialize(from_date:, to_date:, title:, options:)
+      @from_date = from_date
+      @to_date = to_date
+      @title = title
+      @options = options
+    end
+
+    def self.from_orders(orders)
+      orders.map do |order|
+        CalendarEvent.new(
+          from_date: order.line_items.minimum(:from_date),
+          to_date: order.line_items.maximum(:to_date),
+          title: Spree.t(:order),
+          options: {
+            popover: 'shared/calendar/order_popover',
+            classes: ['bg-primary'],
+            order: order
+          }
+        )
+      end
+    end
+  end
+end

--- a/spree_cm_commissioner.gemspec
+++ b/spree_cm_commissioner.gemspec
@@ -36,6 +36,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'searchkick', '~> 5.1'
   s.add_dependency 'byebug'
 
+  s.add_dependency 'simple_calendar', '~> 2.4'
+
   s.add_development_dependency 'pg'
   s.add_development_dependency 'spree_dev_tools'
   s.metadata['rubygems_mfa_required'] = 'true'


### PR DESCRIPTION
# Setup Calendar + Order Calendar
Preparing UI for service calendar, price rule, etc that related to calendar.

## Scope
- [x] Use [simple_calendar](https://github.com/excid3/simple_calendar) gem
- [x] Enable popover bootstrap with `popper`, `bootstrap-sprockets`
- [x] Add Calendar component
  - calendar.js, calendar.scss, shared/calendar.html.erb
  - SpreeCmCommissioner::CalendarEvent
  - event partial on side bar samples
  - event popover samples
- [x] Orders Calendar Controller
  - Fetch by whole calendar month
  - Fetch per vendor

## Demo

| |
| - |
| |
| <img width="1440" alt="image" src="https://user-images.githubusercontent.com/29684683/225943373-77f805ef-43b7-4c32-8f0b-11785fb2d556.png"> |
| |
| <img width="1440" alt="image" src="https://user-images.githubusercontent.com/29684683/225943433-dddc7331-02b6-439f-9771-9d88cadf07f1.png">|