### PR TITLE
close #751 undefine method paid for line items

### DIFF
--- a/app/models/concerns/spree_cm_commissioner/line_items_filter_scope.rb
+++ b/app/models/concerns/spree_cm_commissioner/line_items_filter_scope.rb
@@ -5,6 +5,7 @@ module SpreeCmCommissioner
     included do
       scope :complete, -> { joins(:order).merge(Spree::Order.complete) }
       scope :accepted, -> { joins(:order).merge(Spree::Order.accepted) }
+      scope :paid, -> { joins(:order).merge(Spree::Order.paid) }
 
       scope :filter_by_event, lambda { |event|
         case event

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -71,6 +71,16 @@ RSpec.describe Spree::LineItem, type: :model do
     end
   end
 
+  describe 'paid' do
+    let!(:order1) { create(:order_with_line_items, payment_state: :paid, line_items_count: 1) }
+    let!(:order2) { create(:order_with_line_items, payment_state: :void, line_items_count: 1) }
+
+    it 'it only return paid line items' do
+      expect(described_class.paid.size).to eq 1
+      expect(described_class.paid).to eq order1.line_items
+    end
+  end
+
   describe '#reservation?' do
     let(:ecommerce) { build(:product, product_type: :ecommerce)}
     let(:service) { build(:product, product_type: :service)}


### PR DESCRIPTION
Fix mistake missing paid scope for line items from previous PR: 
https://github.com/channainfo/commissioner/pull/745

Tested on device to make sure:

<img src="https://github.com/channainfo/commissioner/assets/29684683/8e99c7c4-f025-4d74-9ddb-35b4c0d07ed3" width="400px" />
