### PR TITLE
close #721 add order notification to mock send notification

### DIFF
--- a/app/overrides/spree/admin/shared/_order_tabs/notifications.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_order_tabs/notifications.html.erb.deface
@@ -1,0 +1,8 @@
+<!-- insert_after "erb[silent]:contains('Spree::CustomerReturn')" -->
+
+<li class="nav-item" data-hook='admin_order_tabs_notifications'>
+  <%= link_to_with_icon 'send-check-fill.svg',
+    Spree.t(:notification).pluralize,
+    notifications_admin_order_url(@order),
+    class: "#{'active' if current == :notifications} nav-link" %>
+</li>

--- a/app/views/spree/admin/orders/notifications.html.erb
+++ b/app/views/spree/admin/orders/notifications.html.erb
@@ -1,0 +1,28 @@
+<%= render 'spree/admin/shared/order_tabs', current: :notifications %>
+
+<div class="table-responsive border rounded bg-white">
+  <table class="table">
+    <thead class="text-muted">
+      <th><%= Spree.t(:notification).pluralize %></th>
+      <th class="d-flex justify-content-end"><%= Spree.t(:action).pluralize %></th>
+    </thead>
+    <tbody>
+      <% @notification_methods.each do |notification_method| %>
+        <tr>
+          <td><%= notification_method.humanize %></td>
+          <td class="methods">
+            <span class="d-flex justify-content-end">
+              <%= link_to_with_icon "send.svg",
+                notification_method.humanize,
+                fire_notification_admin_order_path(@order, notification_method: notification_method),
+                method: :put,
+                no_text: true,
+                data: { confirm: Spree.t(:order_sure_want_to, event: notification_method.humanize) },
+                class: "btn btn-light btn-sm" %>
+            </span>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/config/initializers/spree_permitted_attributes.rb
+++ b/config/initializers/spree_permitted_attributes.rb
@@ -4,6 +4,7 @@ module Spree
     @@line_item_attributes += %i[from_date to_date]
     @@user_attributes      += %i[first_name last_name dob gender profile]
     @@taxon_attributes     += %i[category_icon custom_redirect_url to_date from_date kind]
+    @@store_attributes     += %i[preferred_telegram_order_alert_chat_id]
 
     @@checkout_attributes += %i[phone_number country_code]
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -144,6 +144,8 @@ en:
     alert_request_to_vendor: 'Alert request to vendor'
     alerted_to_vendor: 'Alerted to vendor Telegram'
     accept_all: 'Accept all'
+    sent: 'Sent'
+    send_failed_or_method_not_support: 'Send failed or method not support'
     subscribe: 'Use Service'
     full_name: 'name'
     address: 'Address'
@@ -161,6 +163,8 @@ en:
     new_customer: 'New Customer'
     listing_price: 'Listing Price'
     length: 'Length'
+    preference: "Preference"
+    notification: "Notification"
     promotion_rule_types:
       fixed_date:
         name: 'Fixed Date'

--- a/config/locales/km.yml
+++ b/config/locales/km.yml
@@ -136,6 +136,8 @@ km:
     alert_request_to_vendor: 'Alert request to vendor'
     alerted_to_vendor: 'Alerted to vendor Telegram'
     accept_all: 'Accept all'
+    sent: 'Sent'
+    send_failed_or_method_not_support: 'Send failed or method not support'
     subscribe: 'ប្រើសេវាកម្ម'
     full_name: 'ឈ្មោះពេញ'
     address: 'អាសយដ្ឋាន'
@@ -153,6 +155,8 @@ km:
     new_customer: 'អតិថិជនថ្មី'
     listing_price: 'តម្លៃលក់'
     length: 'ប្រវែង'
+    preference: "Preference"
+    notification: "Notification"
     promotion_rule_types:
       fixed_date:
         name: 'ថ្ងៃជាក់លាក់'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,9 @@ Spree::Core::Engine.add_routes do
       member do
         put :accept_all
         put :alert_request_to_vendor
+
+        get :notifications
+        put :fire_notification
       end
     end
   end


### PR DESCRIPTION
## Scope
- Add notification page
- Fix can't set channel id to store

## Demo
<img width="1383" alt="image" src="https://github.com/channainfo/commissioner/assets/29684683/cdf7fe2c-691c-43c5-af81-52b249fdcdf5">
