### PR TITLE
close #707 allow payment transition to void from failed

### DIFF
--- a/app/models/spree_cm_commissioner/payment_decorator.rb
+++ b/app/models/spree_cm_commissioner/payment_decorator.rb
@@ -10,6 +10,10 @@ module SpreeCmCommissioner
       base.whitelisted_ransackable_attributes |= %w[payable_id]
     end
 
+    def can_void?
+      state.in? %i[pending processing completed checkout]
+    end
+
     # must set current_user_instance
     # before hand
     def set_payable

--- a/app/services/spree_cm_commissioner/cart/destroy_decorator.rb
+++ b/app/services/spree_cm_commissioner/cart/destroy_decorator.rb
@@ -1,0 +1,19 @@
+module SpreeCmCommissioner
+  module Cart
+    module DestroyDecorator
+      # override to only allow state that can be void.
+      # we don't have to void if state is :failed or :invalid.
+      def void_payments(order:)
+        order.payments.each do |payment|
+          payment.void! if payment.can_void?
+        end
+
+        success(order: order)
+      end
+    end
+  end
+end
+
+unless Spree::Cart::Destroy.included_modules.include?(SpreeCmCommissioner::Cart::DestroyDecorator)
+  Spree::Cart::Destroy.prepend(SpreeCmCommissioner::Cart::DestroyDecorator)
+end

--- a/spec/services/spree/cart/destroy_spec.rb
+++ b/spec/services/spree/cart/destroy_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+
+RSpec.describe Spree::Cart::Destroy do
+  describe '#void_payments' do
+    let(:invalid_payment) { create(:payment, state: :invalid) }
+    let(:failed_payment) { create(:payment, state: :failed) }
+    let(:completed_payment) { create(:payment, state: :completed) }
+
+    it 'only void payments that payment.can_void? true' do
+      allow(invalid_payment).to receive(:can_void?).and_return(false)
+      allow(failed_payment).to receive(:can_void?).and_return(false)
+      allow(completed_payment).to receive(:can_void?).and_return(true)
+
+      order = create(:order_with_line_items, payments: [
+        invalid_payment,
+        failed_payment,
+        completed_payment
+      ])
+
+      described_class.new.send(:void_payments, order: order)
+
+      expect(order.payments[0].state).to eq 'invalid'
+      expect(order.payments[1].state).to eq 'failed'
+      expect(order.payments[2].state).to eq 'void'
+    end
+  end
+end


### PR DESCRIPTION
- When user click back from ABA without paying, it payment state to `failed` 
- In mobile app, if user click back from payment, we call api to cancel/destroy that order which force payment to `void!` that payment. 
- Issue is, default spree doesn't allow `failed` - `void`, so when it already failed, we don't need to void it.