### PR TITLE
close #711 required user for cart & checkout api

### DIFF
--- a/app/controllers/spree_cm_commissioner/api/v2/storefront/cart_controller_decorator.rb
+++ b/app/controllers/spree_cm_commissioner/api/v2/storefront/cart_controller_decorator.rb
@@ -4,6 +4,7 @@ module SpreeCmCommissioner
       module Storefront
         module CartControllerDecorator
           def self.prepended(base)
+            base.before_action :require_spree_current_user
             base.before_action :ensure_cart_exist, only: :add_item
           end
 

--- a/app/controllers/spree_cm_commissioner/api/v2/storefront/checkout_controller_decorator.rb
+++ b/app/controllers/spree_cm_commissioner/api/v2/storefront/checkout_controller_decorator.rb
@@ -4,6 +4,8 @@ module SpreeCmCommissioner
       module Storefront
         module CheckoutControllerDecorator
           def self.prepended(base)
+            base.before_action :require_spree_current_user
+
             # spree_vpago gem update payment state in #payment_redirect
             # GET /payment_redirect
             base.around_action :set_writing_role, only: %i[payment_redirect]


### PR DESCRIPTION
For now, we don't support anonymous booking yet, so let make sure if user not login yet, do not allow them to create cart.