### PR TITLE
close #430 enhanced post-paid and pre-paid

### DIFF
--- a/app/models/spree_cm_commissioner/line_item_decorator.rb
+++ b/app/models/spree_cm_commissioner/line_item_decorator.rb
@@ -51,10 +51,24 @@ module SpreeCmCommissioner
       self.due_date = due_days
     end
 
+    def post_paid?
+      payment_option_type = order.subscription.variant.product.option_types.find_by(name: 'payment-option')
+      payment_option_value = order.subscription.variant.option_values.find_by(option_type_id: payment_option_type.id)
+      payment_option_value.name == 'post-paid'
+    end
+
     def due_days
       due_date_option_type = order.subscription.variant.product.option_types.find_by(name: 'due-date')
       due_date_option_value = order.subscription.variant.option_values.find_by(option_type_id: due_date_option_type.id)
+
       day = due_date_option_value.presentation.to_i
+
+      if post_paid?
+        month_option_type = order.subscription.variant.product.option_types.find_by(name: 'month')
+        month_option_value = order.subscription.variant.option_values.find_by(option_type_id: month_option_type.id)
+
+        return from_date + month_option_value.presentation.to_i.month + day.days
+      end
       from_date + day.days
     end
   end

--- a/lib/spree_cm_commissioner/test_helper/factories/option_type_factory .rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/option_type_factory .rb
@@ -13,6 +13,11 @@ FactoryBot.define do
       presentation { 'due-date' }
     end
 
+    trait :payment_option do
+      name { 'payment-option' }
+      presentation { 'payment-option' }
+    end
+
     initialize_with { Spree::OptionType.where(name: name).first_or_initialize }
   end
 end

--- a/lib/spree_cm_commissioner/test_helper/factories/product_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/product_factory.rb
@@ -36,12 +36,14 @@ FactoryBot.define do
     factory :cm_subscribable_product do
       option_types { [
         create(:cm_option_type, :month),
-        create(:cm_option_type, :due_date)
+        create(:cm_option_type, :due_date),
+        create(:cm_option_type, :payment_option)
       ] }
 
       transient do
         month { 6 }
         due_date { 5 }
+        payment_option { 'pre-paid' }
       end
 
       before(:create) do |product, _evaluator|
@@ -52,9 +54,10 @@ FactoryBot.define do
         # p product.option_types
         option_value1 = create(:cm_option_value, name: "#{evaluator.month}-months", presentation: evaluator.month.to_s, option_type: product.option_types[0])
         option_value2 = create(:cm_option_value, name: "#{evaluator.due_date} Days", presentation: evaluator.due_date.to_s, option_type: product.option_types[1])
+        option_value3 = create(:cm_option_value, name: "#{evaluator.payment_option}", presentation: evaluator.payment_option.to_s, option_type: product.option_types[2])
 
         variant = create(:variant, price: product.price, product: product)
-        variant.option_values = [option_value1, option_value2]
+        variant.option_values = [option_value1, option_value2, option_value3]
         variant.save!
 
         variant.stock_items.first.adjust_count_on_hand(10)

--- a/lib/spree_cm_commissioner/test_helper/factories/subscription_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/subscription_factory.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
       price { 10.0 }
       month { 1 }
       due_date { 5 }
+      payment_option { 'pre-paid' }
     end
 
     before :create do |subscription, evaluator|
@@ -16,6 +17,7 @@ FactoryBot.define do
         price: evaluator.price,
         month: evaluator.month,
         due_date: evaluator.due_date,
+        payment_option: evaluator.payment_option
       ).variants.last
     end
   end

--- a/spec/interactors/spree_cm_commissioner/subscribed_order_creator_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/subscribed_order_creator_spec.rb
@@ -43,5 +43,16 @@ RSpec.describe SpreeCmCommissioner::SubscribedOrderCreator do
       expect(subscription.last_occurence).to eq subscription.start_date + 1.months
       expect(subscription.orders[1].invoice.date).to eq subscription.last_occurence
     end
+
+    it 'create an order with the correct due date' do
+      subscription1 = create(:cm_subscription, customer: customer, start_date: '2023-01-02'.to_date, price: 13.0, month: 1)
+      subscription2 = create(:cm_subscription, customer: customer, start_date: '2023-01-02'.to_date, price: 13.0, month: 1, payment_option:'post-paid')
+      expect(subscription1.orders.last.line_items.last.due_date).to eq subscription1.orders.last.line_items.last.from_date + 5.days
+      expect(subscription2.orders.last.line_items.last.due_date.to_date).to eq Date.parse('2023-02-07')
+
+      context = described_class.call(subscription: subscription2)
+      expect(subscription2.orders.size).to eq 2
+      expect(subscription2.orders.last.line_items.last.due_date.to_date).to eq Date.parse('2023-03-07')
+    end
   end
 end

--- a/spec/interactors/spree_cm_commissioner/subscriptions_order_cron_executor_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/subscriptions_order_cron_executor_spec.rb
@@ -7,12 +7,14 @@ RSpec.describe SpreeCmCommissioner::SubscriptionsOrderCronExecutor do
   let(:option_value_month){create(:option_value, name: "1 month", presentation: "1", option_type: option_type_month)}
   let(:option_type_day) {create(:option_type, name: "due-date", attr_type: :integer)}
   let(:option_value_day){create(:option_value, name: "5 Days", presentation: "5", option_type: option_type_day)}
+  let(:option_type_payment) {create(:option_type, name: "payment-option", attr_type: :string)}
+  let(:option_value_payment){create(:option_value, name: "post-paid", presentation: "post-paid", option_type: option_type_payment)}
 
 
   let(:vendor) {create(:vendor)}
 
-  let(:product) { create(:base_product, option_types: [option_type_month,option_type_day], subscribable: true, vendor: vendor)}
-  let(:variant) { create(:base_variant, option_values: [option_value_month,option_value_day], price: 30, product: product)}
+  let(:product) { create(:base_product, option_types: [option_type_month,option_type_day,option_type_payment], subscribable: true, vendor: vendor)}
+  let(:variant) { create(:base_variant, option_values: [option_value_month,option_value_day,option_value_payment], price: 30, product: product)}
 
   before(:each) do
     variant.stock_items.first.adjust_count_on_hand(10)


### PR DESCRIPTION
- automatically add the month option value to due-date for the pre-paid variant
     Ex: start_date: '2023-01-01'
     variant(month: 1, due_date: 5, payment_option: 'pre-paid' ) => order_due_date = "2023-01-06"
     variant(month: 1, due_date: 5, payment_option: 'post-paid' ) => order_due_date = "2023-02-06"



<img width="1204" alt="image" src="https://github.com/channainfo/commissioner/assets/87005466/07be522f-01f5-40d3-a19c-83e87b49f79f">
