### PR TITLE
close #696 enhance room need confirmation flow - validation, transitions

### DIFF
--- a/app/interactors/spree_cm_commissioner/order_accepted_state_updater.rb
+++ b/app/interactors/spree_cm_commissioner/order_accepted_state_updater.rb
@@ -16,10 +16,7 @@ module SpreeCmCommissioner
 
     def update_line_item_accepted_at_and_accepted_by
       order.line_items.each do |line_item|
-        line_item.update(
-          accepted_at: Time.current,
-          accepted_by: authorized_user
-        )
+        line_item.accepted_by(authorized_user)
       end
     end
   end

--- a/app/interactors/spree_cm_commissioner/order_rejected_state_updater.rb
+++ b/app/interactors/spree_cm_commissioner/order_rejected_state_updater.rb
@@ -16,10 +16,7 @@ module SpreeCmCommissioner
 
     def update_line_item_rejected_at_and_rejected_by
       order.line_items.each do |line_item|
-        line_item.update(
-          rejected_at: Time.current,
-          rejected_by: authorized_user
-        )
+        line_item.rejected_by(authorized_user)
       end
     end
   end

--- a/app/models/concerns/spree_cm_commissioner/order_requestable.rb
+++ b/app/models/concerns/spree_cm_commissioner/order_requestable.rb
@@ -3,50 +3,100 @@ module SpreeCmCommissioner
     extend ActiveSupport::Concern
 
     included do
-      after_commit  :update_to_requested_state_if_confirmation_needed
+      state_machine.after_transition to: :complete do |order, _transition|
+        if order.need_confirmation?
+          order.request!
+        else
+          order.notify_order_complete_app_notification_to_user
+        end
+      end
 
       state_machine :request_state, initial: nil, use_transactions: false do
         event :request do
           transition from: nil, to: :requested
         end
-        after_transition to: :requested, do: :send_order_requested_notification
+        after_transition to: :requested, do: :send_order_request_telegram_confirmation_alert_to_vendor
+        after_transition to: :requested, do: :send_order_requested_app_notification_to_user
+        after_transition to: :requested, do: :send_order_requested_telegram_alert_store
 
         event :accept do
           transition from: :requested, to: :accepted
         end
-        after_transition to: :accepted, do: :send_order_accepted_notification
+        after_transition to: :accepted, do: :send_order_accepted_app_notification_to_user
+        after_transition to: :accepted, do: :send_order_accepted_telegram_alert_to_store
+
+        # call confirmation_delivered column directly since confirmation_delivered? is overrided
+        after_transition to: :accepted, if: :confirmation_delivered, do: :deliver_order_confirmation_email
 
         event :reject do
           transition from: :requested, to: :rejected
         end
-        after_transition to: :rejected, do: :send_order_rejected_notification
-      end
+        after_transition to: :rejected, do: :send_order_rejected_app_notification_to_user
+        after_transition to: :rejected, do: :send_order_rejected_telegram_alert_to_store
 
-      def send_order_requested_notification
-        SpreeCmCommissioner::OrderRequestedNotificationSender.call(order: self)
-      end
-
-      def send_order_accepted_notification
-        SpreeCmCommissioner::OrderAcceptedNotificationSender.call(order: self)
-      end
-
-      def send_order_rejected_notification
-        SpreeCmCommissioner::OrderRejectedNotificationSender.call(order: self)
-      end
-
-      def requested_state?
-        request_state == 'requested'
-      end
-
-      def need_confirmation?
-        line_items.any?(&:need_confirmation)
-      end
-
-      def update_to_requested_state_if_confirmation_needed
-        return unless need_confirmation? && request_state.nil? && complete?
-
-        request!
+        after_transition do |order, transition|
+          order.log_state_changes(
+            old_state: transition.from,
+            new_state: transition.to,
+            state_name: :request
+          )
+        end
       end
     end
+
+    # overrided not to send email yet to user if order needs confirmation
+    # it will send after vendors accepted.
+    def confirmation_delivered?
+      confirmation_delivered || need_confirmation?
+    end
+
+    # overrided
+    def payment_required?
+      return false if need_confirmation?
+
+      super
+    end
+
+    # overrided
+    def approved_by(user)
+      transaction do
+        super
+
+        # line items is considered accepted if admin approve whole order
+        line_items.each do |line_item|
+          line_item.accepted_by(user)
+        end
+      end
+    end
+
+    def requested_state?
+      request_state == 'requested'
+    end
+
+    def need_confirmation?
+      line_items.any?(&:need_confirmation)
+    end
+
+    def send_order_request_telegram_confirmation_alert_to_vendor; end
+
+    def notify_order_complete_app_notification_to_user
+      SpreeCmCommissioner::OrderCompleteNotificationSender.call(order: self)
+    end
+
+    def send_order_requested_app_notification_to_user
+      SpreeCmCommissioner::OrderRequestedNotificationSender.call(order: self)
+    end
+
+    def send_order_accepted_app_notification_to_user
+      SpreeCmCommissioner::OrderAcceptedNotificationSender.call(order: self)
+    end
+
+    def send_order_rejected_app_notification_to_user
+      SpreeCmCommissioner::OrderRejectedNotificationSender.call(order: self)
+    end
+
+    def send_order_requested_telegram_alert_store; end
+    def send_order_accepted_telegram_alert_to_store; end
+    def send_order_rejected_telegram_alert_to_store; end
   end
 end

--- a/app/models/concerns/spree_cm_commissioner/product_delegation.rb
+++ b/app/models/concerns/spree_cm_commissioner/product_delegation.rb
@@ -1,0 +1,12 @@
+module SpreeCmCommissioner
+  module ProductDelegation
+    extend ActiveSupport::Concern
+
+    included do
+      delegate :product_type,
+               :need_confirmation?, :need_confirmation,
+               :accommodation?, :service?, :ecommerce?,
+               to: :product
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/order_decorator.rb
+++ b/app/models/spree_cm_commissioner/order_decorator.rb
@@ -12,8 +12,6 @@ module SpreeCmCommissioner
                                                .order(created_at: :desc)
                                            }
 
-      base.after_commit :send_order_complete_notification, if: :order_completed?
-
       base.before_create :link_by_phone_number
       base.before_create :associate_customer
 
@@ -133,10 +131,6 @@ module SpreeCmCommissioner
 
       self.bill_address ||= customer.bill_address.try(:clone)
       self.ship_address ||= customer.ship_address.try(:clone)
-    end
-
-    def send_order_complete_notification
-      SpreeCmCommissioner::OrderCompleteNotificationSender.call(order: self)
     end
   end
 end

--- a/app/models/spree_cm_commissioner/stock/availability_validator_decorator.rb
+++ b/app/models/spree_cm_commissioner/stock/availability_validator_decorator.rb
@@ -3,6 +3,7 @@ module SpreeCmCommissioner
     module AvailabilityValidatorDecorator
       # override
       def validate(line_item)
+        return if line_item.need_confirmation?
         return validate_reservation(line_item) if line_item.reservation?
 
         super

--- a/app/models/spree_cm_commissioner/variant_decorator.rb
+++ b/app/models/spree_cm_commissioner/variant_decorator.rb
@@ -1,10 +1,11 @@
 module SpreeCmCommissioner
   module VariantDecorator
     def self.prepended(base)
+      base.include SpreeCmCommissioner::ProductDelegation
+
       base.after_commit :update_vendor_price
       base.after_save   :update_vendor_total_inventory, if: :saved_change_to_permanent_stock?
       base.validate     :validate_option_types
-      base.delegate :need_confirmation, :product_type, to: :product
 
       base.scope :subscribable, -> { active.joins(:product).where(product: { subscribable: true, status: :active }) }
     end

--- a/db/migrate/20231010161219_rename_spree_line_item_accepted_by_rejected_by_column_to_accepter_rejecter_id.rb
+++ b/db/migrate/20231010161219_rename_spree_line_item_accepted_by_rejected_by_column_to_accepter_rejecter_id.rb
@@ -1,0 +1,11 @@
+class RenameSpreeLineItemAcceptedByRejectedByColumnToAccepterRejecterId < ActiveRecord::Migration[7.0]
+  def change
+    if column_exists?(:spree_line_items, :accepted_by_id)
+      rename_column :spree_line_items, :accepted_by_id, :accepter_id
+    end
+
+    if column_exists?(:spree_line_items, :rejected_by_id)
+      rename_column :spree_line_items, :rejected_by_id, :rejecter_id
+    end
+  end
+end

--- a/lib/spree_cm_commissioner/test_helper/factories/line_item_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/line_item_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     quantity { 1 }
     price    { BigDecimal('10.00') }
     currency { order.currency }
-    
+
     product do
       if order&.store&.present?
         create(:cm_product_with_product_kind_option_types, stores: [order.store])
@@ -12,8 +12,11 @@ FactoryBot.define do
         create(:cm_product_with_product_kind_option_types)
       end
     end
-  
+
     variant { product.master }
+
+    factory :cm_need_confirmation_line_item do
+      product { create(:product, need_confirmation: true) }
+    end
   end
 end
-  

--- a/spec/interactors/spree_cm_commissioner/order_accepted_state_updater_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/order_accepted_state_updater_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SpreeCmCommissioner::OrderAcceptedStateUpdater do
 
         expect(order.request_state).to eq('accepted')
         expect(order.line_items.first.accepted_at).to_not eq nil
-        expect(order.line_items.first.accepted_by).to eq user
+        expect(order.line_items.first.accepter).to eq user
       end
 
       it 'fail if request state is not requested' do

--- a/spec/interactors/spree_cm_commissioner/order_rejected_state_updater_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/order_rejected_state_updater_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SpreeCmCommissioner::OrderRejectedStateUpdater do
         expect(context.success?).to eq true
         expect(order.request_state).to eq('rejected')
         expect(order.line_items.first.rejected_at).to_not eq nil
-        expect(order.line_items.first.rejected_by).to eq user
+        expect(order.line_items.first.rejecter).to eq user
       end
 
       it 'fail if request state is not requested' do

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -103,4 +103,62 @@ RSpec.describe Spree::LineItem, type: :model do
       expect(line_item2.reservation?).to be true
     end
   end
+
+  describe '#accepted_by' do
+    let(:user1) { create(:user) }
+    let(:user2) { create(:user) }
+
+    it "save accepter & date to database if both yet present" do
+      line_item = create(:line_item, accepted_at: nil, accepter: nil)
+      line_item.accepted_by(user1)
+
+      expect(line_item.accepted_at).to_not be_nil
+      expect(line_item.accepter_id).to eq user1.id
+    end
+
+    it "save new accepter & date to database if only accepted_at present" do
+      line_item = create(:line_item, accepted_at: '2024-03-11'.to_date, accepter: nil)
+      line_item.accepted_by(user1)
+
+      expect(line_item.accepted_at).to_not be_nil
+      expect(line_item.accepter_id).to eq user1.id
+    end
+
+    it "save new accepter & date to database if only accepter present" do
+      line_item = create(:line_item, accepted_at: nil, accepter: user1)
+      line_item.accepted_by(user2)
+
+      expect(line_item.accepted_at).to_not be_nil
+      expect(line_item.accepter_id).to eq(user2.id)
+    end
+  end
+
+  describe '#rejected_by' do
+    let(:user1) { create(:user) }
+    let(:user2) { create(:user) }
+
+    it "save rejecter & date to database if both yet present" do
+      line_item = create(:line_item, rejected_at: nil, rejecter: nil)
+      line_item.rejected_by(user1)
+
+      expect(line_item.rejected_at).to_not be_nil
+      expect(line_item.rejecter_id).to eq user1.id
+    end
+
+    it "save new rejecter & date to database if only rejected_at present" do
+      line_item = create(:line_item, rejected_at: '2024-03-11'.to_date, rejecter: nil)
+      line_item.rejected_by(user1)
+
+      expect(line_item.rejected_at).to_not be_nil
+      expect(line_item.rejecter_id).to eq user1.id
+    end
+
+    it "save new rejecter & date to database if only rejecter present" do
+      line_item = create(:line_item, rejected_at: nil, rejecter: user1)
+      line_item.rejected_by(user2)
+
+      expect(line_item.rejected_at).to_not be_nil
+      expect(line_item.rejecter_id).to eq(user2.id)
+    end
+  end
 end

--- a/spec/models/spree/stock/availability_validator_spec.rb
+++ b/spec/models/spree/stock/availability_validator_spec.rb
@@ -2,6 +2,17 @@ require 'spec_helper'
 
 RSpec.describe Spree::Stock::AvailabilityValidator do
   context 'reservation?' do
+    describe '#validate' do
+      it 'always valid when it needs confirmation' do
+        line_item = build(:line_item)
+        allow(line_item).to receive(:need_confirmation?).and_return(true)
+
+        described_class.new.validate(line_item)
+
+        expect(line_item.errors.size).to eq 0
+      end
+    end
+
     describe '#validate_reservation' do
       let!(:product) { create(:cm_accommodation_product, permanent_stock: 3) }
 
@@ -9,8 +20,8 @@ RSpec.describe Spree::Stock::AvailabilityValidator do
         let(:reservation1) { build(:order, state: :complete) }
         let(:reservation2) { build(:order, state: :complete) }
 
-        let!(:line_item1) { create(:line_item, quantity: 3, order: reservation1, product: product, from_date: date('2023-01-10'), to_date: date('2023-01-11')) }
-        let!(:line_item2) { create(:line_item, quantity: 1, order: reservation2, product: product, from_date: date('2023-01-11'), to_date: date('2023-01-13')) }
+        let!(:line_item1) { create(:line_item, quantity: 3, order: reservation1, product: product, from_date: date('2023-01-10'), to_date: date('2023-01-11'), accepted_at: date('2023-01-11')) }
+        let!(:line_item2) { create(:line_item, quantity: 1, order: reservation2, product: product, from_date: date('2023-01-11'), to_date: date('2023-01-13'), accepted_at: date('2023-01-11')) }
 
         it 'error when at least one day could not supply 3 quantity' do
           line_item = build(:line_item, quantity: 3, product: product, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date)


### PR DESCRIPTION
## Scope
- Make it  no validation when add to cart if product needs confirmation
- Not required payment if product needs confirmation
- Save state change when request state transition from state to state
- Notify vendor, hotel, user (empty method for now, will be real send next PR)