### PR TITLE
close #813 add queue when call queue_webhooks_requests

### DIFF
--- a/app/interactors/spree_cm_commissioner/webhook_subscriber_orders_sender.rb
+++ b/app/interactors/spree_cm_commissioner/webhook_subscriber_orders_sender.rb
@@ -21,7 +21,7 @@ module SpreeCmCommissioner
 
     def queue_webhooks_requests
       context.orders.each do |order|
-        order.queue_webhooks_requests!('order.placed')
+        SpreeCmCommissioner::QueueOrderWebhooksRequestsJob.perform_later(order_id: order.id, event: 'order.placed')
       end
     end
   end

--- a/app/jobs/spree_cm_commissioner/queue_order_webhooks_requests_job.rb
+++ b/app/jobs/spree_cm_commissioner/queue_order_webhooks_requests_job.rb
@@ -1,0 +1,13 @@
+# queue_webhooks_requests! already contains queue job, but before it prepare to call queue_webhooks_requests!,
+# it could raise serializer error which needed to be recorded in queue dashboard.
+module SpreeCmCommissioner
+  class QueueOrderWebhooksRequestsJob < ApplicationJob
+    def perform(options)
+      order_id = options[:order_id]
+      event = options[:event]
+
+      order = Spree::Order.find(order_id)
+      order.queue_webhooks_requests!(event)
+    end
+  end
+end

--- a/spec/jobs/spree_cm_commissioner/queue_order_webhooks_requests_job_spec.rb
+++ b/spec/jobs/spree_cm_commissioner/queue_order_webhooks_requests_job_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::QueueOrderWebhooksRequestsJob, type: :job do
+  describe "#perform" do
+    let(:event) { 'order.placed' }
+    let(:order) { create(:order) }
+
+    it "queues webhooks requests" do
+      allow(Spree::Order).to receive(:find).with(order.id).and_return(order)
+      allow(order).to receive(:queue_webhooks_requests!).with(event)
+
+      described_class.perform_now({ order_id: order.id, event: event })
+
+      expect(Spree::Order).to have_received(:find).with(order.id)
+      expect(order).to have_received(:queue_webhooks_requests!).with(event)
+    end
+  end
+end

--- a/spec/jobs/spree_cm_commissioner/webhook_subscriber_orders_sender_job_spec.rb
+++ b/spec/jobs/spree_cm_commissioner/webhook_subscriber_orders_sender_job_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::WebhookSubscriberOrdersSenderJob, type: :job do
+  describe "#perform" do
+    let(:order_state) { 'complete' }
+    let(:webhooks_subscriber) { create(:cm_webhook_subscriber) }
+
+    it "send orders to webhook subscriber" do
+      allow(Spree::Webhooks::Subscriber).to receive(:find).with(webhooks_subscriber.id).and_return(webhooks_subscriber)
+      allow(SpreeCmCommissioner::WebhookSubscriberOrdersSender).to receive(:call)
+                                                              .with(order_state: order_state, webhooks_subscriber: webhooks_subscriber)
+                                                              .and_return(webhooks_subscriber)
+
+      described_class.perform_now(order_state: order_state, webhooks_subscriber_id: webhooks_subscriber.id)
+
+      expect(Spree::Webhooks::Subscriber).to have_received(:find).with(webhooks_subscriber.id)
+      expect(SpreeCmCommissioner::WebhookSubscriberOrdersSender).to have_received(:call).with(
+        order_state: order_state,
+        webhooks_subscriber: webhooks_subscriber
+      )
+    end
+  end
+end


### PR DESCRIPTION
Previously when we send orders to subscriber, some order raise error which cause whole queue to failed. So this time, we add queue to individual order instead.

This is all jobs:
- WebhookSubscriberOrdersSenderJob: send all order
   - QueueOrderWebhooksRequestsJob: send to a order, capture error if serializer or anything raise
      - Spree::Webhooks::Subscribers::MakeRequestJob: send a order to subscribers

![image](https://github.com/channainfo/commissioner/assets/29684683/8effe246-3c39-4061-8a99-5102b73474ac)
