### PR TITLE
close #242 decorate promotion view to support pricing model

### DIFF
--- a/app/controllers/spree/admin/promotions_controller_decorator.rb
+++ b/app/controllers/spree/admin/promotions_controller_decorator.rb
@@ -1,0 +1,22 @@
+module Spree
+  module Admin
+    module PromotionsControllerDecorator
+      protected
+
+      # @overrided
+      def load_data
+        @actions = fetch_actions
+        @calculators = Rails.application.config.spree.calculators.promotion_actions_create_adjustments
+        @promotion_categories = Spree::PromotionCategory.order(:name)
+      end
+
+      def fetch_actions
+        return @object.class::ACTIONS if member_action?
+
+        Rails.application.config.spree.promotions.actions
+      end
+    end
+  end
+end
+
+Spree::Admin::PromotionsController.prepend(Spree::Admin::PromotionsControllerDecorator)

--- a/app/helpers/spree_cm_commissioner/admin/promotion_rules_helper_decorator.rb
+++ b/app/helpers/spree_cm_commissioner/admin/promotion_rules_helper_decorator.rb
@@ -1,0 +1,15 @@
+module SpreeCmCommissioner
+  module Admin
+    module PromotionRulesHelperDecorator
+      def options_for_promotion_rule_types(promotion)
+        existing = promotion.rules.map { |rule| rule.class.name }
+        rule_names = promotion.class::RULES.map(&:name).reject { |r| existing.include? r }
+
+        options = rule_names.map { |name| [Spree.t("promotion_rule_types.#{name.demodulize.underscore}.name"), name] }
+        options_for_select(options)
+      end
+    end
+  end
+end
+
+Spree::Admin::PromotionRulesHelper.prepend(SpreeCmCommissioner::Admin::PromotionRulesHelperDecorator)

--- a/app/models/spree_cm_commissioner/pricing_model.rb
+++ b/app/models/spree_cm_commissioner/pricing_model.rb
@@ -1,5 +1,8 @@
 module SpreeCmCommissioner
   class PricingModel < Spree::Promotion
+    RULES = Rails.application.config.spree.promotions.rules.select { |r| r.name.start_with?('SpreeCmCommissioner::PricingModel::Rules::') }
+    ACTIONS = Rails.application.config.spree.promotions.actions.select { |a| a.name.start_with?('SpreeCmCommissioner::PricingModel::Actions::') }
+
     has_many :rules, autosave: true, foreign_key: :promotion_id, class_name: 'SpreeCmCommissioner::PricingModelRule', dependent: :destroy
     has_many :actions, autosave: true, foreign_key: :promotion_id, class_name: 'SpreeCmCommissioner::PricingModelAction', dependent: :destroy
 

--- a/app/models/spree_cm_commissioner/pricing_model/actions/create_listing_price_adjustment.rb
+++ b/app/models/spree_cm_commissioner/pricing_model/actions/create_listing_price_adjustment.rb
@@ -7,7 +7,7 @@ module SpreeCmCommissioner
 
         has_many :adjustments, as: :source, class_name: 'Spree::Adjustment'
 
-        before_validation -> { self.calculator ||= Calculator::FlatPercentItemTotal.new }
+        before_validation -> { self.calculator ||= Spree::Calculator::FlatPercentItemTotal.new }
 
         def perform(options = {})
           adjustable = options[:adjustable]

--- a/app/models/spree_cm_commissioner/promotion_decorator.rb
+++ b/app/models/spree_cm_commissioner/promotion_decorator.rb
@@ -1,0 +1,16 @@
+module SpreeCmCommissioner
+  module PromotionDecorator
+    def self.prepended(base)
+      Rails.application.config.after_initialize do
+        const_set(:RULES, Rails.application.config.spree.promotions.rules.select { |r| r.name.start_with?('Spree::Promotion::Rules::') })
+        const_set(:ACTIONS, Rails.application.config.spree.promotions.actions.select { |a| a.name.start_with?('Spree::Promotion::Actions::') })
+      end
+
+      base.whitelisted_ransackable_attributes = %w[type path promotion_category_id code]
+    end
+  end
+end
+
+unless Spree::Promotion.included_modules.include?(SpreeCmCommissioner::PromotionDecorator)
+  Spree::Promotion.prepend(SpreeCmCommissioner::PromotionDecorator)
+end

--- a/app/overrides/spree/admin/promotions/_form/type.html.erb.deface
+++ b/app/overrides/spree/admin/promotions/_form/type.html.erb.deface
@@ -1,0 +1,9 @@
+<!-- insert_after "erb[loud]:contains('field_container :path')" -->
+
+<%= f.field_container :type, :class => ['form-group'] do %>
+  <%= f.label :type, Spree.t(:type) %><br />
+  <%= f.collection_select :type, ['Spree::Promotion', 'SpreeCmCommissioner::PricingModel'], :to_s, :demodulize,
+    {:include_blank => true},
+    {:class => 'select2 fullwidth', :disabled => @object.type.present?, :required => true }.compact
+  %>
+<% end %>

--- a/app/overrides/spree/admin/promotions/index/page_tabs.html.erb.deface
+++ b/app/overrides/spree/admin/promotions/index/page_tabs.html.erb.deface
@@ -1,0 +1,14 @@
+<!-- insert_before "erb[silent]:contains('content_for :table_filter')" -->
+
+<% content_for :page_tabs do %>
+  <li class="nav-item">
+    <%= link_to Spree.t(:promotions),
+                params.merge({q: {type_eq: 'Spree::Promotion'}}).permit!,
+                class: "nav-link #{'active' if params[:q][:type_eq] == 'Spree::Promotion' }" %>
+  </li>
+  <li class="nav-item">
+    <%= link_to Spree.t(:pricing_model),
+                params.merge({q: {type_eq: 'SpreeCmCommissioner::PricingModel'}}).permit!,
+                class: "nav-link #{'active' if params[:q][:type_eq] == 'SpreeCmCommissioner::PricingModel' }" %>
+  </li>
+<% end  %>

--- a/app/views/spree/admin/promotions/actions/_create_listing_price_adjustment.html.erb
+++ b/app/views/spree/admin/promotions/actions/_create_listing_price_adjustment.html.erb
@@ -1,0 +1,30 @@
+<div class="card-body calculator-fields">
+  <div class="row mb-0">
+    <div class="form-group col-12 col-md-6 mb-0">
+      <% field_name = "#{param_prefix}[calculator_type]" %>
+      <%= label_tag field_name, Spree.t(:calculator) %>
+      <%= select_tag field_name,
+                     options_from_collection_for_select(@calculators, :to_s, :description, promotion_action.calculator.type),
+                     class: 'type-select select2' %>
+    </div>
+    <% unless promotion_action.new_record? %>
+      <div class="form-group col-12 col-md-6 mb-0 settings">
+        <% type_name = promotion_action.calculator.type.demodulize.underscore %>
+        <% if lookup_context.exists?("fields",
+            ["spree/admin/promotions/calculators/#{type_name}"], true) %>
+          <%= render "spree/admin/promotions/calculators/#{type_name}/fields",
+            calculator: promotion_action.calculator, prefix: param_prefix %>
+        <% else %>
+          <%= render "spree/admin/promotions/calculators/default_fields",
+            calculator: promotion_action.calculator, prefix: param_prefix %>
+        <% end %>
+        <%= hidden_field_tag "#{param_prefix}[calculator_attributes][id]", promotion_action.calculator.id %>
+      </div>
+    <% end %>
+  </div>
+  <% if promotion_action.calculator.respond_to?(:preferences) %>
+    <div class="alert alert-info js-warning mt-3 mb-0">
+      <%= Spree.t(:calculator_settings_warning) %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/spree/admin/promotions/rules/_fixed_date.html.erb
+++ b/app/views/spree/admin/promotions/rules/_fixed_date.html.erb
@@ -1,0 +1,17 @@
+<div class="card-body">
+  <div class="form-group">
+    <%= label_tag Spree.t(:vendor) %>
+    <%= select_tag("#{param_prefix}[vendor_id]", options_from_collection_for_select(Spree::Vendor.active, :id, :name, promotion_rule.vendor_id), { class: 'form-control custom-select' }) %>
+  </div>
+  <div class="form-row">
+    <div class="form-group col-md-6">
+      <%= label_tag Spree.t(:date) %>
+      <%= date_field_tag "#{param_prefix}[preferred_start_date]", promotion_rule.preferred_start_date, class: 'form-control' %>
+    </div>
+    <div class="form-group col-md-6">
+      <%= label_tag Spree.t(:length) %>
+      <%= number_field_tag "#{param_prefix}[preferred_length]", promotion_rule.preferred_length, class: 'form-control' %>
+    </div>
+    <%= select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(SpreeCmCommissioner::PricingModel::Rules::FixedDate::MATCH_POLICIES.map{|s| [Spree.t("fixed_date_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), {class: 'form-control custom-select'}) %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,3 +63,16 @@ en:
     reason_description:
       sth_broken: "Can you please share us what was not working? We will fix them as soon as possible as we spot them"
       other: "Can you please share us your account deletion reason. If something slipped through our fingers, we'd be so grateful to be aware and fix it."
+
+  spree:
+    length: "Length"
+    promotion_rule_types:
+      fixed_date:
+        name: "Fixed Date"
+        description: "Fixed Date"
+    promotion_action_types:
+      create_listing_price_adjustment:
+        name: "Create listing price adjustment"
+    fixed_date_rule:
+      match_any: "Any of these date"
+      match_none: "None of these date"

--- a/lib/spree_cm_commissioner/engine.rb
+++ b/lib/spree_cm_commissioner/engine.rb
@@ -13,6 +13,16 @@ module SpreeCmCommissioner
       Config = Configuration.new
     end
 
+    config.after_initialize do
+      Rails.application.config.spree.promotions.rules.concat [
+        SpreeCmCommissioner::PricingModel::Rules::FixedDate
+      ]
+
+      Rails.application.config.spree.promotions.actions.concat [
+        SpreeCmCommissioner::PricingModel::Actions::CreateListingPriceAdjustment
+      ]
+    end
+
     def self.activate
       Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*_decorator*.rb')) do |c|
         Rails.configuration.cache_classes ? require(c) : load(c)


### PR DESCRIPTION
| |
| - |
| 1. Add type filter to index |
| <img width="1440" alt="image" src="https://user-images.githubusercontent.com/29684683/226327687-36363e27-dc25-49ce-8443-a1164fb8027b.png"> |
| 2. Add type field to new/edit (disable if already have) |
| <img width="1440" alt="image" src="https://user-images.githubusercontent.com/29684683/226327717-1d82bbba-63bb-41e7-91ed-6706ca8971d8.png"> |
| 3. Add fixed rule UI & listing price adjustment action UI |
| <img width="1440" alt="image" src="https://user-images.githubusercontent.com/29684683/226328499-c912c98f-8d69-415f-8b38-668a64941d44.png"> |
