### PR TITLE
close #736 add full backtrace to telegram exception notifier

### DIFF
--- a/app/exception_notifier/spree_cm_commissioner/telegram_notifier.rb
+++ b/app/exception_notifier/spree_cm_commissioner/telegram_notifier.rb
@@ -4,7 +4,6 @@ module SpreeCmCommissioner
 
     def initialize(options)
       @base_options = options
-      @token = options.delete(:token)
       @channel_id = options.delete(:channel_id)
       @telegram_client = ::Telegram.bots[:exception_notifier]
     end
@@ -54,15 +53,29 @@ module SpreeCmCommissioner
         text << "\n"
       end
 
-      if formatter.backtrace_message.present? && formatter.backtrace_message != "```\n```"
+      backtrace = backtrace_message(exception)
+      if backtrace.present?
         text << '<b>Backtrace:</b>'
-        text << "<code>#{formatter.backtrace_message}</code>"
+        text << "<code>#{backtrace}</code>"
         text << "\n"
       end
 
       text << telegram_exception.to_s if telegram_exception.present?
 
       text.compact.join("\n")
+    end
+
+    def backtrace_message(exception)
+      backtrace = exception.backtrace
+      return if backtrace.blank?
+
+      text = []
+
+      text << '```'
+      backtrace.first(5).each { |line| text << "* #{line}" }
+      text << '```'
+
+      text.join("\n")
     end
   end
 end

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -2,7 +2,6 @@ if ENV['EXCEPTION_NOTIFY_ENABLE'] == 'yes'
   Rails.application.config.middleware.use(
     ExceptionNotification::Rack,
     'spree_cm_commissioner/telegram': {
-      token: ENV.fetch('EXCEPTION_TELEGRAM_BOT_TOKEN', nil),
       channel_id: ENV.fetch('EXCEPTION_NOTIFIER_TELEGRAM_CHANNEL_ID', nil)
     }
   )


### PR DESCRIPTION
- Add first 5 backtrace and not clean
  -> perviously it clean backtrace first & select first 3 backtrace

<img width="603" alt="image" src="https://github.com/channainfo/commissioner/assets/29684683/ce6a8fc4-6a8a-4ba4-ba1e-fd143b79ce62">
