### PR TITLE
close #560 refactor order webhook request body

### DIFF
--- a/app/models/spree_cm_commissioner/order_decorator.rb
+++ b/app/models/spree_cm_commissioner/order_decorator.rb
@@ -61,6 +61,14 @@ module SpreeCmCommissioner
 
     private
 
+    # override :spree_api
+    def webhook_payload_body
+      resource_serializer.new(
+        self,
+        include: included_relationships.reject { |e| %i[shipments state_changes].include?(e) }
+      ).serializable_hash.to_json
+    end
+
     def link_by_phone_number
       return if phone_number.present?
 

--- a/app/serializers/concerns/spree_cm_commissioner/api/v2/resource_serializer_concern_decorator.rb
+++ b/app/serializers/concerns/spree_cm_commissioner/api/v2/resource_serializer_concern_decorator.rb
@@ -1,0 +1,30 @@
+module SpreeCmCommissioner
+  module Api
+    module V2
+      module ResourceSerializerConcernDecorator
+        def self.prepended(base)
+          def base.display_getter_methods(model_klazz)
+            model_klazz.new.methods.find_all do |method_name|
+              next unless method_name.to_s.start_with?('display_')
+              next if method_name.to_s.end_with?('=')
+              next if [Spree::Product, Spree::Variant].include?(model_klazz) && method_name == :display_amount
+
+              # commissioner:
+              # Skip 'display_vendor_' to not dynamic load 'display_vendor_' methods as attributes.
+              #
+              # In spree_multi_vendor, 'display_vendor_..' methods required :vendor args
+              # while default attributes of spree_api does not provide that which cause error when serialize for PlatformApis & Webhook
+              next if method_name.to_s.start_with?('display_vendor')
+
+              method_name
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+unless Spree::Api::V2::ResourceSerializerConcern.included_modules.include?(SpreeCmCommissioner::Api::V2::ResourceSerializerConcernDecorator)
+  Spree::Api::V2::ResourceSerializerConcern.prepend(SpreeCmCommissioner::Api::V2::ResourceSerializerConcernDecorator)
+end


### PR DESCRIPTION
- Exclude 'shipments, state_changes' from the default webhook order serializer
- Fix platform serializers errors caused by new methods of spree_multi_vendor and spree_api doesn't recognize that.