### PR TITLE
 close #542 rename vendor state to default state to avoid confusion, add to serializer

### DIFF
--- a/app/models/spree_cm_commissioner/state_decorator.rb
+++ b/app/models/spree_cm_commissioner/state_decorator.rb
@@ -1,7 +1,7 @@
 module SpreeCmCommissioner
   module StateDecorator
     def self.prepended(base)
-      base.has_many :vendors
+      base.has_many :vendors, foreign_key: 'default_state_id', class_name: 'Spree::Vendor', inverse_of: :default_state, dependent: :nullify
 
       def update_total_inventory
         update(total_inventory: vendors.pluck(:total_inventory).sum)

--- a/app/models/spree_cm_commissioner/vendor_decorator.rb
+++ b/app/models/spree_cm_commissioner/vendor_decorator.rb
@@ -35,6 +35,8 @@ module SpreeCmCommissioner
       base.has_one  :app_promotion_banner, as: :viewable, dependent: :destroy, class_name: 'SpreeCmCommissioner::VendorAppPromotionBanner'
       base.has_one :stock_location, -> { where(active: true) }, class_name: 'Spree::StockLocation', dependent: :destroy
 
+      base.belongs_to :default_state, class_name: 'Spree::State', inverse_of: :vendors
+
       base.delegate :lat, :lon, to: :stock_location, allow_nil: true
 
       base.after_save :update_state_total_inventory, if: :saved_change_to_total_inventory?
@@ -110,11 +112,11 @@ module SpreeCmCommissioner
       end
 
       def update_location
-        update(state_id: stock_locations.first&.state_id)
+        update(default_state_id: stock_locations.first&.state_id)
       end
 
       def update_state_total_inventory
-        SpreeCmCommissioner::StateJob.perform_later(state_id) unless state_id.nil?
+        SpreeCmCommissioner::StateJob.perform_later(default_state_id) unless default_state_id.nil?
       end
     end
 

--- a/app/queries/spree_cm_commissioner/accommodation_query.rb
+++ b/app/queries/spree_cm_commissioner/accommodation_query.rb
@@ -53,7 +53,7 @@ module SpreeCmCommissioner
     end
 
     def apply_filter(scope)
-      scope = scope.where(spree_vendors: { state_id: province_id }) if province_id.present?
+      scope = scope.where(spree_vendors: { default_state_id: province_id }) if province_id.present?
       scope = scope.where(spree_vendors: { id: vendor_id }) if vendor_id.present?
       scope
     end

--- a/app/serializers/spree/v2/storefront/accommodation_serializer.rb
+++ b/app/serializers/spree/v2/storefront/accommodation_serializer.rb
@@ -7,7 +7,7 @@ module Spree
         # because its model still Spree::Vendor
         set_type :vendor
 
-        has_one :state
+        has_one :default_state, serializer: :state
 
         attributes :total_inventory, :service_availabilities
 

--- a/app/serializers/spree/v2/storefront/option_value_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/option_value_serializer_decorator.rb
@@ -8,6 +8,8 @@ module Spree
         def self.prepended(base)
           base.attribute :display_icon do |option_value|
             ActionController::Base.helpers.image_url(option_value.display_icon)
+          rescue StandardError
+            nil
           end
         end
       end

--- a/app/serializers/spree/v2/storefront/stock_location_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/stock_location_serializer_decorator.rb
@@ -4,6 +4,8 @@ module Spree
       module StockLocationSerializerDecorator
         def self.prepended(base)
           base.attributes :lat, :lon, :name, :address1, :reference
+
+          base.has_one :state
         end
       end
     end

--- a/db/migrate/20230905090812_rename_spree_vendors_state_id_column_to_default_state_id.rb
+++ b/db/migrate/20230905090812_rename_spree_vendors_state_id_column_to_default_state_id.rb
@@ -1,0 +1,5 @@
+class RenameSpreeVendorsStateIdColumnToDefaultStateId < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :spree_vendors, :state_id, :default_state_id
+  end
+end

--- a/lib/spree_cm_commissioner/test_helper/factories/vendor_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/vendor_factory.rb
@@ -1,16 +1,16 @@
 FactoryBot.define do
   factory :cm_vendor, parent: :vendor do
     state { :active }
+    default_state_id { Spree::State.first&.id }
 
     transient do
-      state_id { Spree::State.first&.id }
       with_logo { false }
     end
 
     # create a stock_location with the same name as the vendor
     after :build do |vendor, evaluator|
-      state_id ||= create(:state).id
-      stock_location = Spree::StockLocation.find_by(name: vendor.name) || build(:cm_stock_location, name: vendor.name, state_id: evaluator.state_id,
+      vendor.default_state_id ||= create(:state).id
+      stock_location = Spree::StockLocation.find_by(name: vendor.name) || build(:cm_stock_location, name: vendor.name, state_id: vendor.default_state_id,
                                                                                                     vendor: vendor
       )
       vendor.stock_locations = [stock_location]

--- a/spec/interactors/spree_cm_commissioner/accommodation_search_detail_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/accommodation_search_detail_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 RSpec.describe SpreeCmCommissioner::AccommodationSearchDetail do
   let(:phnom_penh) { create(:state, name: 'Phnom Penh') }
   let(:siem_reap) { create(:state, name: 'Siem Reap') }
-  let!(:phnom_penh_hotel) { create(:cm_vendor_with_product, name: 'Phnom Penh Hotel', state_id: phnom_penh.id, permanent_stock: 10) }
-  let!(:sokha_pp_hotel) { create(:cm_vendor_with_product, name: 'Sokha Phnom Penh Hotel', state_id: phnom_penh.id, permanent_stock: 20) }
-  let!(:angkor_hotel) { create(:cm_vendor_with_product, name: 'Angkor Hotel', state_id: siem_reap.id, permanent_stock: 15) }
+  let!(:phnom_penh_hotel) { create(:cm_vendor_with_product, name: 'Phnom Penh Hotel', default_state_id: phnom_penh.id, permanent_stock: 10) }
+  let!(:sokha_pp_hotel) { create(:cm_vendor_with_product, name: 'Sokha Phnom Penh Hotel', default_state_id: phnom_penh.id, permanent_stock: 20) }
+  let!(:angkor_hotel) { create(:cm_vendor_with_product, name: 'Angkor Hotel', default_state_id: siem_reap.id, permanent_stock: 15) }
   let(:passenger_options) { SpreeCmCommissioner::PassengerOption.new(adult: 2, children: 1, room_qty: 1) }
 
   context '.call' do

--- a/spec/interactors/spree_cm_commissioner/state_updater_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/state_updater_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 RSpec.describe SpreeCmCommissioner::StateUpdater do
   describe '.call' do
     let(:state) {create(:state, total_inventory: 0)}
-    let!(:angkor_hotel) { create(:cm_vendor, name: 'Angkor Hotel', state_id: state.id, total_inventory: 3) }
-    let!(:sokha_pp_hotel) { create(:cm_vendor, name: 'Sokha Phnom Penh Hotel', state_id: state.id, total_inventory: 2) }
+    let!(:angkor_hotel) { create(:cm_vendor, name: 'Angkor Hotel', default_state_id: state.id, total_inventory: 3) }
+    let!(:sokha_pp_hotel) { create(:cm_vendor, name: 'Sokha Phnom Penh Hotel', default_state_id: state.id, total_inventory: 2) }
 
     it 'update state total inventory' do
       context = SpreeCmCommissioner::StateUpdater.call(state: state)

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe Spree::LineItem, type: :model do
   describe '#callback before_save' do
     let(:phnom_penh) { create(:state, name: 'Phnom Penh') }
-    let!(:vendor) { create(:cm_vendor_with_product, name: 'Phnom Penh Hotel', state_id: phnom_penh.id) }
+    let!(:vendor) { create(:cm_vendor_with_product, name: 'Phnom Penh Hotel', default_state_id: phnom_penh.id) }
     let!(:variant) { vendor.variants.first }
     let!(:order) { create(:order) }
     let(:line_item) { order.line_items.build(variant_id: variant.id) }

--- a/spec/models/spree/state_spec.rb
+++ b/spec/models/spree/state_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Spree::State, type: :model do
 
   describe 'callbacks' do
     let(:state) { create(:state, total_inventory: 0) }
-    let(:vendor) { create(:cm_vendor, state_id: state.id, total_inventory: 0) }
+    let(:vendor) { create(:cm_vendor, default_state_id: state.id, total_inventory: 0) }
 
     it 'updates state when vendor total_inventory are changed' do
       perform_enqueued_jobs do

--- a/spec/models/spree/stock_location_spec.rb
+++ b/spec/models/spree/stock_location_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe Spree::StockLocation, type: :model do
   describe '#callback after_commit' do
     let(:phnom_penh) { create(:state, name: 'Phnom Penh') }
     let(:siem_reap) { create(:state, name: 'Siem Reap') }
-    let!(:vendor) { create(:cm_vendor_with_product, name: 'Phnom Penh Hotel', state_id: phnom_penh.id) }
+    let!(:vendor) { create(:cm_vendor_with_product, name: 'Phnom Penh Hotel', default_state_id: phnom_penh.id) }
     let!(:stock_location) { vendor.stock_locations.first }
 
     context '#update_vendor_location' do
       it 'should update vendor state_id' do
         stock_location.update(state_id: siem_reap.id)
-        expect(vendor.state_id).to eq siem_reap.id
+        expect(vendor.default_state_id).to eq siem_reap.id
       end
     end
   end

--- a/spec/models/spree/vendor_spec.rb
+++ b/spec/models/spree/vendor_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Spree::Vendor, type: :model do
   describe '#update' do
     let(:phnom_penh) { create(:state, name: 'Phnom Penh') }
     let(:siem_reap) { create(:state, name: 'Siem Reap') }
-    let!(:vendor) { create(:vendor, total_inventory: 0, state_id: phnom_penh.id)  }
+    let!(:vendor) { create(:vendor, total_inventory: 0, default_state_id: phnom_penh.id)  }
     let!(:stock_location) { vendor.stock_locations.first }
     let!(:product1) { create(:product, vendor: vendor)}
     let!(:product2) { create(:product, vendor: vendor)}
@@ -114,7 +114,7 @@ RSpec.describe Spree::Vendor, type: :model do
         stock_location.update(state_id: siem_reap.id)
 
         subject { vendor.update_location }
-        expect(vendor.state_id).to eq siem_reap.id
+        expect(vendor.default_state_id).to eq siem_reap.id
       end
     end
   end

--- a/spec/models/spree_cm_commissioner/promotion/rules/fixed_date_spec.rb
+++ b/spec/models/spree_cm_commissioner/promotion/rules/fixed_date_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SpreeCmCommissioner::Promotion::Rules::FixedDate do
     it 'applicable when any of line items has date range present?' do
       subject = described_class.new
 
-      expect(subject.applicable?(line_item_10_to_12.order))
+      expect(subject.applicable?(line_item_10_to_12.order.reload))
       expect(order.line_items.any?(&:date_present?)).to be true
     end
   end

--- a/spec/queries/spree_cm_commissioner/accommodation_query_spec.rb
+++ b/spec/queries/spree_cm_commissioner/accommodation_query_spec.rb
@@ -3,10 +3,10 @@ require 'spec_helper'
 RSpec.describe SpreeCmCommissioner::AccommodationQuery do
   let(:phnom_penh) { create(:state, name: 'Phnom Penh') }
   let(:siem_reap)  { create(:state, name: 'Siem Reap') }
-  let!(:phnom_penh_hotel) { create(:cm_vendor_with_product, name: 'Phnom Penh Hotel',       state_id: phnom_penh.id, permanent_stock: 20) }
-  let!(:sokha_pp_hotel)   { create(:cm_vendor_with_product, name: 'Sokha Phnom Penh Hotel', state_id: phnom_penh.id, permanent_stock: 20) }
-  let!(:angkor_hotel)     { create(:cm_vendor_with_product, name: 'Angkor Hotel',           state_id: siem_reap.id,  permanent_stock: 20) }
-  let!(:siemreap_hotel)   { create(:cm_vendor_with_product, name: 'Siem Reap Hotel',        state_id: siem_reap.id,  permanent_stock: 20) }
+  let!(:phnom_penh_hotel) { create(:cm_vendor_with_product, name: 'Phnom Penh Hotel',       default_state_id: phnom_penh.id, permanent_stock: 20) }
+  let!(:sokha_pp_hotel)   { create(:cm_vendor_with_product, name: 'Sokha Phnom Penh Hotel', default_state_id: phnom_penh.id, permanent_stock: 20) }
+  let!(:angkor_hotel)     { create(:cm_vendor_with_product, name: 'Angkor Hotel',           default_state_id: siem_reap.id,  permanent_stock: 20) }
+  let!(:siemreap_hotel)   { create(:cm_vendor_with_product, name: 'Siem Reap Hotel',        default_state_id: siem_reap.id,  permanent_stock: 20) }
   let(:order1) { create(:order) }
   let(:order2) { create(:order) }
   let(:booking_fields)   { [:vendor_id, :day, :total_booking] }

--- a/spec/request/spree/api/v2/accommodations_spec.rb
+++ b/spec/request/spree/api/v2/accommodations_spec.rb
@@ -6,9 +6,9 @@ describe 'API V2 Storefront Accommodation Spec', type: :request do
 
   let(:phnom_penh) { create(:state, name: 'Phnom Penh') }
   let(:siem_reap)  { create(:state, name: 'Siem Reap') }
-  let!(:phnom_penh_hotel) { create(:cm_vendor_with_product, name: 'Phnom Penh Hotel',       state_id: phnom_penh.id, permanent_stock: 10) }
-  let!(:sokha_pp_hotel)   { create(:cm_vendor_with_product, name: 'Sokha Phnom Penh Hotel', state_id: phnom_penh.id, permanent_stock: 20) }
-  let!(:angkor_hotel)     { create(:cm_vendor_with_product, name: 'Angkor Hotel',           state_id: siem_reap.id,  permanent_stock: 15) }
+  let!(:phnom_penh_hotel) { create(:cm_vendor_with_product, name: 'Phnom Penh Hotel',       default_state_id: phnom_penh.id, permanent_stock: 10) }
+  let!(:sokha_pp_hotel)   { create(:cm_vendor_with_product, name: 'Sokha Phnom Penh Hotel', default_state_id: phnom_penh.id, permanent_stock: 20) }
+  let!(:angkor_hotel)     { create(:cm_vendor_with_product, name: 'Angkor Hotel',           default_state_id: siem_reap.id,  permanent_stock: 15) }
   let(:params) {
     { from_date: next_month, to_date: next_month + 2.days, province_id: phnom_penh.id, adult: 2, children: 1, room_qty: 1 }
   }

--- a/spec/request/spree/api/v2/nearby_places_spec.rb
+++ b/spec/request/spree/api/v2/nearby_places_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe 'API V2 Storefront Nearby Places Spec', type: :request do
   let(:place) { create(:cm_place) }
   let(:phnom_penh) { create(:state, name: 'Phnom Penh') }
-  let!(:phnom_penh_hotel) { create(:cm_vendor_with_product, name: 'Phnom Penh Hotel', state_id: phnom_penh.id) }
-  let!(:sokha_pp_hotel)   { create(:cm_vendor_with_product, name: 'Sokha Phnom Penh Hotel', state_id: phnom_penh.id, permanent_stock: 20) }
+  let!(:phnom_penh_hotel) { create(:cm_vendor_with_product, name: 'Phnom Penh Hotel', default_state_id: phnom_penh.id) }
+  let!(:sokha_pp_hotel)   { create(:cm_vendor_with_product, name: 'Sokha Phnom Penh Hotel', default_state_id: phnom_penh.id, permanent_stock: 20) }
 
   let(:json_response) { JSON.parse(response.body) }
 

--- a/spec/serializers/spree/v2/storefront/accommodation_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/accommodation_serializer_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Spree::V2::Storefront::AccommodationSerializer, type: :serializer
         :vendor_kind_option_values,
         :active_promotions,
         :logo,
+        :default_state,
       ]).serializable_hash
     }
 
@@ -57,7 +58,7 @@ RSpec.describe Spree::V2::Storefront::AccommodationSerializer, type: :serializer
         :vendor_kind_option_values,
         :active_promotions,
         :logo,
-        :state
+        :default_state
       )
     end
   end

--- a/spec/serializers/spree/v2/storefront/stock_location_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/stock_location_serializer_spec.rb
@@ -22,7 +22,8 @@ describe Spree::V2::Storefront::StockLocationSerializer, type: :serializer do
 
     it 'returns exact relationships' do
       expect(subject[:data][:relationships].keys).to contain_exactly(
-        :vendor
+        :vendor,
+        :state
       )
     end
   end


### PR DESCRIPTION
1. In vendor, rename vendor.state_id to vendor.defaut_state_id to avoid with vendor.state (active, blocked,...)
2. Add default_state to accommodation serializer
3. Add state to stock location serializer
4. Fix bug on option value serializer when no asset or asset failed to load