### PR TITLE
close #371 validate room quantity base on perminent stock & date

### DIFF
--- a/app/queries/spree_cm_commissioner/variant_quantity_availability_query.rb
+++ b/app/queries/spree_cm_commissioner/variant_quantity_availability_query.rb
@@ -1,0 +1,45 @@
+module SpreeCmCommissioner
+  class VariantQuantityAvailabilityQuery
+    attr_reader :variant_id, :from_date, :to_date
+
+    def initialize(variant_id, from_date, to_date)
+      @variant_id = variant_id
+      @from_date = from_date
+      @to_date = to_date
+    end
+
+    # {
+    #   '2023-06-23': { :variant_id => 1, :permanent_stock => 3, :available_quantity => 0 },
+    #   '2023-06-24': { :variant_id => 1, :permanent_stock => 3, :available_quantity => 2 },
+    # }
+    def booked_variants
+      Spree::LineItem
+        .joins(:order, :variant)
+        .select(
+          'spree_line_items.variant_id',
+          'spree_variants.permanent_stock',
+          '(spree_variants.permanent_stock - SUM(spree_line_items.quantity)) AS available_quantity',
+          'd.date AS reservation_date'
+        )
+        .joins("INNER JOIN (#{ActiveRecord::Base.sanitize_sql(date_list_sql)}) d ON d.date >= from_date AND d.date <= to_date")
+        .where('(from_date <= d.date AND d.date <= to_date)')
+        .where(order: { state: :complete })
+        .where(variant_id: variant_id)
+        .group(:variant_id, :permanent_stock, :reservation_date)
+        .order(:reservation_date)
+        .each_with_object({}) do |record, hash|
+        hash[record.reservation_date.to_date] = record.slice(
+          :variant_id,
+          :permanent_stock,
+          :available_quantity
+        ).symbolize_keys
+      end
+    end
+
+    private
+
+    def date_list_sql
+      "SELECT date FROM generate_series('#{from_date}'::date, '#{to_date}'::date, '1 day') AS date"
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -170,7 +170,10 @@ en:
         failed: "Failed"
         unknown: "Unknown"
     upsupported_payment: "Unsupported event"
-    selected_item_not_available_on_date: "Selected item not available on %{date}"
+    exceeded_available_quantity_on_date:
+      zero: "Rooms are not available on %{date}"
+      one: "Only 1 room available on %{date}"
+      other: "Only %{count} rooms available on %{date}"
     auto_apply: "Auto apply"
     auto_apply_info: "Path & code will be removed"
 

--- a/spec/models/spree/stock/availability_validator_spec.rb
+++ b/spec/models/spree/stock/availability_validator_spec.rb
@@ -1,97 +1,32 @@
 require 'spec_helper'
 
 RSpec.describe Spree::Stock::AvailabilityValidator do
-  context 'product type: accommodation' do
-    let(:product) { create(:cm_accommodation_product, permanent_stock: 3) }
-    let(:booked_date_from) { '2023-01-10'.to_date }
-    let(:booked_date_to) { '2023-01-12'.to_date  }
+  context 'reservation?' do
+    describe '#validate_reservation' do
+      let!(:product) { create(:cm_accommodation_product, permanent_stock: 3) }
 
-    let!(:booked_line_item) { create(:line_item, quantity: 1, product: product, from_date: booked_date_from, to_date: booked_date_to) }
+      context 'booked on 10th-12th: 0 left for 10th, 2 left for 11-12th' do
+        before(:each) do
+          reservation1 = build(:order, state: :complete)
+          reservation2 = build(:order, state: :complete)
 
-    describe '#validate' do
-      it 'valid when not either exceed_perminent_stock or any dates are booked' do
-        line_item = build(:line_item, quantity: 1, product: product, from_date: '2023-01-13'.to_date, to_date: '2023-01-15'.to_date)
-        described_class.new.validate(line_item)
+          create(:line_item, quantity: 1, order: reservation1, product: product, from_date: date('2023-01-10'), to_date: date('2023-01-11'))
+          create(:line_item, quantity: 2, order: reservation1, product: product, from_date: date('2023-01-12'), to_date: date('2023-01-13'))
+        end
 
-        expect(line_item.errors.size).to eq 0
-      end
+        it 'error when at least one day could not supply 2 quantity' do
+          line_item = build(:line_item, quantity: 2, product: product, from_date: '2023-01-11'.to_date, to_date: '2023-01-12'.to_date)
+          described_class.new.send(:validate, line_item)
 
-      it 'invalid when exceed_perminent_stock' do
-        line_item = build(:line_item, quantity: 4, product: product, from_date: '2023-01-13'.to_date, to_date: '2023-01-15'.to_date)
-        described_class.new.validate(line_item)
+          expect(line_item.errors.full_messages).to eq (["Quantity Only 1 room available on 2023-01-12"])
+        end
 
-        expect(line_item.errors.size).to eq 1
-        expect(line_item.errors.details).to eq ({ :quantity => [{ :error => :selected_quantity_not_available }] })
-      end
+        it 'success when all day is available for 2 quantity' do
+          line_item = build(:line_item, quantity: 2, product: product, from_date: '2023-01-10'.to_date, to_date: '2023-01-11'.to_date)
+          described_class.new.send(:validate, line_item)
 
-      it 'does not check with booked date if perminent_stock already exceed' do
-        line_item = build(:line_item, quantity: 4, product: product, from_date: '2023-01-12'.to_date, to_date: '2023-01-15'.to_date)
-        described_class.new.validate(line_item)
-
-        expect(line_item.errors.size).to eq 1
-        expect(line_item.errors.details).to eq ({ :quantity => [{ :error => :selected_quantity_not_available }] })
-      end
-
-      it 'invalid when any dates already booked' do
-        line_item = build(:line_item, quantity: 1, product: product, from_date: '2023-01-12'.to_date, to_date: '2023-01-15'.to_date)
-        described_class.new.validate(line_item)
-
-        expect(line_item.errors.size).to eq 1
-        expect(line_item.errors.full_messages).to eq (["Quantity Selected item not available on 2023-01-12"])
-      end
-    end
-
-    describe '#validate_perminent_stock' do
-      it 'valid when quantity < permanent_stock' do
-        line_item = build(:line_item, quantity: 2, product: product, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date)
-        valid = described_class.new.validate_perminent_stock(line_item)
-
-        expect(valid).to be true
-        expect(line_item.errors.size).to eq 0
-      end
-
-      it 'valid when quantity = permanent_stock' do
-        line_item = build(:line_item, quantity: 3, product: product, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date)
-        valid = described_class.new.validate_perminent_stock(line_item)
-
-        expect(valid).to be true
-        expect(line_item.errors.size).to eq 0
-      end
-
-      it 'invalid when quantity > permanent_stock' do
-        line_item = build(:line_item, quantity: 4, product: product, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date)
-        valid = described_class.new.validate_perminent_stock(line_item)
-
-        expect(valid).to be false
-
-        expect(line_item.errors.size).to eq 1
-        expect(line_item.errors.details).to eq ({ :quantity => [{ :error => :selected_quantity_not_available }] })
-      end
-    end
-
-    describe '#validate_with_booked_dates' do
-      it 'invalid when booking on serveral booked dates' do
-        line_item = build(:line_item, quantity: 1, product: product, from_date: '2023-01-11'.to_date, to_date: '2023-01-14'.to_date)
-        valid = described_class.new.validate_with_booked_dates(line_item)
-
-        expect(valid).to be false
-        expect(line_item.errors.full_messages).to eq (["Quantity Selected item not available on 2023-01-11", "Quantity Selected item not available on 2023-01-12"])
-      end
-
-      it 'invalid when booking on a booked date' do
-        line_item = build(:line_item, quantity: 1, product: product, from_date: '2023-01-12'.to_date, to_date: '2023-01-14'.to_date)
-        valid = described_class.new.validate_with_booked_dates(line_item)
-
-        expect(valid).to be false
-        expect(line_item.errors.full_messages).to eq (["Quantity Selected item not available on 2023-01-12"])
-      end
-
-      it 'valid when booking date not yet booked' do
-        line_item = build(:line_item, quantity: 1, product: product, from_date: '2023-01-13'.to_date, to_date: '2023-01-14'.to_date)
-        valid = described_class.new.validate_with_booked_dates(line_item)
-
-        expect(valid).to be true
-        expect(line_item.errors.size).to eq 0
+          expect(line_item.errors.size).to eq 0
+        end
       end
     end
   end

--- a/spec/queries/spree_cm_commissioner/variant_quantity_availability_query_spec.rb
+++ b/spec/queries/spree_cm_commissioner/variant_quantity_availability_query_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::VariantQuantityAvailabilityQuery do
+  describe '#booked_variants' do
+    let!(:product) { create(:cm_accommodation_product, permanent_stock: 3) }
+
+    context 'booked on 10th-12th: 0 left for 10th, 2 left for 11-12th' do
+      before(:each) do
+        reservation1 = build(:order, state: :complete)
+        reservation2 = build(:order, state: :complete)
+
+        create(:line_item, quantity: 2, order: reservation1, product: product, from_date: date('2023-01-10'), to_date: date('2023-01-10'))
+        create(:line_item, quantity: 1, order: reservation1, product: product, from_date: date('2023-01-10'), to_date: date('2023-01-12'))
+      end
+
+      it 'return 2 available_quantity on 11th when inputs 9-11th' do
+        subject = described_class.new(product.master.id, date('2023-01-09'), date('2023-01-11'))
+        result = subject.booked_variants
+
+        expect(result.size).to eq 2
+        expect(result.keys).to eq (date('2023-01-10')..date('2023-01-11')).to_a
+
+        expect(result[date('2023-01-10')]).to eq ({:variant_id => product.master.id, :permanent_stock => 3, :available_quantity => 0})
+        expect(result[date('2023-01-11')]).to eq ({:variant_id => product.master.id, :permanent_stock => 3, :available_quantity => 2})
+      end
+
+      it 'return 2 available_quantity on 11-12th when inputs 10-13th' do
+        subject = described_class.new(product.master.id, date('2023-01-10'), date('2023-01-13'))
+        result = subject.booked_variants
+
+        expect(result.size).to eq 3
+        expect(result.keys).to eq (date('2023-01-10')..date('2023-01-12')).to_a
+
+        expect(result[date('2023-01-10')]).to eq ({:variant_id => product.master.id, :permanent_stock => 3, :available_quantity => 0})
+        expect(result[date('2023-01-11')]).to eq ({:variant_id => product.master.id, :permanent_stock => 3, :available_quantity => 2})
+        expect(result[date('2023-01-12')]).to eq ({:variant_id => product.master.id, :permanent_stock => 3, :available_quantity => 2})
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Improve & decorate 'AvailabilityValidator' of Line Item. 
- This time, we take only completed order & line items
- Also, to check if room is suppliable, we go deeper by checking quantity of each date:
   In each date: `suppliable_quantity = variant.permanent_stock - booked_quantity`