### PR TITLE
close #760 show request booking order when payment_state is not paid

### DIFF
--- a/app/controllers/spree/api/v2/storefront/order_request_notifications_controller.rb
+++ b/app/controllers/spree/api/v2/storefront/order_request_notifications_controller.rb
@@ -11,7 +11,7 @@ module Spree
 
           def serialize_collection(collection)
             options_data = collection_options(collection).merge(params: serializer_params)
-            options_data[:meta][:unread_count] = collection.select(&:unread?).count
+            options_data[:meta][:unread_count] = spree_current_user.notifications.request_notifications.where(read_at: nil).size
 
             collection_serializer.new(
               collection,

--- a/app/models/spree_cm_commissioner/notification.rb
+++ b/app/models/spree_cm_commissioner/notification.rb
@@ -3,10 +3,9 @@ module SpreeCmCommissioner
     include Noticed::Model
 
     scope :request_notifications, lambda {
-      where(
-        type: %w[order_requested_notification order_rejected_notification order_accepted_notification],
-        read_at: nil
-      ).newest_first
+      select('DISTINCT ON (notificable_id) *')
+        .where(type: %w[order_requested_notification order_rejected_notification order_accepted_notification], read_at: nil)
+        .order('notificable_id, created_at DESC')
     }
 
     scope :user_notifications, lambda {

--- a/app/models/spree_cm_commissioner/order_decorator.rb
+++ b/app/models/spree_cm_commissioner/order_decorator.rb
@@ -8,10 +8,11 @@ module SpreeCmCommissioner
       base.scope :paid, -> { where(payment_state: :paid) }
 
       base.scope :filter_by_request_state, lambda {
-                                             where(state: :complete, payment_state: :paid)
-                                               .where.not(request_state: nil)
-                                               .order(created_at: :desc)
-                                           }
+        where(state: :complete)
+          .where.not(request_state: nil)
+          .where.not(payment_state: :paid)
+          .order(created_at: :desc)
+      }
 
       base.before_create :link_by_phone_number
       base.before_create :associate_customer

--- a/spec/models/spree_cm_commissioner/notification_spec.rb
+++ b/spec/models/spree_cm_commissioner/notification_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::Notification, type: :model do
+
+  describe "request_notifications" do
+    it "return the latest notification if records have the same notification_id" do
+      notification1 = create(:notification,
+         type: 'order_requested_notification',
+         read_at: nil,
+         notificable_id: 1,
+         notificable_type: 'Spree::Order'
+      )
+      notification2 = create(:notification,
+        type: 'order_rejected_notification',
+        read_at: nil,
+        notificable_id: 1,
+        notificable_type: 'Spree::Order'
+      )
+
+      notifications = SpreeCmCommissioner::Notification.request_notifications
+
+      expect(notifications).to contain_exactly(notification2)
+    end
+  end
+end


### PR DESCRIPTION
#### Task BreakDown
-  scope :request_notifications: Query only latest request booking notification if it is the same order  (if request order have been accepted want to return  the accepted notification only )

- scope :filter_by_request_state : Query only request order that have not paid yet 