### PR TITLE
close #467 enhance home data api

### DIFF
--- a/app/serializers/spree_cm_commissioner/v2/storefront/homepage_data_serializer.rb
+++ b/app/serializers/spree_cm_commissioner/v2/storefront/homepage_data_serializer.rb
@@ -8,7 +8,7 @@ module SpreeCmCommissioner
         has_many :homepage_banners, serializer: :homepage_banner
         has_many :featured_vendors, serializer: ::Spree::V2::Storefront::AccommodationSerializer
 
-        has_many :trending_categories, serializer: :category_taxon
+        # has_many :trending_categories, serializer: :category_taxon
         # has_many :top_categories, serializer: :category_taxon
         # has_many :display_products, serializer: :taxon_include_product
         # has_many :featured_brands, serializer: :brand_taxon

--- a/app/services/spree_cm_commissioner/homepage_data_loader.rb
+++ b/app/services/spree_cm_commissioner/homepage_data_loader.rb
@@ -37,7 +37,7 @@ module SpreeCmCommissioner
       set_homepage_banners
       set_featured_vendors
 
-      set_trending_categories
+      # set_trending_categories
       # set_top_catgories
       # set_display_products
       # set_featured_brands

--- a/spec/models/spree/stock/availability_validator_spec.rb
+++ b/spec/models/spree/stock/availability_validator_spec.rb
@@ -6,24 +6,26 @@ RSpec.describe Spree::Stock::AvailabilityValidator do
       let!(:product) { create(:cm_accommodation_product, permanent_stock: 3) }
 
       context 'booked on 10th-12th: 0 left for 10th, 2 left for 11-12th' do
-        before(:each) do
-          reservation1 = build(:order, state: :complete)
-          reservation2 = build(:order, state: :complete)
+        let(:reservation1) { build(:order, state: :complete) }
+        let(:reservation2) { build(:order, state: :complete) }
 
-          create(:line_item, quantity: 1, order: reservation1, product: product, from_date: date('2023-01-10'), to_date: date('2023-01-11'))
-          create(:line_item, quantity: 2, order: reservation1, product: product, from_date: date('2023-01-12'), to_date: date('2023-01-13'))
-        end
+        let!(:line_item1) { create(:line_item, quantity: 3, order: reservation1, product: product, from_date: date('2023-01-10'), to_date: date('2023-01-10')) }
+        let!(:line_item2) { create(:line_item, quantity: 1, order: reservation2, product: product, from_date: date('2023-01-11'), to_date: date('2023-01-12')) }
 
-        it 'error when at least one day could not supply 2 quantity' do
-          line_item = build(:line_item, quantity: 2, product: product, from_date: '2023-01-11'.to_date, to_date: '2023-01-12'.to_date)
-          described_class.new.send(:validate, line_item)
+        it 'error when at least one day could not supply 3 quantity' do
+          line_item = build(:line_item, quantity: 3, product: product, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date)
+          described_class.new.send(:validate_reservation, line_item)
 
-          expect(line_item.errors.full_messages).to eq (["Quantity Only 1 room available on 2023-01-12"])
+          expect(line_item.errors.full_messages).to eq ([
+            "Quantity Rooms are not available on 2023-01-10",
+            "Quantity Only 2 rooms available on 2023-01-11",
+            "Quantity Only 2 rooms available on 2023-01-12"
+          ])
         end
 
         it 'success when all day is available for 2 quantity' do
-          line_item = build(:line_item, quantity: 2, product: product, from_date: '2023-01-10'.to_date, to_date: '2023-01-11'.to_date)
-          described_class.new.send(:validate, line_item)
+          line_item = build(:line_item, quantity: 2, product: product, from_date: '2023-01-11'.to_date, to_date: '2023-01-12'.to_date)
+          described_class.new.send(:validate_reservation, line_item)
 
           expect(line_item.errors.size).to eq 0
         end

--- a/spec/queries/spree_cm_commissioner/variant_quantity_availability_query_spec.rb
+++ b/spec/queries/spree_cm_commissioner/variant_quantity_availability_query_spec.rb
@@ -5,13 +5,11 @@ RSpec.describe SpreeCmCommissioner::VariantQuantityAvailabilityQuery do
     let!(:product) { create(:cm_accommodation_product, permanent_stock: 3) }
 
     context 'booked on 10th-12th: 0 left for 10th, 2 left for 11-12th' do
-      before(:each) do
-        reservation1 = build(:order, state: :complete)
-        reservation2 = build(:order, state: :complete)
+      let(:reservation1) { build(:order, state: :complete) }
+      let(:reservation2) { build(:order, state: :complete) }
 
-        create(:line_item, quantity: 2, order: reservation1, product: product, from_date: date('2023-01-10'), to_date: date('2023-01-10'))
-        create(:line_item, quantity: 1, order: reservation1, product: product, from_date: date('2023-01-10'), to_date: date('2023-01-12'))
-      end
+      let!(:line_item1) { create(:line_item, quantity: 3, order: reservation1, product: product, from_date: date('2023-01-10'), to_date: date('2023-01-10')) }
+      let!(:line_item2) { create(:line_item, quantity: 1, order: reservation1, product: product, from_date: date('2023-01-11'), to_date: date('2023-01-12')) }
 
       it 'return 2 available_quantity on 11th when inputs 9-11th' do
         subject = described_class.new(product.master.id, date('2023-01-09'), date('2023-01-11'))

--- a/spec/serializers/spree_cm_commissioner/v2/storefront/homepage_data_serializer_spec.rb
+++ b/spec/serializers/spree_cm_commissioner/v2/storefront/homepage_data_serializer_spec.rb
@@ -2,27 +2,46 @@
 
 RSpec.describe SpreeCmCommissioner::V2::Storefront::HomepageDataSerializer, type: :serializer do
   describe '#serializable_hash' do
-    let(:background) {create(:cm_homepage_background)}
-    let!(:banner)  { create(:cm_homepage_banner) }
-    let!(:product) { create(:base_product) }
-    let!(:brand_taxon) { create(:taxon) }
-    let(:home_data_loader) { SpreeCmCommissioner::HomepageDataLoader.new }
-    
+    let!(:homepage_background) { create(:cm_homepage_background, :with_app_web_image) }
+    let!(:homepage_banner) { create(:cm_homepage_banner, :with_app_web_image) }
+    let(:home_data_loader) { SpreeCmCommissioner::HomepageDataLoader.new.call }
+
     subject {
-      described_class.new(home_data_loader).serializable_hash
+      described_class.new(home_data_loader, include: [
+        :homepage_backgrounds,
+        :homepage_banners,
+        :featured_vendors,
+      ]).serializable_hash
     }
-    
+
     it 'does not have attributes' do
       expect(subject[:data][:attributes]).to be nil
     end
-    
+
     it 'returns exact relationships' do
       expect(subject[:data][:relationships].keys).to contain_exactly(
         :homepage_backgrounds,
         :homepage_banners,
         :featured_vendors,
-        :trending_categories
       )
+    end
+
+    it 'returns [include] with homepage backgrounds' do
+      homepage_backgrounds = subject[:included].filter { |item| item[:type] == :homepage_background }
+
+      expect(homepage_backgrounds.size).to eq 1
+      expect(homepage_backgrounds[0][:type]).to eq :homepage_background
+      expect(homepage_backgrounds[0].keys).to contain_exactly(:id, :type, :attributes, :relationships)
+      expect(homepage_backgrounds[0][:relationships].keys).to contain_exactly(:app_image, :web_image)
+    end
+
+    it 'returns [include] with homepage banners' do
+      homepage_banners = subject[:included].filter { |item| item[:type] == :homepage_banner }
+
+      expect(homepage_banners.size).to eq 1
+      expect(homepage_banners[0][:type]).to eq :homepage_banner
+      expect(homepage_banners[0].keys).to contain_exactly(:id, :type, :attributes, :relationships)
+      expect(homepage_banners[0][:relationships].keys).to contain_exactly(:app_image, :web_image)
     end
   end
 end

--- a/spec/services/spree_cm_commissioner/homepage_data_loader_spec.rb
+++ b/spec/services/spree_cm_commissioner/homepage_data_loader_spec.rb
@@ -1,29 +1,30 @@
 require "spec_helper"
 
 RSpec.describe SpreeCmCommissioner::HomepageDataLoader do
-  before(:all) {
-    background = create(:cm_homepage_background, :with_app_web_image)
-    banner = create(:cm_homepage_banner, :with_app_web_image)
-    vendor = create(:vendor)
-    
-    config = SpreeCmCommissioner::Configuration.new
-    config[:featured_vendor_ids] = vendor.id.to_s
-  }
-  
+  let!(:background) { create(:cm_homepage_background, :with_app_web_image) }
+  let!(:banner) { create(:cm_homepage_banner, :with_app_web_image) }
+  let!(:vendor) { create(:vendor) }
+
   describe '.with_cache' do
+    subject {
+      config = SpreeCmCommissioner::Configuration.new
+      config[:featured_vendor_ids] = vendor.id.to_s
+
+      described_class.with_cache
+    }
+
     it 'returns instance of loaded HomepageDataLoader' do
-      result = described_class.with_cache
-      
-      expect(result).to be_a_kind_of(described_class)
-      
-      expect(result.featured_vendors).to be_a_kind_of(ActiveRecord::Relation)
-      expect(result.featured_vendors[0]).to be_a_kind_of(Spree::Vendor)
-      
-      expect(result.homepage_backgrounds).to be_a_kind_of(ActiveRecord::Relation)
-      expect(result.homepage_backgrounds[0]).to be_a_kind_of(SpreeCmCommissioner::HomepageBackground)
-      
-      expect(result.homepage_banners).to be_a_kind_of(ActiveRecord::Relation)
-      expect(result.homepage_banners[0]).to be_a_kind_of(SpreeCmCommissioner::HomepageBanner)
+
+      expect(subject).to be_a_kind_of(described_class)
+
+      expect(subject.featured_vendors).to be_a_kind_of(ActiveRecord::Relation)
+      expect(subject.featured_vendors[0]).to be_a_kind_of(Spree::Vendor)
+
+      expect(subject.homepage_backgrounds).to be_a_kind_of(ActiveRecord::Relation)
+      expect(subject.homepage_backgrounds[0]).to be_a_kind_of(SpreeCmCommissioner::HomepageBackground)
+
+      expect(subject.homepage_banners).to be_a_kind_of(ActiveRecord::Relation)
+      expect(subject.homepage_banners[0]).to be_a_kind_of(SpreeCmCommissioner::HomepageBanner)
     end
   end
 end


### PR DESCRIPTION
- [x] Cache ids instead of whole home data response as it take more memory and disk space
- [x] Fix home data wrong serializers
- [x] Remove trending_categories for now 
- [x] Fix some rspec ordering issue:
  - I just realize that in rspec, creating objects in `before(:all)` will remain in other specs which cause rspec error.
  - So, I migrate all `before(:all)..` that create objects to `let` instead. `let` are better in this case.