### PR TITLE
close #834 bring back organization tab

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ PATH
       spree_auth_devise (>= 4.5.0)
       spree_backend (>= 4.5.0)
       spree_extension
-      spree_multi_vendor (>= 2.4.0)
+      spree_multi_vendor (>= 2.4.1)
       telegram-bot
       twilio-ruby (~> 5.48.0)
 
@@ -778,7 +778,7 @@ GEM
     spree_extension (0.1.0)
       activerecord (>= 4.2)
       spree_core
-    spree_multi_vendor (2.4.0)
+    spree_multi_vendor (2.4.1)
       deface (~> 1.0)
       spree (>= 4.3.0.rc1)
       spree_backend (>= 4.3.0.rc1)

--- a/app/overrides/spree/admin/shared/_main_menu/sidebar_organizations.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_main_menu/sidebar_organizations.html.erb.deface
@@ -1,6 +1,0 @@
-<!-- remove "#sidebarOrganizations" -->
-
-# TODO:
-
-# Remove as we don't need organizations side bar yet because spree_multi_vendor still has it.
-# Once spree_multi_vendor remove its side bar, we can remove this file.

--- a/app/overrides/spree/admin/vendors/index/index.html.erb.deface
+++ b/app/overrides/spree/admin/vendors/index/index.html.erb.deface
@@ -1,6 +1,6 @@
 <!-- replace "[data-hook='vendors_table']" -->
 
-<div class="table-responsive">
+<div class="table-responsive border rounded">
   <table class="table sortable" data-hook="vendors_table" data-sortable-link="<%= update_positions_admin_vendors_url %>">
     <thead>
       <tr data-hook="vendors_header">

--- a/spree_cm_commissioner.gemspec
+++ b/spree_cm_commissioner.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_api_v1', spree_opts # latest spree_multi_vendor 2.4.0 still depends on the Spree v1 API
   s.add_dependency 'spree_auth_devise', spree_opts
   s.add_dependency 'spree_backend', spree_opts
-  s.add_dependency 'spree_multi_vendor', '>= 2.4.0'
+  s.add_dependency 'spree_multi_vendor', '>= 2.4.1'
   s.add_dependency 'spree_extension'
 
   s.add_dependency 'phonelib'


### PR DESCRIPTION
spree_multi_vendor [2.4.1](https://github.com/spree-contrib/spree_multi_vendor/releases/tag/v2.4.1) removes vendor tab as it already in organization tab of spree_backend.

<img width="210" alt="image" src="https://github.com/channainfo/commissioner/assets/29684683/fc99d0dd-65fd-497e-ace0-f7c5c0125528">

