### PR TITLE
close #278 add merchant payment view

### DIFF
--- a/app/controllers/concerns/spree/admin/merchant/payment_creatable.rb
+++ b/app/controllers/concerns/spree/admin/merchant/payment_creatable.rb
@@ -1,0 +1,66 @@
+# Extracted from
+# Spree::Admin::PaymentsController#create
+module Spree
+  module Admin
+    module Merchant
+      module PaymentCreatable
+        def create
+          invoke_callbacks(:create, :before)
+          begin
+            load_payments
+            create_payment
+          rescue Spree::Core::GatewayError => e
+            invoke_callbacks(:create, :fails)
+            flash[:error] = e.message.to_s
+            redirect_to new_admin_merchant_order_payment_path(@order)
+          end
+        end
+
+        private
+
+        def create_payment
+          if @payments && (saved_payments = @payments.select(&:persisted?)).any?
+            invoke_callbacks(:create, :after)
+
+            # Transition order as far as it will go.
+            while @order.next; end
+            # If "@order.next" didn't trigger payment processing already (e.g. if the order was
+            # already complete) then trigger it manually now
+
+            saved_payments.each { |payment| payment.process! if payment.reload.checkout? && @order.complete? }
+            flash[:success] = flash_message_for(saved_payments.first, :successfully_created)
+            redirect_to spree.admin_merchant_order_payments_path(@order)
+          else
+            @payment ||= @order.payments.build(object_params)
+            invoke_callbacks(:create, :fails)
+            flash[:error] = Spree.t(:payment_could_not_be_created)
+            render :new, status: :unprocessable_entity
+          end
+        end
+
+        def load_payments
+          if @payment_method.store_credit?
+            Spree::Dependencies.checkout_add_store_credit_service.constantize.call(order: @order)
+            @payments = @order.payments.store_credits.valid
+          else
+            @payment.attributes = object_params
+            if @payment.payment_method.source_required? && params[:card].present? && params[:card] != 'new'
+              @payment.source = @payment.payment_method.payment_source_class.find_by(id: params[:card])
+            end
+            @payment.save!
+            @payments = [@payment]
+          end
+        end
+
+        def object_params
+          if params[:payment] && params[:payment_source]
+            source_params = params.delete(:payment_source)[params[:payment][:payment_method_id]]
+            params[:payment][:source_attributes] = source_params
+          end
+
+          params.require(:payment).permit(permitted_payment_attributes)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/spree/admin/merchant/payment_fireable.rb
+++ b/app/controllers/concerns/spree/admin/merchant/payment_fireable.rb
@@ -1,0 +1,37 @@
+# Extracted from
+# Spree::Admin::PaymentsController#fire
+module Spree
+  module Admin
+    module Merchant
+      module PaymentFireable
+        def fire
+          fire_action
+        rescue Spree::Core::GatewayError => e
+          flash[:error] = e.message.to_s
+        ensure
+          redirect_to spree.admin_merchant_order_payments_path(@order)
+        end
+
+        def fire_action
+          return unless @payment.payment_source
+
+          event = params[:e]
+          event = 'void_transaction' if event == 'void'
+          event = supported_events.find { |e| e == event } # safe send()
+
+          raise Spree::Core::GatewayError, Spree.t(:upsupported_payment) if event.blank?
+
+          if @payment.send("#{event}!")
+            flash[:success] = Spree.t(:payment_updated)
+          else
+            flash[:error] = Spree.t(:cannot_perform_operation)
+          end
+        end
+
+        def supported_events
+          %w[void_transaction cancel credit capture]
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/spree/admin/merchant/payments_controller.rb
+++ b/app/controllers/spree/admin/merchant/payments_controller.rb
@@ -3,6 +3,22 @@ module Spree
     module Merchant
       class PaymentsController < Spree::Admin::Merchant::BaseController
         include Spree::Admin::Merchant::OrderParentsConcern
+        include Spree::Admin::Merchant::PaymentCreatable
+        include Spree::Admin::Merchant::PaymentFireable
+
+        before_action :load_data
+
+        def load_data
+          @amount = params[:amount] || @order.total
+          @payment_methods = @order.collect_backend_payment_methods
+
+          if @payment&.payment_method
+            @payment_method = @payment.payment_method
+          else
+            @payment_method = @payment_methods.find { |p| p.id == params[:payment][:payment_method_id].to_i } if params[:payment]
+            @payment_method ||= @payment_methods.first
+          end
+        end
 
         # @overrided
 

--- a/app/controllers/spree/admin/merchant/refunds_controller.rb
+++ b/app/controllers/spree/admin/merchant/refunds_controller.rb
@@ -1,0 +1,11 @@
+module Spree
+  module Admin
+    module Merchant
+      class RefundsController < Spree::Admin::RefundsController
+        def location_after_save
+          admin_merchant_order_payments_path(@payment.order)
+        end
+      end
+    end
+  end
+end

--- a/app/interactors/spree_cm_commissioner/subscribed_order_creator.rb
+++ b/app/interactors/spree_cm_commissioner/subscribed_order_creator.rb
@@ -5,12 +5,13 @@ module SpreeCmCommissioner
     def call
       create_order
       create_line_item
+
+      context.order.create_default_payment_if_eligble
       context.order.reload
     end
 
     def create_order
-      context.order = Spree::Order.create!(
-        state: :payment,
+      context.order = subscription.orders.create!(
         subscription_id: subscription.id,
         phone_number: subscription.customer.phone_number,
         user_id: subscription.customer.user_id

--- a/app/models/spree_cm_commissioner/order_decorator.rb
+++ b/app/models/spree_cm_commissioner/order_decorator.rb
@@ -24,6 +24,22 @@ module SpreeCmCommissioner
       line_items.select { |item| item.ecommerce? && !item.digital? }.size.positive?
     end
 
+    # assume check is default payment method for subscription
+    def create_default_payment_if_eligble
+      return unless subscription?
+
+      default_payment_method = Spree::PaymentMethod::Check.available_on_back_end.first_or_create! do |method|
+        method.name ||= 'Invoice'
+        method.stores = [Spree::Store.default] if method.stores.empty?
+      end
+
+      payments.create!(payment_method: default_payment_method, amount: order_total_after_store_credit)
+    end
+
+    def subscription?
+      subscription.present?
+    end
+
     private
 
     def link_by_phone_number

--- a/app/views/spree/admin/merchant/payments/_list.html.erb
+++ b/app/views/spree/admin/merchant/payments/_list.html.erb
@@ -1,0 +1,42 @@
+<div class="table-responsive border rounded bg-white">
+  <table class="table border rounded" id='payments' data-order-id='<%= @order.number %>'>
+    <thead class="text-muted">
+      <tr data-hook="payments_header">
+        <th><%= Spree::Payment.human_attribute_name(:number) %></th>
+        <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
+        <th class="text-center"><%= Spree.t(:amount) %></th>
+        <th class="text-center"><%= Spree.t(:payment_method) %></th>
+        <th class="text-center"><%= Spree.t(:transaction_id) %></th>
+        <th class="text-center"><%= Spree.t(:payment_state) %></th>
+        <th class="actions text-center"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% payments.each do |payment| %>
+        <tr id="<%= dom_id(payment) %>" data-hook="payments_row" data-number="<%= payment.number %>" data-id="<%= payment.id %>">
+          <td><%= link_to payment.number, spree.admin_merchant_order_payment_path(@order, payment) %></td>
+          <td><%= pretty_time(payment.created_at) %></td>
+          <td class="amount text-center"><%= payment.display_amount %></td>
+          <td class="text-center"><%= payment_method_name(payment) %></td>
+          <td class="text-center"><%= payment.transaction_id %></td>
+          <td class="text-center">
+            <span class="badge badge-pill badge-<%= payment.state %>">
+              <%= Spree.t(payment.state, scope: :payment_states, default: payment.state.capitalize) %>
+            </span>
+          </td>
+          <td class="actions">
+            <span class="d-flex justify-content-center payment-action-buttons">
+              <% payment.actions.each do |action| %>
+                <% if action == 'credit' %>
+                  <%= link_to_with_icon('exit.svg', Spree.t(:refund), new_admin_merchant_order_payment_refund_path(@order, payment), no_text: true, class: "btn btn-light btn-sm") if can?(:create, Spree::Refund) %>
+                <% else %>
+                  <%= link_to_with_icon(action + '.svg', Spree.t(action), fire_admin_merchant_order_payment_path(@order, payment, e: action), method: :put, no_text: true, data: { action: action }, class: "btn btn-light btn-sm") if can?(action.to_sym, payment) %>
+                <% end %>
+              <% end %>
+            </span>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/spree/admin/merchant/payments/index.html.erb
+++ b/app/views/spree/admin/merchant/payments/index.html.erb
@@ -16,7 +16,7 @@
 
 <% if @payments.any? %>
   <div data-hook="payment_list" class="mb-3 table-responsive">
-    <%= render partial: 'spree/admin/payments/list', locals: { payments: @payments } %>
+    <%= render partial: 'list', locals: { payments: @payments } %>
   </div>
 
   <% if @refunds.any? %>

--- a/app/views/spree/admin/merchant/payments/new.html.erb
+++ b/app/views/spree/admin/merchant/payments/new.html.erb
@@ -1,0 +1,24 @@
+<%= render partial: 'spree/admin/merchant/shared/order_tabs', locals: { current: :payments } %>
+
+<% if @payment_methods.any? %>
+  <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @payment } %>
+
+  <%= form_for @payment, url: admin_merchant_order_payments_path(@order) do |f| %>
+    <fieldset>
+      <%= render partial: 'spree/admin/payments/form', locals: { f: f } %>
+
+      <div class="form-actions" data-hook="buttons">
+        <%= button @order.cart? ? Spree.t('actions.continue') : Spree.t('actions.update'), @order.cart? ? 'arrow-right.svg' : 'save.svg' %>
+      </div>
+    </fieldset>
+  <% end %>
+
+<% else %>
+  <div class="text-center m-5">
+    <%= Spree.t(:cannot_create_payment_without_payment_methods) %>
+    <br />
+    <%= link_to Spree.t(:please_define_payment_methods), spree.admin_payment_methods_url %>
+  </div>
+<% end %>
+
+<%= render partial: 'spree/admin/shared/order_summary' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,18 +18,6 @@ en:
     incorrect_password: "Incorrect password"
     invalid_or_missing_params: "Invalid or missing params"
 
-  sms:
-    to:
-      blank: "recipient can not be blank"
-    body:
-      blank: "sms content can not be blank"
-
-      already_exist: '%{login} already exist'
-  authenticator:
-    incorrect_login: 'Incorrect login'
-    incorrect_password: 'Incorrect password'
-    invalid_or_missing_params: 'Invalid or missing params'
-
   hello: 'Hello world'
 
   category_icon:
@@ -94,16 +82,6 @@ en:
       operations_day: 'Operations day'
       exception_rules: 'Exception Rules'
 
-    service_calendars:
-      empty_info: "No <b>Service calendars</b> found."
-      start_date: "Start date"
-      end_date: "End date"
-      from_date: "From date"
-      to_date: "To date"
-      new_calendar: "New Service calendar"
-      operations_day: "Operations day"
-      exception_rules: "Exception Rules"
-
   account_deletion:
     title:
       have_another_account: 'I have another account'
@@ -134,6 +112,9 @@ en:
         roles: "Role"
         subscriptions: "Subscription"
         users: "User"
+      match_any: 'Any of these date'
+      match_none: 'None of these date'
+    upsupported_payment: 'Unsupported event'
 
   activerecord:
     attributes:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,13 @@ Spree::Core::Engine.add_routes do
         resources :users
         resources :orders do
           resource :invoice, only: %i[show create], controller: :invoice
-          resources :payments
+          resources :payments do
+            member do
+              put :fire
+            end
+
+            resources :refunds, only: %i[new create edit update]
+          end
         end
       end
 

--- a/lib/spree_cm_commissioner/test_helper/factories/customer_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/customer_factory.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :cm_customer, class: SpreeCmCommissioner::Customer do
+    vendor
+
+    phone_number { '0962200288' }
+    user { create(:user) }
+  end
+end

--- a/lib/spree_cm_commissioner/test_helper/factories/product_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/product_factory.rb
@@ -36,5 +36,19 @@ FactoryBot.define do
         product.reload
       end
     end
+
+    factory :cm_subscribable_product do
+      option_types { [Spree::OptionType.where(name: "month", attr_type: :integer, presentation: "Month").first_or_create!] }
+
+      before(:create) do |product|
+        product.subscribable = true
+
+        option_value = create(:option_value, name: "6 months", presentation: "6", option_type: product.option_types[0])
+        variant = create(:variant, option_values: [option_value])
+        variant.stock_items.first.adjust_count_on_hand(10)
+
+        product.variants << variant
+      end
+    end
   end
 end

--- a/lib/spree_cm_commissioner/test_helper/factories/subscription_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/subscription_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :cm_subscription, class: SpreeCmCommissioner::Subscription do
+    start_date { '2022-12-25'.to_date }
+    customer { create(:cm_customer) }
+    variant {|s| create(:cm_subscribable_product, vendor: s.customer.vendor).variants.last }
+  end
+end

--- a/spec/interactors/spree_cm_commissioner/subscribed_order_creator_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/subscribed_order_creator_spec.rb
@@ -28,5 +28,16 @@ RSpec.describe SpreeCmCommissioner::SubscribedOrderCreator do
       expect(context.order.user_id).to eq customer.user_id
       expect(context.order.id).to eq subscription.orders.first.id
     end
+
+    it 'created a default payment' do
+      customer = create(:cm_customer)
+      subscription = create(:cm_subscription, customer: customer)
+
+      context = described_class.call(subscription: subscription)
+
+      expect(context.order.payments.size).to eq 1
+      expect(context.order.payments[0].amount).to eq context.order.order_total_after_store_credit
+      expect(context.order.payments[0].state).to eq 'checkout'
+    end
   end
-end 
+end


### PR DESCRIPTION
## Scope
- Add payment flow UI (List & Create & Fire)
- Create default payment when order is created, so admin only needs to click `capture`

| |
| - |
| ![image](https://user-images.githubusercontent.com/29684683/228228622-586cedb7-e29b-49fe-8c95-afd17970ceb6.png) |
| ![image](https://user-images.githubusercontent.com/29684683/228228657-2a0df71e-3893-4382-94e8-8262824da237.png) |
