### PR TITLE
close #840 add create date specific adjustment platform serializer

### DIFF
--- a/app/serializers/spree/api/v2/platform/create_date_specific_item_adjustment_serializer.rb
+++ b/app/serializers/spree/api/v2/platform/create_date_specific_item_adjustment_serializer.rb
@@ -1,0 +1,10 @@
+module Spree
+  module Api
+    module V2
+      module Platform
+        class CreateDateSpecificItemAdjustmentSerializer < PromotionActionSerializer
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This only error when we have active webhook subscribers.
 
```
Application spree_starter


⚠️ Error occurred in production ⚠️
A *NameError* occurred in *customer_details#update*.


Exception:
Spree::Api::V2::Platform::AdjustmentSerializer cannot resolve a serializer class for 'SpreeCmCommissioner::Promotion::Actions::CreateDateSpecificItemAdjustments'.  Attempted to find 'Spree::Api::V2::Platform::CreateDateSpecificItemAdjustmentSerializer'. Consider specifying the serializer directly through options[:serializer].


Set by controller:
{:user=>"2"}
```