### PR TITLE
close #645 fix active record read only mode on api controller

### DIFF
--- a/app/models/spree_cm_commissioner/oauth_access_token_decorator.rb
+++ b/app/models/spree_cm_commissioner/oauth_access_token_decorator.rb
@@ -1,0 +1,13 @@
+module SpreeCmCommissioner
+  module OauthAccessTokenDecorator
+    def revoke_previous_refresh_token!
+      ActiveRecord::Base.connected_to(role: :writing) do
+        super
+      end
+    end
+  end
+end
+
+unless Spree::OauthAccessToken.included_modules.include?(SpreeCmCommissioner::OauthAccessTokenDecorator)
+  Spree::OauthAccessToken.prepend(SpreeCmCommissioner::OauthAccessTokenDecorator)
+end

--- a/app/models/spree_cm_commissioner/oauth_access_token_decorator.rb
+++ b/app/models/spree_cm_commissioner/oauth_access_token_decorator.rb
@@ -1,5 +1,7 @@
 module SpreeCmCommissioner
   module OauthAccessTokenDecorator
+    # override
+    # lib/doorkeeper/models/access_token_mixin.rb
     def revoke_previous_refresh_token!
       ActiveRecord::Base.connected_to(role: :writing) do
         super


### PR DESCRIPTION
It is call when authenticate in lib/doorkeeper/oauth/token.rb.

![image](https://github.com/channainfo/commissioner/assets/29684683/07b03cd7-43c3-4ddb-a9f5-6793bcf3a709)
