### PR TITLE
close #315 fix spec pass when run individually & but fails on all

### DIFF
--- a/spec/interactors/spree_cm_commissioner/subscribed_order_creator_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/subscribed_order_creator_spec.rb
@@ -1,36 +1,22 @@
 require 'spec_helper'
 
 RSpec.describe SpreeCmCommissioner::SubscribedOrderCreator do
+  let(:customer) { create(:cm_customer) }
+
   describe ".call" do
-    it "return 1 as subscription's order" do
-      user = create(:user)
-      option_type = create(:option_type, name: "month", attr_type: :integer)
-      option_value = create(:option_value, name: "6 months", presentation: "6", option_type: option_type)
-
-      vendor = create(:vendor)
-
-      product = create(:base_product, option_types: [option_type], subscribable: true, vendor: vendor)
-      variant = create(:base_variant, option_values: [option_value], price: 30, product: product)
-      variant.stock_items.first.adjust_count_on_hand(10)
-
-      customer = SpreeCmCommissioner::Customer.new(vendor: vendor, phone_number: "0962200288", user: user)
-
-      SpreeCmCommissioner::Subscription.skip_callback(:create, :after, :create_order)
-      subscription = SpreeCmCommissioner::Subscription.create(variant: variant, start_date: '2022-03-24', customer: customer)
-
+    it "return a newly created order" do
+      subscription = create(:cm_subscription, start_date: '2023-01-02'.to_date, customer: customer, price: 13.0, month: 1)
       context = described_class.call(subscription: subscription)
 
-
+      expect(subscription.orders.size).to eq 2
       expect(context.order.subscription_id).to eq subscription.id
-      expect(context.order.line_items.first.from_date).to eq subscription.start_date
-      expect(context.order.line_items.first.to_date).to eq subscription.start_date + 6.months
-      expect(context.order.total).to eq variant.price
+      expect(context.order.line_items[0].from_date).to eq subscription.start_date + 1.months
+      expect(context.order.line_items[0].to_date).to eq subscription.start_date + 2.months
+      expect(context.order.total).to eq subscription.variant.price
       expect(context.order.user_id).to eq customer.user_id
-      expect(context.order.id).to eq subscription.orders.first.id
     end
 
     it 'created a default payment' do
-      customer = create(:cm_customer)
       subscription = create(:cm_subscription, customer: customer)
 
       context = described_class.call(subscription: subscription)

--- a/spec/queries/spree_cm_commissioner/subscription_orders_query_spec.rb
+++ b/spec/queries/spree_cm_commissioner/subscription_orders_query_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SpreeCmCommissioner::SubscriptionOrdersQuery do
       subscription_feb4.orders.each {|o| o.payments.each{|p| p.capture! }}
 
       query = described_class.new(
-        current_date: '2023-04-21',
+        current_date: '2023-04-21'.to_date,
         vendor_id: customer.vendor.id,
         from_date: '2000-01-01',
         to_date: '2100-01-01',
@@ -37,7 +37,7 @@ RSpec.describe SpreeCmCommissioner::SubscriptionOrdersQuery do
       subscription.orders[2].payments.each{|p| p.void!} # march
 
       query = described_class.new(
-        current_date: '2023-04-21',
+        current_date: '2023-04-21'.to_date,
         vendor_id: customer.vendor.id,
         from_date: '2000-01-01',
         to_date: '2100-01-01',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,4 +16,8 @@ RSpec.configure do |config|
   config.include Helper
   config.include DoorkeeperAuthHelper
   config.extend Spree::TestingSupport::AuthorizationHelpers::Request, type: :request
+
+  # https://github.com/channainfo/commissioner/pull/316
+  config.order = :random
+  Kernel.srand config.seed
 end


### PR DESCRIPTION
## Problems
- Run spec fails on subscription-related - cause everyone to fails when create PR
- Spec passes when run individually
- But fails when running all specs

## Cause
This happen because we skip a call back during a spec & not set that callback back. It's `SpreeCmCommissioner::Subscription.skip_callback`. We can call this an ordering issue.

---

### How to track them? - from medium below.
In order to track this kind of problem & save some time, we use --bisect by rspec.

- Run the suite with a specified seed value, to verify that test order is a factor: `rspec --seed <seed>`
- Rerun the tests with the bisect option, to allow RSpec to identify the faulty specs: `rspec --seed <seed> --bisect`
- Once RSpec has narrowed the tests to a “minimal reproduction command”, run it and examine the passing tests to see what they are doing to break the failures that follow.

#### Example:
Step 1. Execute:
```
$ bundle exec rspec --seed 45093 --bisect
```

Result:
`The minimal reproduction command is:
  rspec './spec/interactors/spree_cm_commissioner/subscribed_order_creator_spec.rb[1:1:1]' './spec/interactors/spree_cm_commissioner/subscriptions_order_cron_executor_spec.rb[1:1:1,1:2:1,1:3:1,1:4:1]' './spec/queries/spree_cm_commissioner/subscription_orders_query_spec.rb[1:1:1,1:1:2]' './spec/queries/spree_cm_commissioner/subscription_revenue_overview_query_spec.rb[1:1:1,1:1:2,1:2:1]' --seed 45093`

Step 2. Once we know how to reproduce, its orders & files, we check each file to find the cause & fix them. Like we fix in our problem above.

## Reference
- https://medium.com/skills-matter/find-the-cause-of-randomly-failing-tests-with-rspec-bisect-dfe9ee2a70c2