### PR TITLE
close #632 refactor user identities authentication

### DIFF
--- a/app/controllers/spree/api/v2/storefront/account_checker_controller.rb
+++ b/app/controllers/spree/api/v2/storefront/account_checker_controller.rb
@@ -6,7 +6,6 @@ module Spree
           def index
             checker = SpreeCmCommissioner::ExistingAccountChecker.call(filter_params.to_h)
 
-            Rails.logger.debug filter_params
             if checker.success?
               head :ok
             else

--- a/app/interactors/spree_cm_commissioner/existing_account_checker.rb
+++ b/app/interactors/spree_cm_commissioner/existing_account_checker.rb
@@ -3,7 +3,7 @@ module SpreeCmCommissioner
     include Interactor
 
     def call
-      user = Spree.user_class.find_user_by_login(context.login).first if context.login.present?
+      user = Spree.user_class.find_user_by_login(context.login) if context.login.present?
 
       context.fail!(message: I18n.t('account_checker.verify.already_exist', login: context.login)) if user.present?
     end

--- a/app/interactors/spree_cm_commissioner/user_password_authenticator.rb
+++ b/app/interactors/spree_cm_commissioner/user_password_authenticator.rb
@@ -1,9 +1,9 @@
 module SpreeCmCommissioner
   class UserPasswordAuthenticator < BaseInteractor
-    # :login, :password
-    def call
-      context.user = Spree.user_class.find_for_database_authentication(email: login)
+    delegate :login, :password, to: :context
 
+    def call
+      context.user = Spree.user_class.find_user_by_login(login)
       context.fail!(message: I18n.t('authenticator.incorrect_login')) if context.user.nil?
       if spree_confirmable? && active_for_authentication? && !validate_password(user)
         context.fail!(message: I18n.t('authenticator.incorrect_password'))
@@ -23,14 +23,6 @@ module SpreeCmCommissioner
 
     def active_for_authentication?
       user.active_for_authentication?
-    end
-
-    def login
-      context.login
-    end
-
-    def password
-      context.password
     end
   end
 end

--- a/app/models/concerns/spree_cm_commissioner/phone_number_sanitizer.rb
+++ b/app/models/concerns/spree_cm_commissioner/phone_number_sanitizer.rb
@@ -4,7 +4,7 @@ module SpreeCmCommissioner
     extend ActiveSupport::Concern
 
     included do
-      before_save :sanitize_phone_number
+      before_validation :sanitize_phone_number
     end
 
     private

--- a/app/models/concerns/spree_cm_commissioner/user_identity.rb
+++ b/app/models/concerns/spree_cm_commissioner/user_identity.rb
@@ -1,0 +1,59 @@
+module SpreeCmCommissioner
+  module UserIdentity
+    extend ActiveSupport::Concern
+
+    included do
+      include SpreeCmCommissioner::PhoneNumberSanitizer
+
+      has_many :user_identity_providers, dependent: :destroy, class_name: 'SpreeCmCommissioner::UserIdentityProvider'
+
+      validates :user_identity_providers, presence: true, if: -> (u) { u.require_login_identity_all_blank_for(:user_identity_providers) }
+
+      validates :phone_number, presence: true, if: -> (u) { u.require_login_identity_all_blank_for(:phone_number) }
+      validates :phone_number, uniqueness: { allow_blank: true }
+      validates :phone_number, format: { with: /^\d{8,12}$/, :multiline => true, allow_blank: true }
+
+      validates :login, presence: true, if: -> (u) { u.require_login_identity_all_blank_for(:login) }
+      validates :login, uniqueness: { case_sensitive: false, allow_blank: true }
+    end
+
+    class_methods do
+      def find_user_by_login(login)
+        return nil if login.blank?
+
+        login = login.downcase
+        parser = PhoneNumberParser.call(phone_number: login)
+
+        if parser.intel_phone_number.present?
+          find_by(intel_phone_number: parser.intel_phone_number)
+        elsif login =~ URI::MailTo::EMAIL_REGEXP
+          find_by(email: login)
+        else
+          find_by(login: login)
+        end
+      end
+    end
+
+    # override:spree_auth_devise:app/models/spree/user.rb
+    # set_login is ran before validation.
+    def set_login
+      self.login ||= phone_number if phone_number
+      self.login ||= email if email
+    end
+
+    # override:devise:lib/devise/models/validatable.rb
+    def email_required?
+      require_login_identity_all_blank_for(:email)
+    end
+
+    protected
+
+    def require_login_identity_all_blank_for(field)
+      requierd_fields = %i[phone_number email user_identity_providers login].reject { |item| item == field }
+      requierd_fields.each do |requierd_field|
+        return false if send(requierd_field).present?
+      end
+      true
+    end
+  end
+end

--- a/app/services/spree_cm_commissioner/user_authenticator.rb
+++ b/app/services/spree_cm_commissioner/user_authenticator.rb
@@ -3,7 +3,7 @@ module SpreeCmCommissioner
   class UserAuthenticator
     # :username, :password
     # :id_token
-    def self.call?(params)
+    def self.call!(params)
       context = auth_context(params)
       raise exception(context.message) unless context.success?
 
@@ -12,7 +12,7 @@ module SpreeCmCommissioner
 
     def self.auth_context(params)
       case flow_type(params)
-      when 'email_auth'
+      when 'login_auth'
         options = { login: params[:username], password: params[:password] }
         SpreeCmCommissioner::UserPasswordAuthenticator.call(options)
       when 'social_auth'
@@ -22,7 +22,7 @@ module SpreeCmCommissioner
     end
 
     def self.flow_type(params)
-      return 'email_auth' if params.key?(:username) && params.key?(:password)
+      return 'login_auth' if params.key?(:username) && params.key?(:password)
       return 'social_auth' if params.key?(:id_token)
 
       raise exception(I18n.t('authenticator.invalid_or_missing_params'))

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -13,8 +13,7 @@ Doorkeeper.configure do
   use_polymorphic_resource_owner
 
   resource_owner_from_credentials do
-    user = SpreeCmCommissioner::UserAuthenticator.call?(params)
-    user
+    SpreeCmCommissioner::UserAuthenticator.call!(params)
   end
 
   admin_authenticator do |routes|

--- a/lib/spree_cm_commissioner/test_helper/factories/user_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/user_factory.rb
@@ -6,8 +6,13 @@ FactoryBot.define do
     'eyJhbGciOiJSUzI1NiIsImtpZCI6ImE5NmFkY2U5OTk5YmJmNWNkMzBmMjlmNDljZDM3ZjRjNWU2NDI3NDAiLCJ0eXAiOiJKV1QifQ.eyJuYW1lIjoiUGFuaGEgQ2hvbSIsInBpY3R1cmUiOiJodHRwczovL2xoMy5nb29nbGV1c2VyY29udGVudC5jb20vYS9BTG01d3UyUXRmU2owU0NqTGpuSW9jNk5YSzBvSUpTVGVXZ1dXRWJ6XzgyTj1zOTYtYyIsImlzcyI6Imh0dHBzOi8vc2VjdXJldG9rZW4uZ29vZ2xlLmNvbS9jbS1tYXJrZXQtNDMzYjEiLCJhdWQiOiJjbS1tYXJrZXQtNDMzYjEiLCJhdXRoX3RpbWUiOjE2NjkyODQwMDQsInVzZXJfaWQiOiJWcWZtY2o5V1F2UlM4QllBb2VmMk5meGVJdWQyIiwic3ViIjoiVnFmbWNqOVdRdlJTOEJZQW9lZjJOZnhlSXVkMiIsImlhdCI6MTY2OTI4NDAwNCwiZXhwIjoxNjY5Mjg3NjA0LCJmaXJlYmFzZSI6eyJpZGVudGl0aWVzIjp7Imdvb2dsZS5jb20iOlsiMTExNTkxNzcwMTQ4MjcxOTc5NzYzIl19LCJzaWduX2luX3Byb3ZpZGVyIjoiZ29vZ2xlLmNvbSJ9fQ.R95hhSSQI-LEYgjJx9IQ-weuDIZRc7umxVURhdqWvii3pC67GZkPoXMT0QqnehBb4DB7TQyUN_AGbO_G34HlOJZ3g1L7_f_45zdnGodZdW0he4zrGaqNj59pe1oppyvnG9EwupXwjjP1p-ASMvxUJ5VW4_TvkwJx9nIyB3PHNuqvPEvg8eqHACdxQ4lrqJClPgxJoHvh9rLgQmPLbwGGMDBDH8DMSID1fum5qfwWHUrqDp87MGbe43566tb2rh7YBB0Lpb8LCR-SbkgugnyxSl4LY_2NvP2ozRRY5EtbbggYrW3akMaYNXq6abAJrIucf6GJzerL0tQW'
   end
 
+  sequence :cm_random_phone_number do |n|
+    "01234567#{n}#{n+1}"
+  end
+
   factory :cm_user, class: Spree.user_class do
     email                 { generate(:random_email) }
+    phone_number          { generate(:cm_random_phone_number) }
     login                 { email }
     password              { 'secret' }
     password_confirmation { password }

--- a/spec/interactors/spree_cm_commissioner/user_password_authenticator_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/user_password_authenticator_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
 RSpec.describe SpreeCmCommissioner::UserPasswordAuthenticator do
-  let(:user) { create(:user, password: 'awesome-password') }
+  let(:user) { create(:cm_user, password: 'awesome-password') }
 
   describe '.call' do
     it 'return authenticator.invalid_login error if user login is invalid' do
-      allow(Spree.user_class).to receive(:find_first_by_auth_conditions).with({ email: user.email }).and_return(nil)
+      allow(Spree.user_class).to receive(:find_user_by_login).with(user.email).and_return(nil)
       result_context = described_class.call(login: user.email)
 
       expect(result_context.success?).to eq false
@@ -13,7 +13,7 @@ RSpec.describe SpreeCmCommissioner::UserPasswordAuthenticator do
     end
 
     it 'return authenticator.incorrect_password error if user password is invalid' do
-      allow(Spree.user_class).to receive(:find_first_by_auth_conditions).with({ email: user.email }).and_return(user)
+      allow(Spree.user_class).to receive(:find_user_by_login).with(user.email).and_return(user)
       result_context = described_class.call(login: user.email, password: 'wrong-password')
 
       expect(result_context.success?).to eq false
@@ -21,7 +21,7 @@ RSpec.describe SpreeCmCommissioner::UserPasswordAuthenticator do
     end
 
     it 'return user if password is correct' do
-      allow(Spree.user_class).to receive(:find_first_by_auth_conditions).with({ email: user.email }).and_return(user)
+      allow(Spree.user_class).to receive(:find_user_by_login).with(user.email).and_return(user)
       result_context = described_class.call(login: user.email, password: 'awesome-password')
 
       expect(result_context.success?).to eq true

--- a/spec/models/spree_cm_commissioner/user_spec.rb
+++ b/spec/models/spree_cm_commissioner/user_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+RSpec.describe Spree::User, type: :model do
+  describe '.require_login_identity_all_blank_for' do
+    it 'not required email, phone, or login if already has user_identity_providers' do
+      user = build(
+        :cm_user,
+        phone_number: nil,
+        email: nil,
+        login: nil,
+        user_identity_providers: [build(:user_identity_provider)],
+      )
+      expect(user.send(:require_login_identity_all_blank_for, :email)).to be false
+      expect(user.send(:require_login_identity_all_blank_for, :login)).to be false
+      expect(user.send(:require_login_identity_all_blank_for, :phone_number)).to be false
+    end
+  end
+
+  describe '.find_user_by_login' do
+    let!(:user) { create(:cm_user, password: 'correct-password', phone_number: "0123456789", email: "test@gmail.com") }
+
+    it 'return user by uppercase email' do
+      expect(described_class.find_user_by_login(user.email.upcase)).to eq user
+    end
+
+    it 'return user by randomcase email' do
+      expect(described_class.find_user_by_login('tESt@gmail.com')).to eq user
+    end
+
+    it 'return user by phone_number' do
+      expect(described_class.find_user_by_login('0123456789')).to eq user
+    end
+
+    it 'return user by intel_phone_number with space' do
+      expect(described_class.find_user_by_login('+855 123456789')).to eq user
+    end
+
+    it 'return user by intel_phone_number' do
+      expect(described_class.find_user_by_login('+855123456789')).to eq user
+    end
+
+    it 'return user by login' do
+      expect(described_class.find_user_by_login(user.login)).to eq user
+    end
+
+    it 'return nil when can not find login' do
+      expect(described_class.find_user_by_login('invalid')).to eq nil
+    end
+  end
+end

--- a/spec/request/spree/spree_oauth_spec.rb
+++ b/spec/request/spree/spree_oauth_spec.rb
@@ -4,8 +4,46 @@ describe 'Spree Oauth Spec', type: :request do
 
   # :password
   context 'grant_type: password' do
-    it 'successfully log user in' do
-      user = create(:user)
+    let(:user) { build(:cm_user) }
+
+    it 'successfully log user in with email' do
+      allow(Spree.user_class).to receive(:find_user_by_login).with(user.email).and_return(user)
+
+      post "/spree_oauth/token", params: {
+        "grant_type": "password",
+        "username": user.email,
+        "password": user.password,
+      }
+
+      expect(json_response_body.keys).to contain_exactly(
+        'access_token',
+        'token_type',
+        'expires_in',
+        'refresh_token',
+        'created_at'
+      )
+    end
+
+    it 'successfully log user in with phone_number' do
+      allow(Spree.user_class).to receive(:find_user_by_login).with(user.phone_number).and_return(user)
+
+      post "/spree_oauth/token", params: {
+        "grant_type": "password",
+        "username": user.phone_number,
+        "password": user.password,
+      }
+
+      expect(json_response_body.keys).to contain_exactly(
+        'access_token',
+        'token_type',
+        'expires_in',
+        'refresh_token',
+        'created_at'
+      )
+    end
+
+    it 'successfully log user in with login' do
+      allow(Spree.user_class).to receive(:find_user_by_login).with(user.login).and_return(user)
 
       post "/spree_oauth/token", params: {
         "grant_type": "password",
@@ -23,7 +61,7 @@ describe 'Spree Oauth Spec', type: :request do
     end
 
     it 'return error on incorrect password' do
-      user = create(:user)
+      allow(Spree.user_class).to receive(:find_user_by_login).with(user.login).and_return(user)
 
       post "/spree_oauth/token", params: {
         "grant_type": "password",
@@ -37,7 +75,7 @@ describe 'Spree Oauth Spec', type: :request do
     end
 
     it 'return error on params missing' do
-      user = create(:user)
+      allow(Spree.user_class).to receive(:find_user_by_login).with(user.login).and_return(user)
 
       post "/spree_oauth/token", params: {
         "grant_type": "password",

--- a/spec/services/spree_cm_commissioner/user_authenticator_spec.rb
+++ b/spec/services/spree_cm_commissioner/user_authenticator_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 # only for test execeptions, check: spec/request/spree/spree_oauth_spec.rb
 RSpec.describe SpreeCmCommissioner::UserAuthenticator do
-  let!(:user) { create(:user, password: '12345678', email: 'abc@vtenh.com') }
+  let!(:user) { create(:user, password: '12345678', email: 'abc@cm.com') }
 
   context 'no exceptions' do
     it 'log into user when email & password valid' do
@@ -13,17 +13,17 @@ RSpec.describe SpreeCmCommissioner::UserAuthenticator do
           .and_return(context)
 
       params = { grant_type: 'password', username: user.email, password: user.password }
-      authenticated_user = described_class.call?(params)
+      authenticated_user = described_class.call!(params)
 
-      expect(authenticated_user.email).to eq 'abc@vtenh.com'
+      expect(authenticated_user.email).to eq 'abc@cm.com'
     end
   end
 
   context 'no exceptions' do
     it 'log into user when email & password valid' do
       params = { grant_type: 'password', username: user.email, password: "wrong-password" }
-      expect { described_class.call?(params) }.to raise_error(
-                                                    Doorkeeper::Errors::DoorkeeperError, 
+      expect { described_class.call!(params) }.to raise_error(
+                                                    Doorkeeper::Errors::DoorkeeperError,
                                                     I18n.t('authenticator.incorrect_password')
                                                   )
     end


### PR DESCRIPTION
- Allow login via phone (default only email)
- Add validation to user identity (email, phone, login, identity_providers)