### PR TITLE
close #567 add default state to product

### DIFF
--- a/app/models/spree_cm_commissioner/product_decorator.rb
+++ b/app/models/spree_cm_commissioner/product_decorator.rb
@@ -17,6 +17,8 @@ module SpreeCmCommissioner
                                                 order('spree_variants.position, spree_variants.id, currency')
                                               }, source: :prices, through: :variants_including_master
 
+      base.has_one :default_state, through: :vendor
+
       base.scope :min_price, lambda { |vendor|
         joins(:prices_including_master)
           .where(vendor_id: vendor.id, product_type: vendor.primary_product_type)

--- a/app/serializers/spree/v2/storefront/product_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/product_serializer_decorator.rb
@@ -7,6 +7,8 @@ module Spree
           base.has_many :product_kind_option_types, serializer: :option_type
           base.has_many :promoted_option_types, serializer: :option_type
           base.has_many :possible_promotions, serializer: ::SpreeCmCommissioner::V2::Storefront::PromotionSerializer
+
+          base.has_one :default_state, serializer: :state
         end
       end
     end

--- a/spec/serializers/spree/v2/storefront/product_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/product_serializer_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Spree::V2::Storefront::ProductSerializer, type: :serializer do
         :variant_kind_option_types,
         :product_kind_option_types,
         :promoted_option_types,
-        :possible_promotions
+        :possible_promotions,
+        :default_state,
       ]).serializable_hash
     }
 
@@ -58,7 +59,8 @@ RSpec.describe Spree::V2::Storefront::ProductSerializer, type: :serializer do
         :variant_kind_option_types,
         :product_kind_option_types,
         :promoted_option_types,
-        :possible_promotions
+        :possible_promotions,
+        :default_state,
       )
     end
   end


### PR DESCRIPTION
Delegate default state from vendor to product. Its use case is on ticket view where we need to display ticket province in UI.