### PR TITLE
close #524 integrate order approve & cancel via telegram web bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Following are required varialbles inside .env
 GOOGLE_MAP_KEY = ""
 DEFAULT_LATLON = "10.627543,103.522141"
 ACCOMMODATION_MAX_STAY_DAYS = 10
+DEFAULT_TELEGRAM_BOT_API_TOKEN = ""
 ```
 
 ## Using Deface DSL (.deface files)

--- a/app/assets/config/spree_cm_commissioner_manifest.js
+++ b/app/assets/config/spree_cm_commissioner_manifest.js
@@ -1,3 +1,6 @@
 //= link_tree ../images
 //= link spree_cm_commissioner/mailer/base.css
 //= link spree_cm_commissioner/backend/invoice.css
+
+//= link spree_cm_commissioner/telegram/all.js
+//= link spree_cm_commissioner/telegram/all.css

--- a/app/assets/javascripts/spree_cm_commissioner/telegram.js
+++ b/app/assets/javascripts/spree_cm_commissioner/telegram.js
@@ -1,0 +1,2 @@
+//= require jquery3
+//= require spree_cm_commissioner/telegram/order_confirmation

--- a/app/assets/javascripts/spree_cm_commissioner/telegram/order_confirmation.js
+++ b/app/assets/javascripts/spree_cm_commissioner/telegram/order_confirmation.js
@@ -1,0 +1,86 @@
+const OrderConfirmation = {
+  initialize: function ({ canApprove, canCancel, onApprove, onReject }) {
+    self = this;
+
+    this.canApprove = canApprove == "true";
+    this.canCancel = canCancel == "true";
+    this.onApprove = onApprove;
+    this.onReject = onReject;
+
+    window.Telegram.WebApp.MainButton.onClick(() => {
+      self.mainButtonClickListener();
+    });
+
+    window.Telegram.WebApp.onEvent("viewportChanged", (params) =>
+      this.viewportChangedListener(params)
+    );
+  },
+  viewportChangedListener: function (params) {
+    if (!params.isStateStable) return this.hideMainButton();
+    if (this.currentMainButtonAction() == "confirm") {
+      this.showMainButton({
+        text: "Confirm",
+        color: window.Telegram.WebApp.themeParams.button_color,
+        text_color: window.Telegram.WebApp.themeParams.button_text_color,
+      });
+    } else {
+      this.showMainButton({
+        text: "Reject",
+        color: "#F5564D",
+      });
+    }
+  },
+  currentMainButtonAction: function () {
+    if (window.Telegram.WebApp.isExpanded) {
+      return "confirm";
+    } else {
+      return "reject";
+    }
+  },
+  mainButtonClickListener: function () {
+    if (this.currentMainButtonAction() == "confirm") {
+      this.confirm();
+    } else {
+      this.reject();
+    }
+  },
+  confirm: function () {
+    window.Telegram.WebApp.showPopup(
+      {
+        title: "Are you sure to confirm?",
+        message: "You can't undo this action.",
+        buttons: [
+          { id: "close", type: "close" },
+          { id: "confirm", type: "default", text: "Confirm" },
+        ],
+      },
+      function (buttonId) {
+        if (buttonId == "confirm") self.onApprove();
+      }
+    );
+  },
+  reject: function () {
+    window.Telegram.WebApp.showPopup(
+      {
+        title: "Are you sure to reject?",
+        message: "You can't undo this action.",
+        buttons: [
+          { id: "close", type: "close" },
+          { id: "reject", type: "destructive", text: "Reject" },
+        ],
+      },
+      function (buttonId) {
+        if (buttonId == "reject") self.onReject();
+      }
+    );
+  },
+  hideMainButton: function () {
+    if (window.Telegram.WebApp.MainButton.isVisible) {
+      window.Telegram.WebApp.MainButton.hide();
+    }
+  },
+  showMainButton: function (params) {
+    window.Telegram.WebApp.MainButton.setParams(params);
+    window.Telegram.WebApp.MainButton.show();
+  },
+};

--- a/app/assets/stylesheets/spree_cm_commissioner/telegram.css
+++ b/app/assets/stylesheets/spree_cm_commissioner/telegram.css
@@ -1,0 +1,7 @@
+/*
+ * This is a manifest file that'll automatically include all the stylesheets available in this directory
+ * and any sub-directories. You're free to add application-wide styles to this file and they'll appear at
+ * the top of the compiled file, but it's generally better to create a new file per style scope.
+ *
+ *= require spree_cm_commissioner/telegram/telegram_bot
+*/

--- a/app/assets/stylesheets/spree_cm_commissioner/telegram/telegram_bot.css.scss
+++ b/app/assets/stylesheets/spree_cm_commissioner/telegram/telegram_bot.css.scss
@@ -1,0 +1,95 @@
+@import 'bootstrap';
+
+// Green
+.badge-completed,
+.badge-complete,
+.badge-resumed,
+.badge-considered_safe,
+.badge-paid,
+.badge-shipped,
+.badge-ready,
+.badge-active,
+.badge-success,
+.badge-sold,
+.badge-open,
+.badge-authorized,
+.badge-published,
+.badge-live,
+.badge-approved {
+  @include badge-variant(theme-color('success'));
+}
+
+// Red
+.badge-failed,
+.badge-considered_risky,
+.badge-error,
+.badge-invalid,
+.badge-rejected,
+.badge-closed {
+  @include badge-variant(theme-color('danger'));
+}
+
+// Orange
+.badge-processing,
+.badge-pending,
+.badge-awaiting_return,
+.badge-returned,
+.badge-credit_owed,
+.badge-balance_due,
+.badge-backorder,
+.badge-checkout,
+.badge-cart,
+.badge-address,
+.badge-delivery,
+.badge-payment,
+.badge-confirm,
+.badge-canceled,
+.badge-void,
+.badge-inactive,
+.badge-notice,
+.badge-suspended,
+.badge-partial {
+  @include badge-variant(theme-color('warning'));
+}
+
+:root {
+  --color-border: color-mix(in srgb, var(--tg-theme-text-color) 10%, transparent);
+}
+
+body {
+  background-color: var(--tg-theme-secondary-bg-color);
+  color: var(--tg-theme-text-color);
+}
+
+a {
+  color: var(--tg-theme-link-color);
+}
+
+.card {
+  background-color: var(--tg-theme-bg-color);
+}
+
+.card-header {
+  background-color: var(--tg-theme-bg-color);
+  border-color: var(--color-border);
+}
+
+.btn-primary {
+  background-color: var(--tg-theme-button-color);
+  border-color: var(--tg-theme-button-color);
+  color: var(--tg-theme-button-text-color);
+}
+
+.btn-outline-primary {
+  border-color: var(--tg-theme-button-color);
+  color: var(--tg-theme-button-color);
+}
+
+.badge-primary {
+  background-color: var(--tg-theme-button-color);
+}
+
+.list-group-item {
+  background-color: var(--tg-theme-bg-color);
+  border-color: var(--color-border);
+}

--- a/app/controllers/spree/telegram/base_controller.rb
+++ b/app/controllers/spree/telegram/base_controller.rb
@@ -1,0 +1,37 @@
+module Spree
+  module Telegram
+    class BaseController < ApplicationController
+      layout 'spree_cm_commissioner/layouts/telegram'
+      helper 'spree_cm_commissioner/telegram/base'
+
+      before_action :required_telegram_vendor_user!
+
+      rescue_from SpreeCmCommissioner::UnauthorizedVendorError, with: :handle_unauthorized_vendor
+      rescue_from ActiveRecord::RecordNotFound, with: :resource_not_found
+
+      def required_telegram_vendor_user!
+        raise SpreeCmCommissioner::UnauthorizedVendorError if params[:telegram_init_data].blank?
+        raise SpreeCmCommissioner::UnauthorizedVendorError unless authorizer_context.success?
+      end
+
+      def resource_not_found
+        redirect_to telegram_resource_not_found_url
+      end
+
+      def handle_unauthorized_vendor
+        redirect_to telegram_forbidden_url
+      end
+
+      def authorized_vendors
+        @authorized_vendors ||= authorizer_context.user.vendors
+      end
+
+      def authorizer_context
+        @authorizer_context ||= ::SpreeCmCommissioner::TelegramWebAppVendorUserAuthorizer.call(
+          telegram_init_data: params[:telegram_init_data],
+          bot_token: ENV.fetch('DEFAULT_TELEGRAM_BOT_API_TOKEN', nil)
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/spree/telegram/errors_controller.rb
+++ b/app/controllers/spree/telegram/errors_controller.rb
@@ -1,0 +1,15 @@
+module Spree
+  module Telegram
+    class ErrorsController < BaseController
+      skip_before_action :required_telegram_vendor_user!
+
+      def forbidden
+        @message = "You're either not a vendor user or the vendor isn't belonging to you."
+      end
+
+      def resource_not_found
+        @message = 'Resources you are looking are not found.'
+      end
+    end
+  end
+end

--- a/app/controllers/spree/telegram/orders_controller.rb
+++ b/app/controllers/spree/telegram/orders_controller.rb
@@ -1,0 +1,39 @@
+module Spree
+  module Telegram
+    class OrdersController < BaseController
+      skip_before_action :required_telegram_vendor_user!, only: :show
+
+      def show
+        @order = Order.find_by(number: params[:id])
+      end
+
+      def reject
+        order = order_scope.find_by(number: params[:id])
+        raise ActiveRecord::RecordNotFound if order.nil?
+
+        result = Spree::Orders::Cancel.call(order: order, canceler: authorizer_context.user)
+        if result.success?
+          head :ok
+        else
+          head :unprocessable_entity
+        end
+      end
+
+      def approve
+        order = order_scope.find_by(number: params[:id])
+        raise ActiveRecord::RecordNotFound if order.nil?
+
+        result = Spree::Orders::Approve.call(order: order, approver: authorizer_context.user)
+        if result.success?
+          head :ok
+        else
+          head :unprocessable_entity
+        end
+      end
+
+      def order_scope
+        Spree::Order.joins(:line_items).where(line_items: { vendor_id: authorized_vendors.pluck(:id) })
+      end
+    end
+  end
+end

--- a/app/helpers/spree_cm_commissioner/telegram/base_helper.rb
+++ b/app/helpers/spree_cm_commissioner/telegram/base_helper.rb
@@ -1,0 +1,17 @@
+module SpreeCmCommissioner
+  module Telegram
+    module BaseHelper
+      def render_image
+        return unless item.variant.images.any?
+
+        image_tag main_app.url_for(item.variant.images.first.url(:small)), :class => 'mr-3'
+      end
+
+      def pretty_time(time)
+        return '' if time.blank?
+
+        [I18n.l(time.to_date, format: :long), time.strftime('%l:%M %p %Z')].join(' ')
+      end
+    end
+  end
+end

--- a/app/interactors/spree_cm_commissioner/telegram_web_app_init_data_validator.rb
+++ b/app/interactors/spree_cm_commissioner/telegram_web_app_init_data_validator.rb
@@ -1,0 +1,27 @@
+module SpreeCmCommissioner
+  class TelegramWebAppInitDataValidator < BaseInteractor
+    delegate :telegram_init_data, :bot_token, to: :context
+
+    def call
+      context.decoded_telegram_init_data = Rack::Utils.parse_nested_query(telegram_init_data).to_h
+
+      context.initial_hash = context.decoded_telegram_init_data['hash']
+      context.verify_hash = generate_verify_hash
+
+      context.fail!(message: 'Could not verify hash') if context.verify_hash != context.initial_hash
+    end
+
+    # https://core.telegram.org/bots/webapps#validating-data-received-via-the-web-app
+    #
+    # data_check_string = <sorted alphabetically, in the format key=<value> with a line feed character ('\n', 0x0A) used as separator>
+    # secret_key = HMAC_SHA256(<bot_token>, "WebAppData")
+    # verify_hash = hex(HMAC_SHA256(data_check_string, secret_key))
+    #
+    def generate_verify_hash
+      data_check_string = context.decoded_telegram_init_data.filter_map { |k, v| "#{k}=#{v}" unless k == 'hash' }.sort.join("\n")
+
+      secret_key = OpenSSL::HMAC.digest('sha256', 'WebAppData', bot_token)
+      OpenSSL::HMAC.hexdigest('sha256', secret_key, data_check_string)
+    end
+  end
+end

--- a/app/interactors/spree_cm_commissioner/telegram_web_app_vendor_user_authorizer.rb
+++ b/app/interactors/spree_cm_commissioner/telegram_web_app_vendor_user_authorizer.rb
@@ -1,0 +1,7 @@
+module SpreeCmCommissioner
+  class TelegramWebAppVendorUserAuthorizer
+    include Interactor::Organizer
+
+    organize TelegramWebAppInitDataValidator, TelegramWebAppVendorUserChecker
+  end
+end

--- a/app/interactors/spree_cm_commissioner/telegram_web_app_vendor_user_checker.rb
+++ b/app/interactors/spree_cm_commissioner/telegram_web_app_vendor_user_checker.rb
@@ -1,0 +1,35 @@
+module SpreeCmCommissioner
+  class TelegramWebAppVendorUserChecker < BaseInteractor
+    delegate :decoded_telegram_init_data, to: :context
+
+    def call
+      context.decoded_telegram_user_id = decode_telegram_user_id
+      context.user = find_spree_user(context.decoded_telegram_user_id)
+
+      check_vendors
+    end
+
+    def decode_telegram_user_id
+      decode_telegram_user = ActiveSupport::JSON.decode(decoded_telegram_init_data['user'])
+      telegram_user_id = decode_telegram_user['id']
+
+      return telegram_user_id if telegram_user_id.present?
+
+      context.fail!(message: 'Telegram user is not provided')
+    end
+
+    def find_spree_user(telegram_user_id)
+      user_identity_provider = SpreeCmCommissioner::UserIdentityProvider.find_by(identity_type: :telegram, sub: telegram_user_id)
+
+      return user_identity_provider.user if user_identity_provider&.user.present?
+
+      context.fail!(message: 'Could not find connected user')
+    end
+
+    def check_vendors
+      return unless context.user.vendors.empty?
+
+      context.fail!(message: "You're not a vendor user")
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/order_decorator.rb
+++ b/app/models/spree_cm_commissioner/order_decorator.rb
@@ -54,6 +54,10 @@ module SpreeCmCommissioner
       subscription.present?
     end
 
+    def customer_address
+      bill_address || ship_address
+    end
+
     private
 
     def link_by_phone_number

--- a/app/models/spree_cm_commissioner/user_identity_provider.rb
+++ b/app/models/spree_cm_commissioner/user_identity_provider.rb
@@ -2,7 +2,7 @@ require_dependency 'spree_cm_commissioner'
 
 module SpreeCmCommissioner
   class UserIdentityProvider < ApplicationRecord
-    enum identity_type: { :google => 0, :apple => 1, :facebook => 2 }
+    enum identity_type: { :google => 0, :apple => 1, :facebook => 2, :telegram => 3 }
 
     belongs_to :user, class_name: Spree.user_class.to_s
 

--- a/app/views/spree/telegram/errors/_error.html.erb
+++ b/app/views/spree/telegram/errors/_error.html.erb
@@ -1,0 +1,7 @@
+<div class="d-flex align-items-center justify-content-center" style="height: var(--tg-viewport-height);">
+  <div class="text-center">
+    <h3 class="fs-3"><span class="text-danger">Oops!</span></h3>
+    <p><%= @message %></p>
+    <button class="btn btn-outline-primary" onclick="window.Telegram.WebApp.close();" type="button">Close</button>
+  </div>
+</div>

--- a/app/views/spree/telegram/errors/forbidden.html.erb
+++ b/app/views/spree/telegram/errors/forbidden.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "error" %>

--- a/app/views/spree/telegram/errors/resource_not_found.html.erb
+++ b/app/views/spree/telegram/errors/resource_not_found.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "error" %>

--- a/app/views/spree/telegram/orders/_line_items.html.erb
+++ b/app/views/spree/telegram/orders/_line_items.html.erb
@@ -1,0 +1,15 @@
+<div class="card rounded-0 mb-2">
+  <div class="card-header">
+    <h3 class="card-title mb-0 h6"><%= Spree.t(:rooms) %></h3>
+  </div>
+  <ul class="list-group m-2 p-2">
+    <% @order.line_items.each do |item| %>
+      <li class="list-group-item d-flex justify-content-between align-items-center ">
+        <div>
+          <small><%= item.name %></small><br>
+          <small><%= item.display_price %> x <%= item.quantity %></small>
+        </div>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/spree/telegram/orders/_order_confirmation_script.html.erb
+++ b/app/views/spree/telegram/orders/_order_confirmation_script.html.erb
@@ -1,0 +1,48 @@
+<script>
+  OrderConfirmation.initialize({
+    canApprove: "<%= @order.can_approve? %>",
+    canCancel: "<%= @order.allow_cancel? %>",
+    onApprove: function () {
+      window.Telegram.WebApp.MainButton.showProgress();
+      $.ajax({
+        url: "<%= approve_telegram_order_path(@order) %>",
+        type: "PATCH",
+        data: {
+          telegram_init_data: window.Telegram.WebApp.initData,
+          authenticity_token: "<%= form_authenticity_token %>",
+        },
+        success: function (response) {
+          location.reload();
+          window.Telegram.WebApp.MainButton.hideProgress();
+          window.Telegram.WebApp.showAlert("Success");
+        },
+        error: function (xhr, status, error) {
+          location.reload();
+          window.Telegram.WebApp.MainButton.hideProgress();
+          window.Telegram.WebApp.showAlert("Failed");
+        },
+      });
+    },
+    onReject: function () {
+      window.Telegram.WebApp.MainButton.showProgress();
+      $.ajax({
+        url: "<%= reject_telegram_order_path(@order) %>",
+        type: "PATCH",
+        data: {
+          telegram_init_data: window.Telegram.WebApp.initData,
+          authenticity_token: "<%= form_authenticity_token %>",
+        },
+        success: function (response) {
+          location.reload();
+          window.Telegram.WebApp.MainButton.hideProgress();
+          window.Telegram.WebApp.showAlert("Success");
+        },
+        error: function (xhr, status, error) {
+          location.reload();
+          window.Telegram.WebApp.MainButton.hideProgress();
+          window.Telegram.WebApp.showAlert("Failed");
+        },
+      });
+    },
+  });
+</script>

--- a/app/views/spree/telegram/orders/_order_summary.html.erb
+++ b/app/views/spree/telegram/orders/_order_summary.html.erb
@@ -1,0 +1,129 @@
+<div class="card rounded-0" id="order_tab_summary">
+  <div class="card-header">
+    <h3 class="card-title mb-0 h6"><%= Spree.t(:summary) %></h3>
+  </div>
+  <ul class="list-group list-group-flush">
+    <li class="list-group-item d-flex justify-content-between align-items-center">
+      <small><%= Spree.t(:status) %></small>
+      <span class="state badge badge-<%= @order.state %> badge-pill text-capitalize" id="order_status">
+        <%= Spree.t(@order.state, scope: :order_state) %>
+      </span>
+    </li>
+
+    <% if @order.shipment_state.present? %>
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <small><%= Spree.t(:shipment) %></small>
+        <span class="state badge badge-<%= @order.shipment_state %> badge-pill text-capitalize" id="shipment_status">
+          <%= Spree.t(@order.shipment_state, scope: :shipment_states, default: [:missing, "none"]) %>
+        </span>
+      </li>
+    <% end %>
+
+    <% if @order.payment_state.present? %>
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <small><%= Spree.t(:payment) %></small>
+        <span class="state badge badge-<%= @order.payment_state %> badge-pill text-capitalize" id="payment_status">
+          <%= Spree.t(@order.payment_state, scope: :payment_states, default: [:missing, "none"]) %>
+        </span>
+      </li>
+    <% end %>
+
+    <li class="list-group-item d-flex justify-content-between align-items-center">
+      <small><%= Spree.t(:address) %></small>
+      <span class="state badge font-weight-normal text-capitalize" id='order_channel'>
+        <%= @order.customer_address.address1 %>
+      </span>
+    </li>
+
+    <li class="list-group-item d-flex justify-content-between align-items-center">
+      <small><%= Spree.t(:customer) %></small>
+      <span class="state badge font-weight-normal text-capitalize" id='order_channel'>
+        <%= @order.customer_address.full_name %>
+      </span>
+    </li>
+
+    <% if @order.completed? %>
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <small data-hook='admin_order_tab_date_completed_title'><%= Spree.t(:date_completed) %></small>
+        <span class="text-right small font-weight-bold" id='date_complete'>
+          <%= pretty_time(@order.completed_at) %>
+        </span>
+      </li>
+    <% end %>
+
+    <% if @order.approved? %>
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <small><%= Spree.t(:approved_at) %></small>
+        <span class="text-right small font-weight-bold">
+          <%= pretty_time(@order.approved_at) %>
+        </span>
+      </li>
+      <% if @order.approver.present? %>
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <small><%= Spree.t(:approver) %></small>
+          <span class="text-right small font-weight-bold">
+            <%= link_to @order.approver.email, spree.admin_users_path(@order.approver) %>
+          </span>
+        </li>
+      <% end %>
+    <% end %>
+
+    <% if @order.canceled? && @order.canceled_at %>
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <small><%= Spree.t(:canceled_at) %></small>
+        <span class="text-right small font-weight-bold">
+          <%= pretty_time(@order.canceled_at) %>
+        </span>
+      </li>
+      <% if @order.canceler.present? %>
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <small><%= Spree.t(:canceler) %></small>
+          <span class="text-right small font-weight-bold">
+            <%= link_to @order.canceler.email, spree.admin_users_path(@order.canceler) %>
+          </span>
+        </li>
+      <% end %>
+    <% end %>
+
+    <li class="list-group-item d-flex justify-content-between align-items-center">
+      <small data-hook='admin_order_tab_subtotal_title'><%= Spree.t(:subtotal) %></small>
+      <span class="state badge font-weight-normal text-capitalize" id='item_total'>
+        <%= @order.display_item_total.to_html %>
+      </span>
+    </li>
+
+    <% if @order.checkout_steps.include?("delivery") && @order.ship_total > 0 %>
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <small data-hook='admin_order_tab_ship_total_title'><%= Spree.t(:ship_total) %></small>
+        <span class="state badge font-weight-normal text-capitalize" id='ship_total'>
+          <%= @order.display_ship_total.to_html %>
+        </span>
+      </li>
+    <% end %>
+
+    <% if @order.included_tax_total != 0 %>
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <small data-hook='admin_order_tab_included_tax_title'><%= Spree.t(:tax_included) %></small>
+        <span class="state badge font-weight-normal text-capitalize" id='included_tax_total'>
+          <%= @order.display_included_tax_total.to_html %>
+        </span>
+      </li>
+    <% end %>
+
+    <% if @order.additional_tax_total != 0 %>
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <small data-hook='admin_order_tab_additional_tax_title'><%= Spree.t(:tax) %></small>
+        <span class="state badge font-weight-normal text-capitalize" id='additional_tax_total'>
+          <%= @order.display_additional_tax_total.to_html %>
+        </span>
+      </li>
+    <% end %>
+
+    <li class="list-group-item d-flex justify-content-between align-items-center">
+      <small data-hook='admin_order_tab_total_title'><%= Spree.t(:total) %></small>
+      <span class="state badge badge-primary text-capitalize" id='order_total'>
+        <%= @order.display_total.to_html %>
+      </span>
+    </li>
+  </ul>
+</div>

--- a/app/views/spree/telegram/orders/show.html.erb
+++ b/app/views/spree/telegram/orders/show.html.erb
@@ -1,0 +1,3 @@
+<%= render partial: 'line_items' %>
+<%= render partial: 'order_summary' %>
+<%= render partial: 'order_confirmation_script' if @order.can_approve? %>

--- a/app/views/spree_cm_commissioner/layouts/telegram.html.erb
+++ b/app/views/spree_cm_commissioner/layouts/telegram.html.erb
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <%= csrf_meta_tags %>
+
+  <title>
+  <% if content_for? :title %>
+    <%= yield :title %>
+  <% else %>
+    <%= "Spree #{Spree.t('administration')}: " %>
+    <%= Spree.t(controller.controller_name, default: controller.controller_name.titleize) %>
+  <% end %>
+  </title>
+
+  <%= stylesheet_link_tag 'spree_cm_commissioner/telegram/all', media: :all %>
+
+  <script src="https://telegram.org/js/telegram-web-app.js"></script>
+
+  <%= javascript_include_tag 'spree_cm_commissioner/telegram/all', data: { turbo_track: "reload" } %>
+</head>
+
+<body>
+  <%= yield %>
+</body>
+
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,18 @@ Spree::Core::Engine.add_routes do
     end
   end
 
+  namespace :telegram do
+    resources :orders, only: %i[show update] do
+      member do
+        patch :reject
+        patch :approve
+      end
+    end
+
+    get '/forbidden', to: 'errors#forbidden'
+    get '/resource_not_found', to: 'errors#resource_not_found'
+  end
+
   scope '(:locale)', locale: /#{I18n.available_locales.join("|")}/ do
     namespace :billing do
       resource :report, only: %i[show], controller: :report do

--- a/lib/generators/spree_cm_commissioner/install/install_generator.rb
+++ b/lib/generators/spree_cm_commissioner/install/install_generator.rb
@@ -39,6 +39,11 @@ module SpreeCmCommissioner
         inject_into_file 'app/javascript/spree-dashboard.js', "\nimport \"./spree_cm_commissioner/utilities.js\"",
                          after: %r{import "@spree/dashboard"}, verbose: true
       end
+
+      def install_telegram_web_bot
+        template 'vendor/assets/javascript/spree_cm_commissioner/telegram/all.js'
+        template 'vendor/assets/stylesheets/spree_cm_commissioner/telegram/all.css'
+      end
     end
   end
 end

--- a/lib/generators/spree_cm_commissioner/install/templates/vendor/assets/javascript/spree_cm_commissioner/telegram/all.js
+++ b/lib/generators/spree_cm_commissioner/install/templates/vendor/assets/javascript/spree_cm_commissioner/telegram/all.js
@@ -1,0 +1,8 @@
+// This is a manifest file that'll be compiled into including all the files listed below.
+// Add new JavaScript/Coffee code in separate files in this directory and they'll automatically
+// be included in the compiled file accessible from http://example.com/assets/application.js
+// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
+// the compiled file.
+//
+//= require spree_cm_commissioner/telegram
+//= require_tree .

--- a/lib/generators/spree_cm_commissioner/install/templates/vendor/assets/stylesheets/spree_cm_commissioner/telegram/all.css
+++ b/lib/generators/spree_cm_commissioner/install/templates/vendor/assets/stylesheets/spree_cm_commissioner/telegram/all.css
@@ -1,0 +1,9 @@
+/*
+ * This is a manifest file that'll automatically include all the stylesheets available in this directory
+ * and any sub-directories. You're free to add application-wide styles to this file and they'll appear at
+ * the top of the compiled file, but it's generally better to create a new file per style scope.
+ *
+ *= require spree_cm_commissioner/telegram
+ *= require_self
+ *= require_tree .
+*/

--- a/lib/spree_cm_commissioner/test_helper/factories/user_identity_provider_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/user_identity_provider_factory.rb
@@ -3,5 +3,9 @@ FactoryBot.define do
     sequence(:sub) { |n| "sub-#{n}" }
     identity_type { SpreeCmCommissioner::UserIdentityProvider.identity_types[:google] }
     email { 'fake@example.com' }
+
+    trait :telegram do
+      identity_type { SpreeCmCommissioner::UserIdentityProvider.identity_types[:telegram] }
+    end
   end
 end

--- a/spec/interactors/spree_cm_commissioner/telegram_web_app_init_data_validator_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/telegram_web_app_init_data_validator_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::TelegramWebAppInitDataValidator do
+  let(:bot_token) { '6453379064:AAF8ISKbrDljptn6r5lMRj2Ben_s_ASmnnE' }
+  let(:wrong_bot_token) { 'invalid-bot-token' }
+
+  describe '.call' do
+    context 'inline web bot (eg. https://t.me/contigoasiabot)' do
+      let(:telegram_init_data) { 'user=%7B%22id%22%3A1029000609%2C%22first_name%22%3A%22Spooky%22%2C%22last_name%22%3A%22%22%2C%22username%22%3A%22theacontigo%22%2C%22language_code%22%3A%22en%22%2C%22allows_write_to_pm%22%3Atrue%7D&chat_instance=6719130073186955468&chat_type=private&auth_date=1692617684&hash=9c467fcab396b22e3670698cbb3cc9e7e486ce224c72c993ae295507a29f67bd' }
+
+      it 'verified that data is from Telegram' do
+        context = described_class.call(telegram_init_data: telegram_init_data, bot_token: bot_token)
+        expect(context.success?).to be true
+      end
+
+      it 'could not verify that data is from Telegram' do
+        context = described_class.call(telegram_init_data: telegram_init_data, bot_token: wrong_bot_token)
+        expect(context.success?).to be false
+      end
+
+      it 'decoded telegram data whether it verified or not' do
+        context1 = described_class.call(telegram_init_data: telegram_init_data, bot_token: bot_token)
+        context2 = described_class.call(telegram_init_data: telegram_init_data, bot_token: wrong_bot_token)
+
+        expect(context1.decoded_telegram_init_data).to eq context2.decoded_telegram_init_data
+        expect(context1.decoded_telegram_init_data).to eq ({
+          "user"=>"{\"id\":1029000609,\"first_name\":\"Spooky\",\"last_name\":\"\",\"username\":\"theacontigo\",\"language_code\":\"en\",\"allows_write_to_pm\":true}",
+          "chat_instance"=>"6719130073186955468",
+          "chat_type"=>"private",
+          "auth_date"=>"1692617684",
+          "hash"=>"9c467fcab396b22e3670698cbb3cc9e7e486ce224c72c993ae295507a29f67bd"
+        })
+      end
+    end
+
+    context 'web bot (user open web bot via telegram link: https://t.me/contigoasiabot/contigo)' do
+      let(:telegram_init_data) { 'query_id=AAGhTVU9AAAAAKFNVT3HP4z4&user=%7B%22id%22%3A1029000609%2C%22first_name%22%3A%22Spooky%22%2C%22last_name%22%3A%22%22%2C%22username%22%3A%22theacontigo%22%2C%22language_code%22%3A%22en%22%2C%22allows_write_to_pm%22%3Atrue%7D&auth_date=1692617748&hash=e8ac0a19b0ec35dcce16e0788115cbec1ec1e38fd30c60ca9459246d1c1450ea' }
+
+      it 'verified that data is from Telegram' do
+        context = described_class.call(telegram_init_data: telegram_init_data, bot_token: bot_token)
+
+        expect(context.success?).to be true
+      end
+
+      it 'could not verify that data is from Telegram when input wrong bot token' do
+        context = described_class.call(telegram_init_data: telegram_init_data, bot_token: wrong_bot_token)
+
+        expect(context.success?).to be false
+      end
+
+      it 'decoded telegram data whether it verified or not' do
+        context1 = described_class.call(telegram_init_data: telegram_init_data, bot_token: bot_token)
+        context2 = described_class.call(telegram_init_data: telegram_init_data, bot_token: wrong_bot_token)
+
+        expect(context1.decoded_telegram_init_data).to eq context2.decoded_telegram_init_data
+        expect(context1.decoded_telegram_init_data).to eq ({
+          "query_id"=>"AAGhTVU9AAAAAKFNVT3HP4z4",
+          "user"=>"{\"id\":1029000609,\"first_name\":\"Spooky\",\"last_name\":\"\",\"username\":\"theacontigo\",\"language_code\":\"en\",\"allows_write_to_pm\":true}",
+          "auth_date"=>"1692617748",
+          "hash"=>"e8ac0a19b0ec35dcce16e0788115cbec1ec1e38fd30c60ca9459246d1c1450ea"
+        })
+      end
+    end
+  end
+end

--- a/spec/interactors/spree_cm_commissioner/telegram_web_app_vendor_user_authorizer_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/telegram_web_app_vendor_user_authorizer_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::TelegramWebAppVendorUserAuthorizer do
+  let(:bot_token) { '6453379064:AAF8ISKbrDljptn6r5lMRj2Ben_s_ASmnnE' }
+  let(:wrong_bot_token) { 'invalid-bot-token' }
+  let(:telegram_init_data) { 'user=%7B%22id%22%3A1029000609%2C%22first_name%22%3A%22Spooky%22%2C%22last_name%22%3A%22%22%2C%22username%22%3A%22theacontigo%22%2C%22language_code%22%3A%22en%22%2C%22allows_write_to_pm%22%3Atrue%7D&chat_instance=6719130073186955468&chat_type=private&auth_date=1692617684&hash=9c467fcab396b22e3670698cbb3cc9e7e486ce224c72c993ae295507a29f67bd' }
+
+  let(:vendor) { build(:vendor) }
+  let(:provider) { build(:user_identity_provider, :telegram, sub: '1029000609') }
+
+  describe '.call' do
+    it 'failed when could not validated telegram init data' do
+      context = described_class.call(telegram_init_data: telegram_init_data, bot_token: wrong_bot_token)
+
+      expect(context.success?).to be false
+      expect(context.message).to eq "Could not verify hash"
+    end
+
+    it 'failed when could not find connected user' do
+      context = described_class.call(telegram_init_data: telegram_init_data, bot_token: bot_token)
+
+      expect(context.success?).to be false
+      expect(context.message).to eq "Could not find connected user"
+    end
+
+    it 'failed when connected user is not vendor user' do
+      user = create(:user, user_identity_providers: [provider])
+      context = described_class.call(telegram_init_data: telegram_init_data, bot_token: bot_token)
+
+      expect(context.success?).to be false
+      expect(context.message).to eq "You're not a vendor user"
+    end
+
+    it 'success when validated telegram data & found connected vendor user' do
+      user = create(:user, user_identity_providers: [provider], vendors: [vendor])
+      context = described_class.call(telegram_init_data: telegram_init_data, bot_token: bot_token)
+
+      expect(context.success?).to be true
+      expect(context.user.vendors.size).to eq 1
+      expect(context.decoded_telegram_user_id).to eq 1029000609
+    end
+  end
+end

--- a/spec/interactors/spree_cm_commissioner/telegram_web_app_vendor_user_checker_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/telegram_web_app_vendor_user_checker_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::TelegramWebAppVendorUserChecker do
+  let(:vendor) { build(:vendor) }
+  let(:provider) { build(:user_identity_provider, :telegram, sub: '1029000609') }
+
+  describe '.call' do
+    let(:telegram_init_data) { 'user=%7B%22id%22%3A1029000609%2C%22first_name%22%3A%22Spooky%22%2C%22last_name%22%3A%22%22%2C%22username%22%3A%22theacontigo%22%2C%22language_code%22%3A%22en%22%2C%22allows_write_to_pm%22%3Atrue%7D&chat_instance=6719130073186955468&chat_type=private&auth_date=1692617684&hash=9c467fcab396b22e3670698cbb3cc9e7e486ce224c72c993ae295507a29f67bd' }
+    let(:decoded_telegram_init_data) { Rack::Utils.parse_nested_query(telegram_init_data).to_h }
+
+    it 'failed when could not found user that connect with decoded_telegram_user_id' do
+      context = described_class.call(decoded_telegram_init_data: decoded_telegram_init_data)
+
+      expect(context.success?).to be false
+      expect(context.message).to eq "Could not find connected user"
+    end
+
+    it 'failed when found connected user but user is not vendor user' do
+      user = create(:user, user_identity_providers: [provider])
+      context = described_class.call(decoded_telegram_init_data: decoded_telegram_init_data)
+
+      expect(context.success?).to be false
+      expect(context.user).to eq user
+      expect(context.message).to eq "You're not a vendor user"
+    end
+
+    it 'success when found connected user & is a vendor user' do
+      user = create(:user, user_identity_providers: [provider], vendors: [vendor])
+      context = described_class.call(decoded_telegram_init_data: decoded_telegram_init_data)
+
+      expect(context.success?).to be true
+      expect(context.user.vendors.size).to eq 1
+      expect(context.decoded_telegram_user_id).to eq 1029000609
+    end
+  end
+end


### PR DESCRIPTION
## Scope
- [x] Create new /telegram scope for telegram bot
- [x] Create view order page with confirm & reject button
- [x] On confirm or reject, we create telegram data validator to validate telegram data (verify hash)
  - When validate, we find with telegram user id is connect to any vendor user
  - Only vendor user can approve or reject

Note: 
- When click on reject, we use order.cancel which is not really an reject.
  - When click on confirm, we just call order.approve which is for admin.
  - We will need another PR to enhance it.
- No telegram bot or push notification included, I just create the page and view it manually on telegram. Next scope will be push notification to vendor (I'll move to work on ticket for now as it more priority)

## Demo
### 1. Approve
https://github.com/channainfo/commissioner/assets/29684683/b979f7cd-cd05-4d6e-863d-7454f8023ce4

### 2. Cancel
https://github.com/channainfo/commissioner/assets/29684683/74f42472-7700-44e5-b510-fb0b9af21b21

## References
- https://core.telegram.org/bots/webapps#validating-data-received-via-the-web-app