### PR TITLE
close #648 fix :platform not defined when cleanup_device_token

### DIFF
--- a/app/mailers/spree/order_mailer_decorator.rb
+++ b/app/mailers/spree/order_mailer_decorator.rb
@@ -8,7 +8,7 @@ module Spree
       @product_type = @order.products.first.product_type || 'accommodation'
 
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
-      subject += "BookMe+ Booking Confirmation ##{order.number}"
+      subject += "#{current_store&.name} Booking Confirmation ##{@order.number}"
 
       mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.url) do |format|
         format.html { render layout: 'spree_cm_commissioner/layouts/order_mailer' }

--- a/app/notifications/noticed_fcm_base.rb
+++ b/app/notifications/noticed_fcm_base.rb
@@ -73,7 +73,9 @@ class NoticedFcmBase < Noticed::Base
     self.class.to_s.underscore
   end
 
-  def cleanup_device_token(token:)
+  # rubocop:disable Lint/UnusedMethodArgument
+  def cleanup_device_token(token:, platform:)
     SpreeCmCommissioner::DeviceToken.where(registration_token: token).destroy_all
   end
+  # rubocop:enable Lint/UnusedMethodArgument
 end

--- a/spec/notifications/spree_cm_commissioner/customer_content_notifications_spec.rb
+++ b/spec/notifications/spree_cm_commissioner/customer_content_notifications_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe SpreeCmCommissioner::CustomerContentNotification do
     it 'removes selected device token' do
       device_token = create(:cm_device_token, user: user, registration_token: 'registration_token')
 
-      noticed_customer.send(:cleanup_device_token, token: device_token.registration_token)
+      noticed_customer.send(:cleanup_device_token, token: device_token.registration_token, platform: 'fcm')
       expect { device_token.reload }.to raise_error ActiveRecord::RecordNotFound
     end
   end


### PR DESCRIPTION
- [x] fcm call `notification.send(:cleanup_device_token, token: device_token, platform: "fcm")` and we forget to add platform
- [x] in mailer: use `@order` instead of `order`