### PR TITLE
close #477 fix inconsistent checkin checkout date usage

### DIFF
--- a/app/models/concerns/spree_cm_commissioner/line_item_durationable.rb
+++ b/app/models/concerns/spree_cm_commissioner/line_item_durationable.rb
@@ -1,0 +1,41 @@
+module SpreeCmCommissioner
+  module LineItemDurationable
+    extend ActiveSupport::Concern
+
+    def date_present?
+      from_date.present? && to_date.present?
+    end
+
+    def amount_per_date_unit
+      amount / date_unit
+    end
+
+    def date_unit
+      return nil unless reservation?
+
+      return number_of_nights if accommodation?
+    end
+
+    # Example:
+    # 24-10-2023 -> 25-10-2023 = 1 night
+    def number_of_nights
+      return nil unless date_present?
+
+      (to_date.to_date - from_date.to_date)
+    end
+
+    # Example:
+    # 24-10-2023 -> 25-10-2023 = 2 days
+    def number_of_days
+      return nil unless date_present?
+
+      (to_date.to_date - from_date.to_date) + 1
+    end
+
+    def date_range
+      return [] unless date_present?
+
+      from_date.to_date..to_date.to_date
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/promotion/actions/create_date_specific_item_adjustments.rb
+++ b/app/models/spree_cm_commissioner/promotion/actions/create_date_specific_item_adjustments.rb
@@ -34,11 +34,9 @@ module SpreeCmCommissioner
 
         # compute only on eligible date
         def compute_line_item_amount(line_item)
-          amount_per_date = line_item.amount / line_item.duration
-
           line_item.date_range.filter_map do |date|
             if promotion.date_eligible?(date)
-              object = Object.new.tap { |obj| obj.define_singleton_method(:amount) { amount_per_date } }
+              object = Object.new.tap { |obj| obj.define_singleton_method(:amount) { line_item.amount_per_date_unit } }
               compute(object)
             end
           end.sum

--- a/app/models/spree_cm_commissioner/stock/availability_validator_decorator.rb
+++ b/app/models/spree_cm_commissioner/stock/availability_validator_decorator.rb
@@ -39,7 +39,7 @@ module SpreeCmCommissioner
       end
 
       def find_booked_variants(variant_id, from_date, to_date)
-        VariantQuantityAvailabilityQuery.new(variant_id, from_date, to_date).booked_variants
+        SpreeCmCommissioner::ReservationVariantQuantityAvailabilityQuery.new(variant_id, from_date, to_date).booked_variants
       end
     end
   end

--- a/lib/spree_cm_commissioner/test_helper/factories/vendor_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/vendor_factory.rb
@@ -23,10 +23,11 @@ FactoryBot.define do
     factory :cm_vendor_with_product do
       transient do
         permanent_stock { 10 }
+        product_type { :accommodation }
       end
 
       after :create do |vendor, evaluator|
-        product = create(:product, vendor: vendor)
+        product = create(:product, vendor: vendor, product_type: evaluator.product_type)
 
         variant = product.master
         variant.permanent_stock = evaluator.permanent_stock

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe Spree::LineItem, type: :model do
   describe '#amount' do
     context 'product type: accommodation' do
       let(:product) { create(:cm_accommodation_product, price: BigDecimal('10.0'), permanent_stock: 4) }
-      let(:line_item) { create(:line_item, price: BigDecimal('10.0'), quantity: 2, product: product, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
+      let(:line_item) { create(:line_item, price: BigDecimal('10.0'), quantity: 2, product: product, from_date: '2023-01-10'.to_date, to_date: '2023-01-13'.to_date) }
 
-      it 'caculate amount base on price, date range & quantity' do
-        expect(line_item.amount).to eq BigDecimal('60.0') # 10.0 * 2 * 3 days
+      it 'caculate amount base on price, quantity & number of nights' do
+        expect(line_item.amount).to eq BigDecimal('60.0') # 10.0 * 2 * 3 nights
       end
     end
 

--- a/spec/models/spree/stock/availability_validator_spec.rb
+++ b/spec/models/spree/stock/availability_validator_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Spree::Stock::AvailabilityValidator do
         let(:reservation1) { build(:order, state: :complete) }
         let(:reservation2) { build(:order, state: :complete) }
 
-        let!(:line_item1) { create(:line_item, quantity: 3, order: reservation1, product: product, from_date: date('2023-01-10'), to_date: date('2023-01-10')) }
-        let!(:line_item2) { create(:line_item, quantity: 1, order: reservation2, product: product, from_date: date('2023-01-11'), to_date: date('2023-01-12')) }
+        let!(:line_item1) { create(:line_item, quantity: 3, order: reservation1, product: product, from_date: date('2023-01-10'), to_date: date('2023-01-11')) }
+        let!(:line_item2) { create(:line_item, quantity: 1, order: reservation2, product: product, from_date: date('2023-01-11'), to_date: date('2023-01-13')) }
 
         it 'error when at least one day could not supply 3 quantity' do
           line_item = build(:line_item, quantity: 3, product: product, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date)

--- a/spec/queries/spree_cm_commissioner/reservation_variant_quantity_availability_query_spec.rb
+++ b/spec/queries/spree_cm_commissioner/reservation_variant_quantity_availability_query_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe SpreeCmCommissioner::VariantQuantityAvailabilityQuery do
+RSpec.describe SpreeCmCommissioner::ReservationVariantQuantityAvailabilityQuery do
   describe '#booked_variants' do
     let!(:product) { create(:cm_accommodation_product, permanent_stock: 3) }
 
@@ -8,8 +8,8 @@ RSpec.describe SpreeCmCommissioner::VariantQuantityAvailabilityQuery do
       let(:reservation1) { build(:order, state: :complete) }
       let(:reservation2) { build(:order, state: :complete) }
 
-      let!(:line_item1) { create(:line_item, quantity: 3, order: reservation1, product: product, from_date: date('2023-01-10'), to_date: date('2023-01-10')) }
-      let!(:line_item2) { create(:line_item, quantity: 1, order: reservation1, product: product, from_date: date('2023-01-11'), to_date: date('2023-01-12')) }
+      let!(:line_item1) { create(:line_item, quantity: 3, order: reservation1, product: product, from_date: date('2023-01-10'), to_date: date('2023-01-11')) }
+      let!(:line_item2) { create(:line_item, quantity: 1, order: reservation1, product: product, from_date: date('2023-01-11'), to_date: date('2023-01-13')) }
 
       it 'return 2 available_quantity on 11th when inputs 9-11th' do
         subject = described_class.new(product.master.id, date('2023-01-09'), date('2023-01-11'))


### PR DESCRIPTION
## Problem 
Sometime, we use `to_date` as check-out date, and sometime to_date + 1 is check-out date.

## Finalize
We use `to_date` as checkout date. 
- So, check-out date / to_date is considered bookable.
- This might raise some concern, but vendor could have policy to set check-in on check-out time to avoid confliction.