### PR TITLE
close #595 add user contacts controller update phone & email

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,7 @@ PATH
       byebug
       dry-validation (~> 1.10)
       elasticsearch (~> 8.5)
+      exception_notification
       font-awesome-sass (~> 6.4.0)
       googleauth
       interactor (~> 3.1)
@@ -55,6 +56,7 @@ PATH
       spree_backend (>= 4.5.0)
       spree_extension
       spree_multi_vendor (>= 2.4.0)
+      telegram-bot
       twilio-ruby (~> 5.48.0)
 
 GEM
@@ -298,6 +300,9 @@ GEM
     elasticsearch-api (8.9.0)
       multi_json
     erubi (1.12.0)
+    exception_notification (4.5.0)
+      actionmailer (>= 5.2, < 8)
+      activesupport (>= 5.2, < 8)
     execjs (2.8.1)
     factory_bot (4.11.1)
       activesupport (>= 3.0.0)
@@ -376,6 +381,7 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
+    httpclient (2.8.3)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -736,6 +742,10 @@ GEM
     stimulus-rails (1.2.2)
       railties (>= 6.0.0)
     stringex (2.8.6)
+    telegram-bot (0.15.7)
+      actionpack (>= 4.0, < 7.1)
+      activesupport (>= 4.0, < 7.1)
+      httpclient (~> 2.7)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.2)

--- a/app/controllers/spree/api/v2/storefront/user_contacts_controller.rb
+++ b/app/controllers/spree/api/v2/storefront/user_contacts_controller.rb
@@ -1,0 +1,34 @@
+module Spree
+  module Api
+    module V2
+      module Storefront
+        class UserContactsController < Spree::Api::V2::ResourceController
+          def update
+            options = user_with_pin_code_params
+
+            generator_context = ::SpreeCmCommissioner::UserContactUpdater.call(options)
+
+            if generator_context.success?
+              # head :ok
+              render_serialized_payload { serialize_resource(generator_context.user) }
+            else
+              render_error_payload(generator_context.message)
+            end
+          end
+
+          private
+
+          def user_with_pin_code_params
+            results = params.permit(:pin_code, :pin_code_token, :email, :phone_number)
+            results[:user] = spree_current_user
+            results.to_h
+          end
+
+          def resource_serializer
+            ::SpreeCmCommissioner::V2::Storefront::UserContactSerializer
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/interactors/spree_cm_commissioner/user_contact_updater.rb
+++ b/app/interactors/spree_cm_commissioner/user_contact_updater.rb
@@ -1,0 +1,49 @@
+module SpreeCmCommissioner
+  class UserContactUpdater < BaseInteractor
+    # :email, :phone_number, :pin_code, :pin_code_token, to: :context
+    def call
+      sanitize_contact
+      validate_pin_code!
+      update_user_contact!
+    end
+
+    private
+
+    def validate_pin_code!
+      options = context.to_h.slice(:email, :phone_number, :pin_code, :pin_code_token)
+      options[:type] = 'SpreeCmCommissioner::PinCodeContactUpdate'
+      options[:long_life_pin_code] = true
+
+      pin_code_checker = SpreeCmCommissioner::PinCodeChecker.call(options)
+
+      return if pin_code_checker.success?
+
+      context.fail!(message: pin_code_checker.message)
+    end
+
+    def update_user_contact!
+      ok = context.user.update(update_options)
+
+      if ok
+        SpreeCmCommissioner::PinCode.mark_expired!(context.pin_code_token)
+      else
+        field = context.email.present? ? 'email' : 'phone_number'
+        context.fail!(message: I18n.t("user_update_contact.#{field}_is_already_used"))
+      end
+    end
+
+    def update_options
+      # don't use context.email.present? since user might use validate pincode email
+      # however try to update phone number and viceversa
+      if context.email.present?
+        { email: context.email }
+      else
+        { phone_number: context.phone_number }
+      end
+    end
+
+    def sanitize_contact
+      context.email = nil if context.phone_number.present?
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/user_decorator.rb
+++ b/app/models/spree_cm_commissioner/user_decorator.rb
@@ -8,6 +8,7 @@ module SpreeCmCommissioner
       base.enum gender: %i[male female other]
 
       base.validates :email, presence: true, if: :email_required?
+      base.validates :phone_number, uniqueness: { allow_blank: true }
 
       base.has_many :user_identity_providers, dependent: :destroy, class_name: 'SpreeCmCommissioner::UserIdentityProvider'
       base.has_many :customers, class_name: 'SpreeCmCommissioner::Customer'

--- a/app/serializers/spree_cm_commissioner/v2/storefront/user_contact_serializer.rb
+++ b/app/serializers/spree_cm_commissioner/v2/storefront/user_contact_serializer.rb
@@ -1,0 +1,11 @@
+module SpreeCmCommissioner
+  module V2
+    module Storefront
+      class UserContactSerializer < BaseSerializer
+        set_type :user
+
+        attributes :email, :phone_number
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,10 @@ en:
     app_banner: App Banner (16x9)
     web_banner: Web banner (10x2)
 
+  user_update_contact:
+    phone_number_is_already_used: "Phone number is already used"
+    email_is_already_used: "Email is already used"
+
   calendar:
     event:
       empty_info: "No <b>Events</b> found."

--- a/config/locales/km.yml
+++ b/config/locales/km.yml
@@ -31,6 +31,10 @@ km:
     app_banner: App Banner (16x9)
     web_banner: Web banner (10x2)
 
+  user_update_contact:
+    phone_number_is_already_used: "លេខទូរស័ព្ធបានប្រើប្រាស់រួច"
+    email_is_already_used: "Email បានប្រើប្រាស់រួច"
+
   calendar:
     event:
       empty_info: "No <b>Events</b> found."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,6 +162,7 @@ Spree::Core::Engine.add_routes do
         resources :order_request_notifications, only: %i[index show]
 
         resources :customer_notifications, only: [:show]
+        resource :user_contacts, only: [:update]
         resource :user_registration_with_pin_codes, only: [:create]
         resources :user_device_token_registrations, only: %i[create destroy]
         resources :user_account_linkages, only: %i[index create destroy]

--- a/spec/interactors/spree_cm_commissioner/user_contact_updater_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/user_contact_updater_spec.rb
@@ -1,0 +1,112 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::UserContactUpdater do
+  let!(:user) { create(:user, phone_number: '012555555', email: 'user@example.com') }
+
+  describe '.call' do
+    context 'with a valid user' do
+      it 'updates phone_number' do
+        new_phone_number = '85512111222'
+        pin_code = create(:pin_code, :with_number, contact: new_phone_number,
+                                                            type: 'SpreeCmCommissioner::PinCodeContactUpdate')
+
+        context_update = described_class.call(
+          pin_code: pin_code.code,
+          pin_code_token: pin_code.token,
+          phone_number: new_phone_number,
+          user: user
+        )
+
+        expect(context_update.success?).to eq true
+        expect(user.reload.phone_number).to eq('012111222')
+      end
+
+      it 'updates email' do
+        new_email = 'new@example.com'
+        pin_code = create(:pin_code, :with_email, contact: new_email,
+                                                           type: 'SpreeCmCommissioner::PinCodeContactUpdate')
+        context_update = described_class.call(
+          pin_code: pin_code.code,
+          pin_code_token: pin_code.token,
+          email: new_email,
+          user: user
+        )
+
+        expect(context_update.success?).to eq true
+        expect(user.reload.email).to eq new_email
+      end
+    end
+
+    context 'Update invalid user' do
+      it 'updates invalid phone_number' do
+        pin_code = create(:pin_code, :with_number, contact: '012999001',
+                                                            type: 'SpreeCmCommissioner::PinCodeContactUpdate')
+        context_update = described_class.call(
+          pin_code: pin_code.code,
+          pin_code_token: pin_code.token,
+          phone_number: '012333555',
+          user: user
+        )
+
+        expect(context_update.success?).to eq false
+        expect(context_update.message).to eq 'Verification Code not found!'
+        expect(user.reload.phone_number).to eq('012555555')
+      end
+
+      it 'updates phone_number that is already in use' do
+        other_user_phone_number = '012111222'
+        other_user = create(:user, phone_number: other_user_phone_number, email: 'other@example.com')
+        pin_code = create(:pin_code, :with_number, contact: other_user_phone_number, type: 'SpreeCmCommissioner::PinCodeContactUpdate')
+
+        p other_user.reload.phone_number
+        p other_user.reload.intel_phone_number
+
+        context_update = described_class.call(
+          pin_code: pin_code.code,
+          pin_code_token: pin_code.token,
+          phone_number: other_user_phone_number,
+          user: user
+        )
+
+        expect(context_update.success?).to eq false
+        expect(context_update.message).to eq 'Phone number is already used'
+        expect(user.reload.phone_number).to eq('012555555')
+      end
+
+      it 'updates email that is already in use' do
+        other_user_email = 'other@example.com'
+        other_user = create(:user, phone_number: '012111222', email: other_user_email)
+        pin_code = create(:pin_code, :with_email, contact: other_user_email, type: 'SpreeCmCommissioner::PinCodeContactUpdate')
+
+        context_update = described_class.call(
+          pin_code: pin_code.code,
+          pin_code_token: pin_code.token,
+          email: other_user_email,
+          user: user
+        )
+
+        expect(context_update.success?).to eq false
+        expect(context_update.message).to eq 'Email is already used'
+        expect(user.reload.email).to eq('user@example.com')
+      end
+    end
+  end
+
+  describe '#sanitize_contact' do
+    it 'removes email if phone number exist' do
+      options = { email: 'joe@vtenh.com', phone_number: '012999888' }
+      registerer = described_class.new(options)
+      registerer.send(:sanitize_contact)
+
+      expect(registerer.context.email).to eq nil
+    end
+
+    it 'keep email is phone number is blank' do
+      options = { email: 'joe@vtenh.com', phone_number: '' }
+      registerer = described_class.new(options)
+      registerer.send(:sanitize_contact)
+
+      expect(registerer.context.email).to eq 'joe@vtenh.com'
+    end
+  end
+end


### PR DESCRIPTION
## Usages
### 1. To update email for current account:
- Call pin code generate api to generate pin: 
  `api/v2/storefront/pin_code_generators?type=SpreeCmCommissioner::PinCodeContactUpdate&email=example@gmail.com`
- Call user contacts api to update with pin code sent to email
  `/api/v2/storefront/user_contacts?pin_code=204110&pin_code_token=sEyjD65L6KbGZ7TP9YMrCwX1&email=panhachom@gmail.com`

### 2. To update phone for current account:
- Call pin code generate api to generate pin: 
  `api/v2/storefront/pin_code_generators?type=SpreeCmCommissioner::PinCodeContactUpdate&phone_number=0123456789`
- Call user contacts api to update with pin code sent to phone number
  `/api/v2/storefront/user_contacts?pin_code=204110&pin_code_token=sEyjD65L6KbGZ7TP9YMrCwX1&phone_number=0123456789`

### Check postman for response examples
![image](https://github.com/channainfo/commissioner/assets/29684683/5e566483-9c32-42b6-ac28-f94e99d62e6d)

## Reference
- https://github.com/bookmebus/vshop168/pull/1013
