### PR TITLE
close #819 fix relation between vendor to promotions

### DIFF
--- a/app/models/concerns/spree_cm_commissioner/vendor_promotable.rb
+++ b/app/models/concerns/spree_cm_commissioner/vendor_promotable.rb
@@ -3,7 +3,8 @@ module SpreeCmCommissioner
     extend ActiveSupport::Concern
 
     included do
-      has_many :promotion_rules, class_name: 'Spree::PromotionRule'
+      has_many :vendor_promotion_rules, class_name: 'SpreeCmCommissioner::VendorPromotionRule'
+      has_many :promotion_rules, through: :vendor_promotion_rules, class_name: 'Spree::PromotionRule'
       has_many :promotions, through: :promotion_rules, class_name: 'Spree::Promotion'
 
       has_many :active_promotions, -> { active },

--- a/spec/models/spree/vendor_spec.rb
+++ b/spec/models/spree/vendor_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe Spree::Vendor, type: :model do
     it { should have_many(:option_values).class_name('Spree::OptionValue').through(:products) }
     it { should have_many(:option_types).class_name('Spree::OptionType').through(:vendor_option_types) }
     it { should have_many(:promoted_option_types).class_name('Spree::OptionType').through(:vendor_option_types) }
+    it { should have_many(:vendor_promotion_rules).class_name('SpreeCmCommissioner::VendorPromotionRule') }
+    it { should have_many(:promotion_rules).class_name('Spree::PromotionRule').through(:vendor_promotion_rules) }
+    it { should have_many(:promotions).class_name('Spree::Promotion').through(:promotion_rules) }
   end
 
   describe 'attributes' do


### PR DESCRIPTION
We move promotion vendor rule to be multiple, but forget to set relation between vendor to promotion. This will cause promotion to not display on UI and also not auto apply.

Back now!

<img src="https://github.com/channainfo/commissioner/assets/29684683/92d85947-0de7-4183-bed9-8573c245df66" width="350px" />
