### PR TITLE
close #842 fix undefine promotion_id for source when promotion action is deleted

### DIFF
--- a/app/models/spree_cm_commissioner/order_decorator.rb
+++ b/app/models/spree_cm_commissioner/order_decorator.rb
@@ -66,6 +66,15 @@ module SpreeCmCommissioner
       super
     end
 
+    # overrided
+    # avoid raise error when source_id is nil.
+    # https://github.com/channainfo/commissioner/pull/843
+    def valid_promotion_ids
+      all_adjustments.eligible.nonzero.promotion
+                     .where.not(source_id: nil)
+                     .map { |a| a.source.promotion_id }.uniq
+    end
+
     # assume check is default payment method for subscription
     def create_default_payment_if_eligble
       return unless subscription?


### PR DESCRIPTION
When delete promotion or promotion action, it will delete all related adjustments.  Following error is when it does not delete related adjustments. 

```
Application spree_starter


⚠️ Error occurred in production ⚠️
A *NoMethodError* occurred in *orders#show*.


Exception:
undefined method `promotion_id' for nil:NilClass
```