### PR TITLE
close #838 not force update order.request_state when complete

### DIFF
--- a/app/models/concerns/spree_cm_commissioner/order_requestable.rb
+++ b/app/models/concerns/spree_cm_commissioner/order_requestable.rb
@@ -9,7 +9,7 @@ module SpreeCmCommissioner
       # since it has usecase that order state is forced to update which not fire after_transition
 
       after_update :notify_order_complete_app_notification_to_user, if: -> { state_changed_to_complete? }
-      after_update :request!, if: -> { state_changed_to_complete? && need_confirmation? }
+      after_update :request, if: -> { state_changed_to_complete? && need_confirmation? }
       after_update :send_order_complete_telegram_alert_to_vendors, if: -> { state_changed_to_complete? && !need_confirmation? }
       after_update :send_order_complete_telegram_alert_to_store, if: -> { state_changed_to_complete? && !need_confirmation? }
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -185,13 +185,13 @@ RSpec.describe Spree::Order, type: :model do
       allow(order).to receive(:confirmation_required?).and_return(false)
     end
 
-    it "calls request! when order need_confirmation?" do
+    it "calls request when order need_confirmation?" do
       allow(order).to receive(:need_confirmation?).and_return(true)
-      allow(order).to receive(:request!).and_return(true)
+      allow(order).to receive(:request).and_return(true)
 
       order.next!
 
-      expect(order).to have_received(:request!)
+      expect(order).to have_received(:request)
     end
 
     it "notify user when need confirmation" do


### PR DESCRIPTION
Fix case where order is not yet complete, but request state already accepted or rejected which not valid.

```
Application spree_starter


⚠️ Error occurred in production ⚠️
A *StateMachines::InvalidTransition* occurred in *payments#create*.


Exception:
Cannot transition request_state via :request from :accepted (Reason(s): Request state cannot transition via "request")


Set by controller:
{:user=>"40"}
```