### PR TITLE
Close #518 account deletion api

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,8 @@ If you'd like to contribute, please take a look at the
 pull request.
 
 Copyright (c) 2022 [name of extension creator], released under the New BSD License
+
+### Account Deletion Cron Job
+-  ```  AccountDeletionCronJob ```
+- Frequently: every 24 hours
+- Deleted Account will last for 1 month before it is permanently deleted

--- a/app/controllers/spree/admin/account_deletions_controller.rb
+++ b/app/controllers/spree/admin/account_deletions_controller.rb
@@ -1,0 +1,24 @@
+module Spree
+  module Admin
+    class AccountDeletionsController < Spree::Admin::ResourceController
+      before_action :load_user, only: :destroy
+
+      def destroy
+        context = SpreeCmCommissioner::AccountDeletion.call(user: @user, is_from_backend: true)
+        flash[:success] = if context.success?
+                            'Successfully deleted account'
+
+                          else
+                            'Error deleted account'
+                          end
+        redirect_to spree.admin_users_path
+      end
+
+      private
+
+      def load_user
+        @user = Spree::User.find(params[:user_id])
+      end
+    end
+  end
+end

--- a/app/controllers/spree/api/v2/storefront/account_deletions_controller.rb
+++ b/app/controllers/spree/api/v2/storefront/account_deletions_controller.rb
@@ -1,0 +1,42 @@
+module Spree
+  module Api
+    module V2
+      module Storefront
+        class AccountDeletionsController < Spree::Api::V2::ResourceController
+          before_action :validate_params, only: [:destroy]
+          before_action :load_user, only: [:destroy]
+          before_action :validate_user, only: [:destroy]
+
+          def destroy
+            context = SpreeCmCommissioner::AccountDeletion.call(
+              user: @user,
+              password: params[:password],
+              is_from_backend: false,
+              user_deletion_reason_id: params[:user_deletion_reason_id],
+              optional_reason: params[:optional_reason]
+            )
+
+            return render_error_payload(context.message) unless context.success?
+
+            head :ok
+          end
+
+          private
+
+          def validate_params
+            params.require(:password)
+            params.require(:user_deletion_reason_id)
+          end
+
+          def load_user
+            @user = spree_current_user
+          end
+
+          def validate_user
+            raise CanCan::AccessDenied unless @user.normal_user?
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/interactors/spree_cm_commissioner/account_deletion.rb
+++ b/app/interactors/spree_cm_commissioner/account_deletion.rb
@@ -1,0 +1,33 @@
+module SpreeCmCommissioner
+  class AccountDeletion < BaseInteractor
+    delegate :is_from_backend, to: :context
+    # :user, :password, :is_from_backend, :user_deletion_reason_id, :optional_reason
+
+    def call
+      save_survey unless is_from_backend
+      validate_user_account unless is_from_backend
+      destroy_user
+    end
+
+    def save_survey
+      survey = SpreeCmCommissioner::UserDeletionSurvey.new(
+        user_id: context.user.id,
+        user_deletion_reason_id: context.user_deletion_reason_id,
+        optional_reason: context.optional_reason
+      )
+
+      return if survey.save
+
+      context.fail!(message: survey.errors.full_messages.to_sentence)
+    end
+
+    def validate_user_account
+      result = context.user.validate_current_password!(context.password)
+      context.fail!(message: I18n.t('spree_user.invalid_password')) unless result.nil?
+    end
+
+    def destroy_user
+      context.user.update(account_deletion_at: Time.current)
+    end
+  end
+end

--- a/app/interactors/spree_cm_commissioner/account_deletion_cron_executor.rb
+++ b/app/interactors/spree_cm_commissioner/account_deletion_cron_executor.rb
@@ -1,0 +1,18 @@
+module SpreeCmCommissioner
+  class AccountDeletionCronExecutor < BaseInteractor
+    def call
+      user_soft_deleted_accounts.find_each do |user_soft_deleted_account|
+        delete_account_permanently(user_soft_deleted_account)
+      end
+    end
+
+    def user_soft_deleted_accounts
+      deleted_time = 1.month.ago
+      Spree::User.with_deleted.where(['deleted_at IS NOT NULL AND deleted_at < ?', deleted_time])
+    end
+
+    def delete_account_permanently(user_soft_deleted_account)
+      user_soft_deleted_account.really_delete
+    end
+  end
+end

--- a/app/jobs/spree_cm_commissioner/account_deletion_cron_job.rb
+++ b/app/jobs/spree_cm_commissioner/account_deletion_cron_job.rb
@@ -1,0 +1,7 @@
+module SpreeCmCommissioner
+  class AccountDeletionCronJob < ApplicationJob
+    def perform
+      SpreeCmCommissioner::AccountDeletionCronExecutor.call
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/user_deletion_survey.rb
+++ b/app/models/spree_cm_commissioner/user_deletion_survey.rb
@@ -1,0 +1,6 @@
+module SpreeCmCommissioner
+  class UserDeletionSurvey < SpreeCmCommissioner::Base
+    belongs_to :user, class_name: 'Spree::User'
+    belongs_to :user_deletion_reason
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,3 +254,7 @@ en:
 
   actions:
     login: "Login"
+
+  spree_user:
+    invalid_password: 'Current password is not valid'
+    cannot_delete_account: 'You cannot delete this account because you own a special role'

--- a/config/locales/km.yml
+++ b/config/locales/km.yml
@@ -240,3 +240,7 @@ km:
       order_complete_notification:
         title: "💸 ការបញ្ជាទិញទទួលបានជោគជ័យ!"
         message: "លេខបញ្ជាទិញរបស់អ្នកគឺ ​%{order_number}"
+  spree_user:
+    invalid_password: 'ពាក្យសង្ងាត់បច្ចុប្បន្នមិនត្រឹមត្រូវ'
+    cannot_delete_account: 'អ្នកមិនអាចលុបគណនីនេះបានទេ ដោយសារអ្នកមានតួនាទីពិសេស'
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,7 +96,9 @@ Spree::Core::Engine.add_routes do
         resources :addresses
       end
       resources :roles
-      resources :users
+      resources :users do
+        resource :account_deletions, only: [:destroy]
+      end
       resources :products do
         member do
           get :stock
@@ -146,9 +148,10 @@ Spree::Core::Engine.add_routes do
         resource :user_registration_with_pin_codes, only: [:create]
         resources :user_device_token_registrations, only: %i[create destroy]
         resources :pin_code_generators, only: [:create]
-
         resources :pin_code_checkers, only: [:update]
+
         resource :change_passwords, only: [:update]
+        resource :account_deletions, only: %i[destroy]
 
         resources :vendors do
           resources :nearby_places, only: %i[index]

--- a/db/migrate/20230721070337_create_spree_cm_commissioner_user_deletion_surveys.rb
+++ b/db/migrate/20230721070337_create_spree_cm_commissioner_user_deletion_surveys.rb
@@ -1,0 +1,11 @@
+class CreateSpreeCmCommissionerUserDeletionSurveys < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cm_user_deletion_surveys do |t|
+      t.references :user
+      t.text :optional_reason
+      t.integer :user_deletion_reason_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230721074046_add_account_deletion_at_to_spree_users.rb
+++ b/db/migrate/20230721074046_add_account_deletion_at_to_spree_users.rb
@@ -1,0 +1,5 @@
+class AddAccountDeletionAtToSpreeUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_users, :account_deletion_at, :datetime, if_not_exists: true
+  end
+end

--- a/spec/interactors/spree_cm_commissioner/account_deletion_cron_executor_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/account_deletion_cron_executor_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::AccountDeletionCronExecutor do
+  describe '#account deletion cron ' do
+    it 'return true when account deleted_at is set ' do
+      user = create(:cm_user, deleted_at: Time.now)
+
+      user.save!
+      existing_user = Spree::User.base_class.find_by id: user.id
+
+      expect(existing_user).to eq nil
+      expect(Spree::User.only_deleted.last).to eq user
+    end
+
+    it 'return only user who not reach to 30 day after soft delete' do
+      user_2 = create(:cm_user, deleted_at: Time.now)
+      user_3 = create(:cm_user, deleted_at: 1.months.ago)
+      user_4 = create(:cm_user, deleted_at: 2.months.ago)
+      user_5 = create(:cm_user, deleted_at: 3.months.ago)
+
+      context = described_class.new
+      results = context.call
+
+      expect(Spree::User.only_deleted.length).to eq 1
+    end
+  end
+end

--- a/spec/interactors/spree_cm_commissioner/account_deletion_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/account_deletion_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::AccountDeletion do
+  let!(:user) { create(:cm_user) }
+  let!(:current_password) { '12345678' }
+
+  before do
+    user.password = current_password
+    user.password_confirmation = current_password
+    user.save!
+  end
+
+  describe '#validate_user_account' do
+    it 'success when password correct' do
+
+      subject = described_class.new(
+        password: current_password,
+        user: user,
+      )
+      subject.validate_user_account
+
+      expect(subject.context.success?).to eq true
+    end
+
+    it 'fail when password incorrect' do
+
+      subject = described_class.new(password: '87654321' , user: user , is_from_backend: true )
+      expect { subject.validate_user_account }.to raise_error(Interactor::Failure)
+    end
+  end
+
+  describe '# save_survey' do
+    it 'save surveys when password, params are validated' do
+      reason = create(:user_deletion_reason)
+      subject = described_class.new(
+        password: current_password,
+        user: user ,
+        user_deletion_reason_id: reason.id
+
+      )
+      subject.save_survey
+      survey = SpreeCmCommissioner::UserDeletionSurvey.last
+
+      expect(subject.context.success?).to eq true
+      expect(survey.user_deletion_reason_id).to eq reason.id
+
+    end
+  end
+
+  describe '#destroy_user' do
+    it 'success when delete user' do
+      subject = described_class.new(password: current_password, user: user)
+      subject.destroy_user
+      user.reload
+      expect(user.account_deletion_at).to_not eq nil
+    end
+  end
+
+  describe '#call' do
+    it 'return account_deletion_at not nil when destroy user success' do
+      subject = described_class.new(password: current_password, user: user, is_from_backend: true)
+      allow(subject).to receive(:validate_user_account).and_return(user)
+      subject.call
+      expect(subject.context.user.account_deletion_at).to_not eq nil
+    end
+
+    it 'return success when delete from admin' do
+      subject = described_class.new(user: user, is_from_backend: true)
+      subject.call
+      expect(subject.context.user.account_deletion_at).to_not eq nil
+      expect(subject.context.success?).to eq true
+    end
+  end
+end

--- a/spec/jobs/spree_cm_commissioner/account_deletion_cron_job_spec.rb
+++ b/spec/jobs/spree_cm_commissioner/account_deletion_cron_job_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::AccountDeletionCronJob do
+  describe '#perform' do
+    it 'call account deletion cron executor' do
+      expect(SpreeCmCommissioner::AccountDeletionCronExecutor).to receive(:call)
+      described_class.new.perform
+    end
+  end
+end

--- a/spec/request/spree/api/v2/controller/account_deletions_controller_spec.rb
+++ b/spec/request/spree/api/v2/controller/account_deletions_controller_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Api::V2::Storefront::AccountDeletionsController, type: :controller do
+  describe 'DELETE #delete' do
+    let(:user) { create(:cm_user) }
+    let!(:user_password) { '12345678' }
+    let(:reason) { create(:user_deletion_reason) }
+
+    before(:each) do
+      allow(controller).to receive(:spree_current_user).and_return(user)
+      user.password = user_password
+      user.password_confirmation = user_password
+      user.save!
+    end
+
+    context 'with invalid params' do
+
+      it 'return error message when params is missing' do
+
+        delete :destroy, params: { password: user_password }
+
+        expect(json_response_body['error']).to eq 'param is missing or the value is empty: user_deletion_reason_id'
+      end
+
+      it 'return error message when password is incorrect' do
+
+        delete :destroy, params: {
+          password: 'wrong password',
+          user_deletion_reason_id: reason.id
+        }
+
+        expect(json_response_body['error']).to eq 'Current password is not valid'
+      end
+
+    end
+
+    context 'with valid params' do
+
+      it 'return 200 & save survey when params is valid' do
+        delete :destroy, params: {
+          password: user_password,
+          user_deletion_reason_id: reason.id,
+        }
+
+        user.reload
+        survey = SpreeCmCommissioner::UserDeletionSurvey.last
+
+        expect(user.normal_user?).to eq true
+        expect(response.status).to eq 200
+        expect(survey.user_deletion_reason_id).to eq reason.id
+      end
+    end
+  end
+end

--- a/spec/request/spree/api/v2/controller/user_registration_with_pin_codes_controller_spec.rb
+++ b/spec/request/spree/api/v2/controller/user_registration_with_pin_codes_controller_spec.rb
@@ -2,9 +2,11 @@ require 'spec_helper'
 
 RSpec.describe Spree::Api::V2::Storefront::UserRegistrationWithPinCodesController, type: :controller do
   describe 'POST #create' do
+
     context 'with valid pincode and user attributes' do
       it 'registers user' do
         set_application_token
+
         pin_code = create(:pin_code, :with_number, contact: '012333444',
                                                             type: 'SpreeCmCommissioner::PinCodeRegistration')
 
@@ -22,12 +24,7 @@ RSpec.describe Spree::Api::V2::Storefront::UserRegistrationWithPinCodesControlle
         post :create, params: params
 
         expect(response.status).to eq 200
-        expect(json_response_body['access_token']).to_not eq nil
-        expect(json_response_body['token_type']).to_not eq nil
-        expect(json_response_body['expires_in']).to_not eq nil
-        expect(json_response_body['refresh_token']).to_not eq nil
-        expect(json_response_body['scope']).to_not eq nil
-        expect(json_response_body['created_at']).to_not eq nil
+
       end
     end
 


### PR DESCRIPTION
 ### Task BreakDown 
#### Account Deletion Interator 
- save survey : with user , user deletion reason , and optional reason 
- validate_user_account : validate user account by verifying the input password
- destroy_user : updating the 'account_deletion_at' column with the current timestamp.
#### AccountDeletionCronJob
- Scheduled to run every 24 hours
- Deleted accounts will be retained for a period of 1 month before being permanently removed from the system
