### PR TITLE
close #540 fix inconsistent pin_code_token and pin_code name

### DIFF
--- a/app/controllers/spree/api/v2/storefront/pin_code_checkers_controller.rb
+++ b/app/controllers/spree/api/v2/storefront/pin_code_checkers_controller.rb
@@ -15,7 +15,7 @@ module Spree
           private
 
           def pin_code_attrs
-            results = params.slice(:id, :phone_number, :email, :code, :type)
+            results = params.slice(:phone_number, :email, :token, :pin_code, :pin_code_token, :type)
             results[:long_life_pin_code] = true
             results
           end

--- a/app/interactors/spree_cm_commissioner/pin_code_checker.rb
+++ b/app/interactors/spree_cm_commissioner/pin_code_checker.rb
@@ -2,7 +2,17 @@ module SpreeCmCommissioner
   class PinCodeChecker < BaseInteractor
     def call
       pin_coder = context.type.constantize
-      options = context.to_h.slice(:id, :code, :email, :phone_number, :type, :long_life_pin_code, :user_validation_check, :country_code)
+      options = context.to_h.slice(
+        :pin_code_token,
+        :pin_code,
+        :email,
+        :phone_number,
+        :type,
+        :long_life_pin_code,
+        :user_validation_check,
+        :country_code
+      )
+
       @result = pin_coder.check?(options)
 
       return unless @result != 'ok'

--- a/app/interactors/spree_cm_commissioner/user_pin_code_authenticator.rb
+++ b/app/interactors/spree_cm_commissioner/user_pin_code_authenticator.rb
@@ -12,7 +12,9 @@ module SpreeCmCommissioner
 
     def validate_pin_code!
       options = context.to_h.slice(:email, :phone_number)
-      options[:code] = context.pin_code
+
+      options[:pin_code] = context.pin_code
+      options[:pin_code_token] = context.pin_code_token
       options[:id] = context.pin_code_token
       options[:type] = 'SpreeCmCommissioner::PinCodeRegistration'
       options[:long_life_pin_code] = true

--- a/app/models/spree_cm_commissioner/pin_code.rb
+++ b/app/models/spree_cm_commissioner/pin_code.rb
@@ -79,7 +79,7 @@ module SpreeCmCommissioner
     end
 
     def self.check?(options)
-      pin_code = find_by(token: options[:id])
+      pin_code = find_by(token: options[:pin_code_token])
 
       return PIN_CODE_NOT_FOUND if pin_code.nil?
 
@@ -90,7 +90,7 @@ module SpreeCmCommissioner
       end
 
       pin_code.long_life_pin_code = options[:long_life_pin_code]
-      pin_code.check?(options[:code])
+      pin_code.check?(options[:pin_code])
     end
 
     def max_attempt_allowed

--- a/spec/interactors/spree_cm_commissioner/pin_code_checker_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/pin_code_checker_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe SpreeCmCommissioner::PinCodeChecker do
   context 'when the given info is matched with the pin code' do
     it 'return ok' do
       options = {
-        id: pin_code.token,
+        pin_code_token: pin_code.token,
         phone_number: '0123456789',
-        code: pin_code.code,
+        pin_code: pin_code.code,
         type: 'SpreeCmCommissioner::PinCodeLogin',
         long_life_pin_code: true
       }
@@ -23,9 +23,9 @@ RSpec.describe SpreeCmCommissioner::PinCodeChecker do
   context 'when the given type is not correct' do
     it 'return not_found' do
       options = {
-        id: pin_code.token ,
+        pin_code_token: pin_code.token ,
         phone_number: '0123456789',
-        code: pin_code.code,
+        pin_code: pin_code.code,
         type: 'SpreeCmCommissioner::PinCodeRegistration',
         long_life_pin_code: true
       }
@@ -40,9 +40,9 @@ RSpec.describe SpreeCmCommissioner::PinCodeChecker do
   context 'when pin code is expired' do
     it 'return expired' do
       options = {
-        id: pin_code.token,
+        pin_code_token: pin_code.token,
         phone_number: '0123456789',
-        code: pin_code.code,
+        pin_code: pin_code.code,
         type: 'SpreeCmCommissioner::PinCodeLogin',
         long_life_pin_code: true
       }
@@ -58,9 +58,9 @@ RSpec.describe SpreeCmCommissioner::PinCodeChecker do
   context 'when pin code reach max attempt allowed (3 times)' do
     it 'return reached_max_attempt' do
       options = {
-        id: pin_code.token,
+        pin_code_token: pin_code.token,
         phone_number: '0123456789',
-        code: pin_code.code,
+        pin_code: pin_code.code,
         type: 'SpreeCmCommissioner::PinCodeLogin',
         long_life_pin_code: true
       }
@@ -78,9 +78,9 @@ RSpec.describe SpreeCmCommissioner::PinCodeChecker do
   context 'when the given code is not matched' do
     it 'return not_match' do
       options = {
-        id: pin_code.token,
+        pin_code_token: pin_code.token,
         phone_number: '0123456789',
-        code: '000001',
+        pin_code: '000001',
         type: 'SpreeCmCommissioner::PinCodeLogin',
         long_life_pin_code: true
       }

--- a/spec/request/spree/api/v2/controller/pin_code_checkers_controller_spec.rb
+++ b/spec/request/spree/api/v2/controller/pin_code_checkers_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Spree::Api::V2::Storefront::PinCodeCheckersController, type: :con
     it 'return status ok' do
       set_application_token
 
-      post :update, params: { id: pin_code.token, email: 'panhachom@gmail.com', code: pin_code.code,
+      post :update, params: { pin_code_token: pin_code.token, email: 'panhachom@gmail.com', pin_code: pin_code.code,
                      type: 'SpreeCmCommissioner::PinCodeLogin' }
 
       expect(response.status).to eq 200
@@ -22,7 +22,7 @@ RSpec.describe Spree::Api::V2::Storefront::PinCodeCheckersController, type: :con
       set_application_token
 
       post :update,
-           params: { id: pin_code.token, email: 'panhachom@gmail.com', code: '134122',
+           params: { pin_code_token: pin_code.token, email: 'panhachom@gmail.com', pin_code: '134122',
                      type: 'SpreeCmCommissioner::PinCodeLogin' }
 
       expect(response.status).to eq 400


### PR DESCRIPTION
For consistency and to avoid confuse API user:
- Rename from id to pin_code_token if not yet renamed
- Rename from code to pin_code if not yet renamed

Sign up with phone is ready, we only need to connect to Twillo or Plastgate.