### PR TITLE
Close #395 customer notification sender

### DIFF
--- a/app/interactors/spree_cm_commissioner/customer_notification_sender.rb
+++ b/app/interactors/spree_cm_commissioner/customer_notification_sender.rb
@@ -1,0 +1,48 @@
+module SpreeCmCommissioner
+  class CustomerNotificationSender < BaseInteractor
+    delegate :customer_notification, to: :context
+
+    def call
+      update_customer_notification_sent_at
+      send_notification
+    end
+
+    def update_customer_notification_sent_at
+      return if customer_notification.sent_at.present?
+
+      customer_notification.sent_at = Time.current
+      customer_notification.save
+    end
+
+    def send_notification
+      send_to_all_users
+    end
+
+    def send_to_all_users
+      users_not_recieved_notifications.find_each do |user|
+        deliver_notification_to_user(user)
+      end
+    end
+
+    def deliver_notification_to_user(user)
+      SpreeCmCommissioner::CustomerContentNotificationCreatorJob.perform_later(
+        user_id: user.id,
+        customer_notification_id: customer_notification.ida
+      )
+    end
+
+    def users_not_recieved_notifications
+      end_users.where(cm_notifications: { id: nil })
+    end
+
+    def end_users
+      Spree.user_class.end_users_push_notificable.joins(
+        "LEFT JOIN cm_notifications ON (
+          cm_notifications.recipient_id = spree_users.id
+          AND cm_notifications.notificable_type = 'SpreeCmCommissioner::CustomerNotification'
+          AND cm_notifications.notificable_id = #{customer_notification.id}
+        )"
+      )
+    end
+  end
+end

--- a/spec/interactors/spree_cm_commissioner/customer_notification_sender_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/customer_notification_sender_spec.rb
@@ -1,0 +1,111 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::CustomerNotificationSender do
+
+  describe '#update customer_notification_send_at' do
+    it 'does not update sent_at if customer_notification has already been sent' do
+      sent_at = Time.now - 1.day
+      customer_notification = create(:customer_notification, sent_at: sent_at)
+      alert = described_class.new(customer_notification: customer_notification)
+      alert.update_customer_notification_sent_at
+      expect(customer_notification.sent_at).to eq sent_at
+    end
+
+    it 'update sent_at if it is nil' do
+      customer_notification = create(:customer_notification, sent_at: nil)
+      alert = described_class.new(customer_notification: customer_notification)
+      alert.update_customer_notification_sent_at
+      customer_notification.reload
+      expect(customer_notification.sent_at).to_not eq nil
+    end
+  end
+
+  describe '#end_users' do
+    it 'return users that has at least one device token' do
+
+      user= create(:cm_user, device_tokens_count: 1)
+
+      customer_notification = create(:customer_notification)
+      alert = described_class.new(customer_notification: customer_notification)
+      users = alert.end_users
+
+      expect(users.size).to eq 1
+      expect(users.first.id).to eq user.id
+    end
+
+    it 'return users that either has or has not recieved notifications' do
+      user_1 = create(:cm_user, device_tokens_count: 1)
+      user_2 = create(:cm_user, device_tokens_count: 2)
+
+      customer_notification = create(:customer_notification)
+      alert = described_class.new(customer_notification: customer_notification)
+      users = alert.end_users
+
+      # pushed
+      notification = create(
+        :notification,
+        recipient: user_1,
+        notificable: customer_notification
+      )
+
+      expect(users.size).to eq 2
+
+      # user 1
+      expect(users.first.id).to eq user_1.id
+      expect(users.first.notifications.size).to eq 1
+      expect(users.first.notifications.first.id).to eq notification.id
+
+      # users 2
+      expect(users.last.id).to eq user_2.id
+      expect(users.last.notifications.first).to eq nil
+    end
+  end
+
+  describe '#users_not_recieved_notifications' do
+    it 'return user_2 that has not recieved notification yet' do
+      user_1 = create(:cm_user, device_tokens_count: 1)
+      user_2 = create(:cm_user, device_tokens_count: 2)
+
+      customer_notification = create(:customer_notification)
+      alert = described_class.new(customer_notification: customer_notification)
+      users = alert.users_not_recieved_notifications
+
+      # pushed
+      notification = create(
+        :notification,
+        recipient: user_1,
+        notificable: customer_notification
+      )
+
+      expect(users.size).to eq 1
+      expect(users.first.id).to eq user_2.id
+    end
+  end
+
+  describe '#send_to_all_users' do
+    it 'deliver notification to users' do
+      user_1 = create(:cm_user, device_tokens_count: 0)
+      user_2 = create(:cm_user, device_tokens_count: 2)
+      user_3 = create(:cm_user, device_tokens_count: 1)
+
+      customer_notification = create(:customer_notification)
+      alert = described_class.new(customer_notification: customer_notification)
+
+      expect(alert).to receive(:deliver_notification_to_user).with(user_2)
+      expect(alert).to receive(:deliver_notification_to_user).with(user_3)
+
+      alert.send_to_all_users
+    end
+  end
+
+  describe '#call' do
+    it 'sends notification and update record' do
+      customer_notification = create(:customer_notification)
+      alert = described_class.new(customer_notification: customer_notification)
+
+      expect(alert).to receive(:send_notification)
+      expect(alert).to receive(:update_customer_notification_sent_at)
+      alert.call
+    end
+  end
+end


### PR DESCRIPTION
Customer Notification Sender Interactor 
 - check and set sent_at datetime   
 - check if user have device tokens 
 - query users that  have not received notifications  
 - send notification to all users 
 