### PR TITLE
close #666 add generate qr api

### DIFF
--- a/app/controllers/spree/api/v2/storefront/order_qrs_controller.rb
+++ b/app/controllers/spree/api/v2/storefront/order_qrs_controller.rb
@@ -1,0 +1,22 @@
+module Spree
+  module Api
+    module V2
+      module Storefront
+        class OrderQrsController < ::Spree::Api::V2::ResourceController
+          include ActionController::MimeResponds
+
+          before_action :require_spree_current_user
+
+          def show
+            order = Spree::Order.find_by(number: params[:id])
+
+            respond_to do |format|
+              format.png { send_data order.generate_png_qr, type: 'image/png', disposition: 'inline' }
+              format.svg { send_data order.generate_svg_qr, type: 'image/svg+xml', disposition: 'inline' }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/spree/mail_helper_decorator.rb
+++ b/app/helpers/spree/mail_helper_decorator.rb
@@ -32,18 +32,6 @@ module Spree
       "https://www.google.com/maps/@#{lat},#{lon},15z?entry=ttu"
     end
 
-    def generate_qr(order)
-      qrcode = RQRCode::QRCode.new("#{order.store.url}/orders/#{order.number}")
-      qrcode.as_svg(
-        color: '000',
-        shape_rendering: 'crispEdges',
-        module_size: 5,
-        standalone: true,
-        use_path: true,
-        viewbox: '0 0 20 10'
-      )
-    end
-
     def notice_info(current_store, product_type)
       notice_page = current_store.cms_pages.find_by(slug: 'hotel-notice')
       notice_page = current_store.cms_pages.find_by(slug: 'event-notice') if product_type == 'ecommerce'

--- a/app/models/spree_cm_commissioner/order_decorator.rb
+++ b/app/models/spree_cm_commissioner/order_decorator.rb
@@ -70,6 +70,34 @@ module SpreeCmCommissioner
       complete? && need_confirmation? == false
     end
 
+    def generate_svg_qr
+      qrcode = RQRCode::QRCode.new("#{store.url}/orders/#{number}")
+      qrcode.as_svg(
+        color: '000',
+        shape_rendering: 'crispEdges',
+        module_size: 5,
+        standalone: true,
+        use_path: true,
+        viewbox: '0 0 20 10'
+      )
+    end
+
+    def generate_png_qr
+      qrcode = RQRCode::QRCode.new("#{store.url}/orders/#{number}")
+      qrcode.as_png(
+        bit_depth: 1,
+        border_modules: 4,
+        color_mode: ChunkyPNG::COLOR_GRAYSCALE,
+        color: 'black',
+        file: nil,
+        fill: 'white',
+        module_px_size: 6,
+        resize_exactly_to: false,
+        resize_gte_to: false,
+        size: 120
+      )
+    end
+
     private
 
     # override :spree_api

--- a/app/views/spree_cm_commissioner/order_mailer/_greeting.html.erb
+++ b/app/views/spree_cm_commissioner/order_mailer/_greeting.html.erb
@@ -8,7 +8,7 @@
   </div>
   <div class="qr-container">
     <div class='qr-code'>
-      <%= raw generate_qr(order)%>
+      <%= raw order.generate_svg_qr %>
     </div>
     <p>Show your QR to enter</p>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -185,6 +185,7 @@ Spree::Core::Engine.add_routes do
           resources :nearby_places, only: %i[index]
         end
         resource :homepage_data, only: [:show]
+        resources :order_qrs, only: [:show]
       end
     end
 


### PR DESCRIPTION
## Scope
- [x] Add QR API, make sure it appear in app first
- [ ] -> Next PR (we can do later), generate QR with logo, encryption or any

## Demo on chrome
| | |
| - | - |
| <img width="1157" alt="image" src="https://github.com/channainfo/commissioner/assets/29684683/ebf7fb93-fffc-4d2e-bf4f-0d79946df4df"> |  <img width="1157" alt="image" src="https://github.com/channainfo/commissioner/assets/29684683/1dd845d2-5716-4aa1-ba9f-f72c3db4755e"> | 

