### PR TITLE
close #308 use libraries via npm package instead of gem

### DIFF
--- a/app/assets/javascripts/spree_cm_commissioner/backend.js
+++ b/app/assets/javascripts/spree_cm_commissioner/backend.js
@@ -1,7 +1,4 @@
-//= require popper
-//= require bootstrap-sprockets
 //= require map/map-control-button
 //= require map/map-picker
 //= require spree_cm_commissioner/calendar
-//= require spree_cm_commissioner/popover
 //= require spree_cm_commissioner/role_form

--- a/lib/generators/spree_cm_commissioner/install/install_generator.rb
+++ b/lib/generators/spree_cm_commissioner/install/install_generator.rb
@@ -3,6 +3,7 @@ module SpreeCmCommissioner
     class InstallGenerator < Rails::Generators::Base
       class_option :migrate, type: :boolean, default: true
       source_root File.expand_path('../../../../spree/templates', __dir__)
+      source_root File.expand_path('templates', __dir__)
 
       def add_migrations
         gems = %i[
@@ -32,6 +33,11 @@ module SpreeCmCommissioner
 
         inject_into_file 'vendor/assets/javascripts/spree/backend/all.js', "\n//= require spree_cm_commissioner/backend",
                          after: %r{//= require spree/backend}, verbose: true
+
+        # For NPM support
+        template 'app/javascript/spree_cm_commissioner/utilities.js'
+        inject_into_file 'app/javascript/spree-dashboard.js', "\nimport \"./spree_cm_commissioner/utilities.js\"",
+                         after: %r{import "@spree/dashboard"}, verbose: true
       end
     end
   end

--- a/lib/generators/spree_cm_commissioner/install/templates/app/javascript/spree_cm_commissioner/utilities.js
+++ b/lib/generators/spree_cm_commissioner/install/templates/app/javascript/spree_cm_commissioner/utilities.js
@@ -1,3 +1,8 @@
+import jquery from "jquery";
+import "bootstrap/js/dist/popover.js";
+
+const $ = jquery;
+
 document.addEventListener("spree:load", function () {
   $('[data-toggle="popover"]').popover();
 });

--- a/spec/interactors/spree_cm_commissioner/subscribed_order_creator_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/subscribed_order_creator_spec.rb
@@ -1,36 +1,22 @@
 require 'spec_helper'
 
 RSpec.describe SpreeCmCommissioner::SubscribedOrderCreator do
+  let(:customer) { create(:cm_customer) }
+
   describe ".call" do
-    it "return 1 as subscription's order" do
-      user = create(:user)
-      option_type = create(:option_type, name: "month", attr_type: :integer)
-      option_value = create(:option_value, name: "6 months", presentation: "6", option_type: option_type)
-
-      vendor = create(:vendor)
-
-      product = create(:base_product, option_types: [option_type], subscribable: true, vendor: vendor)
-      variant = create(:base_variant, option_values: [option_value], price: 30, product: product)
-      variant.stock_items.first.adjust_count_on_hand(10)
-
-      customer = SpreeCmCommissioner::Customer.new(vendor: vendor, phone_number: "0962200288", user: user)
-
-      SpreeCmCommissioner::Subscription.skip_callback(:create, :after, :create_order)
-      subscription = SpreeCmCommissioner::Subscription.create(variant: variant, start_date: '2022-03-24', customer: customer)
-
+    it "return a newly created order" do
+      subscription = create(:cm_subscription, start_date: '2023-01-02'.to_date, customer: customer, price: 13.0, month: 1)
       context = described_class.call(subscription: subscription)
 
-
+      expect(subscription.orders.size).to eq 2
       expect(context.order.subscription_id).to eq subscription.id
-      expect(context.order.line_items.first.from_date).to eq subscription.start_date
-      expect(context.order.line_items.first.to_date).to eq subscription.start_date + 6.months
-      expect(context.order.total).to eq variant.price
+      expect(context.order.line_items[0].from_date).to eq subscription.start_date + 1.months
+      expect(context.order.line_items[0].to_date).to eq subscription.start_date + 2.months
+      expect(context.order.total).to eq subscription.variant.price
       expect(context.order.user_id).to eq customer.user_id
-      expect(context.order.id).to eq subscription.orders.first.id
     end
 
     it 'created a default payment' do
-      customer = create(:cm_customer)
       subscription = create(:cm_subscription, customer: customer)
 
       context = described_class.call(subscription: subscription)


### PR DESCRIPTION
## a. Problem
We got some problems when importing libraries via gem which include duplicate import, conflict - some JS does not work, popover & dropdown also not work, etc.

## b. Solution
To solve this:
- We add needed libraries/code to our `utilities.js` & inject it to `spree-dashboard.js` instead.
- Then, run `yarn build` to build it.
- By default, it will be around 1.2mb after build, so don't forget to use --minify which keep around 500kb.
  In `package.json`:

  ```s
  "scripts": {
    "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --minify"
  }
  ```

This way, we can easily import any NPM packages.

----

1. Original template file: [spree-dashboard.js](https://github.com/spree/spree_backend/blob/main/lib/generators/spree/backend/install/templates/app/javascript/spree-dashboard.js):
```js
// Entry point for the build script in your package.json

import "./application" // Load the default rails Turbo setup from application.js
import "@spree/dashboard"

new SpreeDashboard.Dashboard()
```

2. After run generator: spree-dashboard.js:
```js
// Entry point for the build script in your package.json

import "./application" // Load the default rails Turbo setup from application.js
import "@spree/dashboard"
import "./spree_cm_commissioner/utilities.js"

new SpreeDashboard.Dashboard()
```

## Reference
- https://github.com/spree/spree_backend/pull/28
- On server: https://github.com/bookmebus/cm-market-server/pull/46/commits/9395f500df0216e27983ff6309e803c207ba9406