### PR TITLE
close #610 set telegram channel to vendor & list authorized telegram users

### DIFF
--- a/app/controllers/spree/admin/vendor_authorized_users_controller.rb
+++ b/app/controllers/spree/admin/vendor_authorized_users_controller.rb
@@ -1,0 +1,53 @@
+module Spree
+  module Admin
+    class VendorAuthorizedUsersController < Spree::Admin::ResourceController
+      before_action :load_vendor
+
+      def load_vendor
+        @vendor ||= Spree::Vendor.by_vendor_id!(params[:vendor_id])
+      end
+
+      def collection
+        load_vendor
+
+        @users = @vendor.users
+      end
+
+      def update_telegram_chat
+        context = ::SpreeCmCommissioner::TelegramChatsFinder.call(
+          telegram_chat_name: params['vendor']['preferred_telegram_chat_name'],
+          telegram_chat_type: params['vendor']['preferred_telegram_chat_type']
+        )
+
+        if context.chats.present? && context.chats.is_a?(Hash)
+          vendor_attributes = {
+            preferred_telegram_chat_name: params['vendor']['preferred_telegram_chat_name'],
+            preferred_telegram_chat_type: params['vendor']['preferred_telegram_chat_type'],
+            preferred_telegram_chat_id: context.chats[:id]
+          }
+
+          flash[:error] = @vendor.errors.full_messages.to_sentence unless @vendor.update(vendor_attributes)
+        else
+          flash[:error] = I18n.t('vendor.validation.could_not_find_telegram_chat')
+        end
+
+        redirect_to collection_url(@vendor)
+      end
+
+      # @overrided
+      def model_class
+        Spree::User
+      end
+
+      # @overrided
+      def object_name
+        'user'
+      end
+
+      # @overrided
+      def collection_url(options = {})
+        admin_vendor_vendor_authorized_users_url(options)
+      end
+    end
+  end
+end

--- a/app/exception_notifier/spree_cm_commissioner/telegram_notifier.rb
+++ b/app/exception_notifier/spree_cm_commissioner/telegram_notifier.rb
@@ -6,7 +6,7 @@ module SpreeCmCommissioner
       @base_options = options
       @token = options.delete(:token)
       @channel_id = options.delete(:channel_id)
-      @telegram_client = ::Telegram::Bot::Client.wrap(token)
+      @telegram_client = ::Telegram.bots[:exception_notifier]
     end
 
     def call(exception, opts = {})

--- a/app/interactors/spree_cm_commissioner/telegram_chats_finder.rb
+++ b/app/interactors/spree_cm_commissioner/telegram_chats_finder.rb
@@ -1,0 +1,28 @@
+module SpreeCmCommissioner
+  class TelegramChatsFinder < BaseInteractor
+    delegate :telegram_chat_type, :telegram_chat_name, to: :context
+
+    def call
+      updates = fetch_updates
+      context.chats = get_chats(updates)
+    end
+
+    def get_chats(updates)
+      updates['result'].filter_map do |update|
+        chat = update.dig('my_chat_member', 'chat')
+
+        if chat.present? && chat['title'] == telegram_chat_name.strip && chat['type'] == telegram_chat_type
+          return {
+            id: chat['id'],
+            title: chat['title'],
+            type: chat['type']
+          }
+        end
+      end
+    end
+
+    def fetch_updates
+      ::Telegram.bot.get_updates
+    end
+  end
+end

--- a/app/models/concerns/spree_cm_commissioner/vendor_preference.rb
+++ b/app/models/concerns/spree_cm_commissioner/vendor_preference.rb
@@ -1,0 +1,13 @@
+module SpreeCmCommissioner
+  module VendorPreference
+    extend ActiveSupport::Concern
+
+    TELEGRAM_CHAT_TYPE = %i[channel group].freeze
+
+    included do
+      preference :telegram_chat_id, :string
+      preference :telegram_chat_name, :string
+      preference :telegram_chat_type, :string
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/vendor_decorator.rb
+++ b/app/models/spree_cm_commissioner/vendor_decorator.rb
@@ -6,6 +6,7 @@ module SpreeCmCommissioner
     def self.prepended(base)
       base.include SpreeCmCommissioner::ProductType
       base.include SpreeCmCommissioner::VendorPromotable
+      base.include SpreeCmCommissioner::VendorPreference
 
       base.attr_accessor :service_availabilities
 
@@ -54,6 +55,14 @@ module SpreeCmCommissioner
       base.has_many :invoices, class_name: 'SpreeCmCommissioner::Invoice', dependent: :destroy
       base.has_many :subscriptions, through: :customers, class_name: 'SpreeCmCommissioner::Subscription'
       base.has_many :subscription_orders, through: :subscriptions, class_name: 'Spree::Order', source: :orders
+
+      def base.by_vendor_id!(vendor_id)
+        if vendor_id.to_s =~ /^\d+$/
+          find(vendor_id)
+        else
+          find_by!(slug: vendor_id)
+        end
+      end
 
       # TODO: we will need searchkick later
       # unless Rails.env.test?

--- a/app/views/spree/admin/shared/_vendor_tabs.html.erb
+++ b/app/views/spree/admin/shared/_vendor_tabs.html.erb
@@ -38,10 +38,18 @@
     <% end if can?(:admin, SpreeCmCommissioner::VendorPlace) %>
 
     <%= content_tag :li do %>
-      <%= link_to_with_icon 'images.svg',
+      <%= link_to_with_icon 'calendar2-week.svg',
         Spree.t(:service_calendars),
         admin_vendor_vendor_service_calendars_url(@vendor),
         class: "nav-link #{'active' if current == :service_calendars}"
       %>
     <% end if can?(:admin, SpreeCmCommissioner::ServiceCalendar) %>
+
+    <%= content_tag :li do %>
+      <%= link_to_with_icon 'telegram.svg',
+        Spree.t(:telegram),
+        admin_vendor_vendor_authorized_users_url(@vendor),
+        class: "nav-link #{'active' if current == :vendor_authorized_users }"
+      %>
+    <% end if can?(:admin, Spree::Vendor) %>
 <% end %>

--- a/app/views/spree/admin/vendor_authorized_users/index.html.erb
+++ b/app/views/spree/admin/vendor_authorized_users/index.html.erb
@@ -1,0 +1,67 @@
+<%= render partial: 'spree/admin/shared/vendor_tabs', locals: { current: :vendor_authorized_users } %>
+
+<% content_for :sidebar do %>
+  <%= form_with model: @vendor, url: { action: 'update_telegram_chat' } do |f| %>
+    <fieldset data-hook="edit_vendor">
+      <div data-hook="admin_user_device_token_form_fields">
+        <%= f.field_container :preferred_telegram_chat_name do %>
+          <%= f.label :preferred_telegram_chat_name, Spree.t(:telegram_chat_name) %>
+          <%= f.text_field :preferred_telegram_chat_name, class: 'form-control' %>
+        <% end %>
+        <%= f.field_container :preferred_telegram_chat_type do %>
+          <%= f.label :preferred_telegram_chat_type, Spree.t(:telegram_chat_type) %>
+          <%= f.select :preferred_telegram_chat_type, SpreeCmCommissioner::VendorPreference::TELEGRAM_CHAT_TYPE, {}, :class => "fullwidth select2" %>
+        <% end %>
+        <%= f.field_container :preferred_telegram_chat_id do %>
+          <%= f.label :preferred_telegram_chat_id, Spree.t(:telegram_chat_id) %>
+          <%= f.text_field :preferred_telegram_chat_id, class: 'form-control', disabled: true %>
+        <% end %>
+        <small class="form-text text-muted">
+          <ul>
+            <% allow_extensions = SpreeCmCommissioner::VectorIcon::ACCEPTED_EXTENSIONS.to_sentence %>
+            <li><%= raw I18n.t("telegram_chat_bot.vendor_channel_group_info") %></li>
+            <li><%= raw I18n.t("telegram_chat_bot.only_for_authorized_user_info") %></li>
+          </ul>
+        </small>
+      </div>
+      <%= render partial: 'spree/admin/shared/edit_resource_links' %>
+    </fieldset>
+  <% end %>
+<% end %>
+
+<% if @users.any? %>
+  <div class="table-responsive border rounded bg-white mb-3">
+    <table class="table" id="listing_users" data-hook>
+      <thead class="text-muted">
+        <tr data-hook="admin_users_index_headers">
+          <th><%= Spree.t(:email) %></th>
+          <th><%= Spree.t(:phone_number) %></th>
+          <th><%= Spree.t(:first_name) %></th>
+          <th><%= Spree.t(:last_name) %></th>
+          <th><%= Spree.t(:telegram) %></th>
+          <th data-hook="admin_users_index_header_actions" class="actions"></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @users.each do |user| %>
+          <tr id="<%= spree_dom_id user %>" data-hook="admin_users_index_rows">
+            <td><%= user.email%></td>
+            <td><%= user.intel_phone_number %></td>
+            <td><%= user.first_name %></td>
+            <td><%= user.last_name %></td>
+            <td><small class="badge badge-active"><%= user.user_identity_providers.telegram.pluck(:sub).to_sentence.presence || 'No telegram' %></small class="badge-active"></td>
+            <td data-hook="admin_users_index_row_actions" class="actions">
+              <span class="d-flex justify-content-end">
+                <%= link_to_edit user, no_text: true if can?(:edit, user) %>
+              </span>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% else %>
+  <div class="text-center no-objects-found m-5 mb-3">
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree.user_class)) %>,
+  </div>
+<% end %>

--- a/config/initializers/telegram_bot.rb
+++ b/config/initializers/telegram_bot.rb
@@ -1,0 +1,7 @@
+Telegram.bots_config = {
+  # Telegram.bot.get_updates
+  default: ENV.fetch('DEFAULT_TELEGRAM_BOT_API_TOKEN', nil),
+
+  # Telegram.bots[:exception_notifier]
+  exception_notifier: ENV.fetch('EXCEPTION_TELEGRAM_BOT_TOKEN', nil)
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,10 +89,15 @@ en:
   nearby_place:
     empty_info: "No <b>Nearby places</b> found."
 
+  telegram_chat_bot:
+    vendor_channel_group_info: "This channel/group will be recieve order notifications"
+    only_for_authorized_user_info: "Only authorized users can approve/reject line items, make sure to input their telegram username"
+
   vendor:
     validation:
       vendor_kind_option_types:
         empty_info: "<b>Note:</b> Set vendor option types to vendor first. To edit, go to <b>Details</b> tab > <b>Option Types</b>"
+      could_not_find_telegram_chat: "Could not find telegram channel, try remove Bot from Telegram channel and add again as admin."
 
     service_calendars:
       empty_info: "No <b>Service calendars</b> found."

--- a/config/locales/km.yml
+++ b/config/locales/km.yml
@@ -81,10 +81,15 @@ km:
   nearby_place:
     empty_info: "រក <b>Nearby places</b> មិនឃើញទេ"
 
+  telegram_chat_bot:
+    vendor_channel_group_info: "This channel/group will be recieve order notifications"
+    only_for_authorized_user_info: "Only authorized users can approve/reject line items, make sure to input their telegram username"
+
   vendor:
     validation:
       vendor_kind_option_types:
         empty_info: "<b>Note:</b> កំណត់ប្រភេទសម្រាប់ក្រុមហ៊ុនជាមុនសិន. ដើម្បីកែប្រែ, ចូលទៅ <b>លម្អិត</b> tab > <b>ប្រភេទ</b>"
+      could_not_find_telegram_chat: "Could not find telegram channel, try remove Bot from Telegram channel and add again as admin."
 
     service_calendars:
       empty_info: "រក <b>ប្រតិទិនសេវាកម្ម</b> មិនឃើញទេ."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,11 @@ Spree::Core::Engine.add_routes do
           patch :update_status
         end
       end
+      resources :vendor_authorized_users do
+        collection do
+          patch :update_telegram_chat
+        end
+      end
     end
 
     resources :customer_notifications do

--- a/db/migrate/20230920100147_add_preferences_to_spree_vendor.rb
+++ b/db/migrate/20230920100147_add_preferences_to_spree_vendor.rb
@@ -1,0 +1,5 @@
+class AddPreferencesToSpreeVendor < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_vendors, :preferences, :text, if_not_exists: true
+  end
+end

--- a/spec/interactors/spree_cm_commissioner/telegram_chats_finder_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/telegram_chats_finder_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::TelegramChatsFinder do
+  let(:updates) { {
+    "ok"=>true,
+    "result"=> [
+      {
+        "update_id"=>31545797,
+        "my_chat_member"=> {
+          "chat"=>{"id"=>-1001712207468, "title"=>"BookMe+ DEV Exception", "type"=>"channel"},
+          "from"=>{"id"=>969777666, "is_bot"=>false, "first_name"=>"Savuth", "last_name"=>"Yuvaneath", "username"=>"va_neath"},
+          "date"=>1695185042,
+          "old_chat_member"=>{"user"=>{"id"=>6441690414, "is_bot"=>true, "first_name"=>"Contigo Asia", "username"=>"contigoasiabot"}, "status"=>"left"},
+          "new_chat_member"=> {
+            "user"=>{"id"=>6441690414, "is_bot"=>true, "first_name"=>"Contigo Asia", "username"=>"contigoasiabot"},
+            "status"=>"administrator",
+            "can_be_edited"=>false,
+            "can_manage_chat"=>true,
+            "can_change_info"=>true,
+            "can_post_messages"=>true,
+            "can_edit_messages"=>true,
+            "can_delete_messages"=>true,
+            "can_invite_users"=>true,
+            "can_restrict_members"=>true,
+            "can_promote_members"=>false,
+            "can_manage_video_chats"=>true,
+            "is_anonymous"=>false,
+            "can_manage_voice_chats"=>true
+          }
+        }
+      }
+    ]
+  } }
+
+  it 'return chats matched to telegram_chat_name & telegram_chat_type' do
+    subject = described_class.new(telegram_chat_name: 'BookMe+ DEV Exception', telegram_chat_type: 'channel')
+    allow(subject).to receive(:fetch_updates).and_return(updates)
+
+    chats = subject.call
+    expect(chats).to match({:id=>-1001712207468, :title=>"BookMe+ DEV Exception", :type=>"channel"})
+  end
+
+  it 'return empty chats when no matched to telegram_chat_name' do
+    subject = described_class.new(telegram_chat_name: 'Wrong name', telegram_chat_type: 'channel')
+    allow(subject).to receive(:fetch_updates).and_return(updates)
+
+    chats = subject.call
+    expect(chats).to be_empty
+  end
+
+  it 'return empty chats when no matched to telegram_chat_type' do
+    subject = described_class.new(telegram_chat_name: 'BookMe+ DEV Exception', telegram_chat_type: 'group')
+    allow(subject).to receive(:fetch_updates).and_return(updates)
+
+    chats = subject.call
+    expect(chats).to be_empty
+  end
+end

--- a/spec/models/spree/vendor_spec.rb
+++ b/spec/models/spree/vendor_spec.rb
@@ -37,6 +37,28 @@ RSpec.describe Spree::Vendor, type: :model do
     end
   end
 
+  describe '.by_vendor_id!' do
+    it 'return vendor by slug or id' do
+      vendor = create(:vendor, slug: 'vendor')
+
+      result1 = described_class.by_vendor_id!(vendor.slug)
+      result2 = described_class.by_vendor_id!(vendor.id)
+
+      expect(result1.id).to eq vendor.id
+      expect(result2.id).to eq vendor.id
+    end
+
+    it 'raise error when id in int not found' do
+      vendor = create(:vendor, slug: 'vendor')
+      expect { described_class.by_vendor_id!(1000) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'raise error when id in slug-from not found' do
+      vendor = create(:vendor, slug: 'vendor')
+      expect { described_class.by_vendor_id!('wrong-vendor-slug') }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
   describe '#primary_product_type' do
     it 'raise error on enter invalid primary_product_type' do
       expect{create(:vendor, primary_product_type: :fake)}


### PR DESCRIPTION
## Scope
- [x] Add `vendor/:slug/vendor_authorized_users` controller
  - List all vendor users that authorized to reject or confirm line item
- [x] Add preference to vendor to store
  - telegram_chat_id 
  - telegram_chat_name
  - telegram_chat_type: group or channel
- [x] Auto set telegram chat id with chat name & chat type (using telegram api)
  - Next PR, we will use that chat id to push telegram notification

## Demo
https://github.com/channainfo/commissioner/assets/29684683/2455fb7e-791f-47fb-b6c5-53211491bb4a
