### PR TITLE
WIP #884 fix Noticed::ResponseUnsuccessful when push to ios device

### DIFF
--- a/app/controllers/spree/admin/customer_notifications_controller.rb
+++ b/app/controllers/spree/admin/customer_notifications_controller.rb
@@ -21,14 +21,12 @@ module Spree
       def send_test
         user_ids = params[:user_ids] || []
         customer_notification = SpreeCmCommissioner::CustomerNotification.find(params[:notification_id])
-
         context = { customer_notification: customer_notification, user_ids: user_ids }
-        response = SpreeCmCommissioner::CustomerNotificationSender.call(context)
-
-        if response.success?
-          redirect_to admin_customer_notifications_path, notice: I18n.t('notification.send_test_success')
-        else
-          redirect_to admin_customer_notifications_path, alert: response.error_message
+        begin
+          response = SpreeCmCommissioner::CustomerNotificationSender.call(context)
+          redirect_to admin_customer_notifications_path, notice: I18n.t('notification.send_test_success') if response.success?
+        rescue StandardError => e
+          redirect_to admin_customer_notifications_path, alert: e.message
         end
       end
     end

--- a/app/notifications/noticed_fcm_base.rb
+++ b/app/notifications/noticed_fcm_base.rb
@@ -32,7 +32,9 @@ class NoticedFcmBase < Noticed::Base
     {
       data: convert_hash_values_to_str(payload),
       token: device_token,
-      notification: notification_data
+      notification: notification_data,
+      android: android,
+      apns: apns
     }
   end
 
@@ -48,7 +50,8 @@ class NoticedFcmBase < Noticed::Base
 
   def payload
     default_payload = {
-      id: notificable.id.to_s
+      id: notificable.id.to_s,
+      type: type
     }
     default_payload.merge(extra_payload)
   end


### PR DESCRIPTION
Application spree_starter

⚠️ Error occurred in staging ⚠️
A Noticed::ResponseUnsuccessful occurred in customer_notifications#send_test.

Exception:
Noticed::ResponseUnsuccessful

Set by controller:
{:user=>"1"}

Request:

* url : https://staging-server.contigo.asia/admin/customer_notifications/3/send_test
* http_method : POST
* ip_address : 43.230.192.190
* parameters : {"authenticity_token"=>"[FILTERED]", "notification_id"=>"3", "user_ids"=>["", "42"], "commit"=>"Send", "controller"=>"spree/admin/customer_notifications", "action"=>"send_test", "customer_notification_id"=>"3"}
* timestamp : 2023-11-21 17:01:07 +0700
Backtrace:

* /app/vendor/bundle/ruby/3.2.0/gems/noticed-1.6.3/lib/noticed/delivery_methods/base.rb:88:in `post'
* /app/vendor/bundle/ruby/3.2.0/gems/noticed-1.6.3/lib/noticed/delivery_methods/fcm.rb:21:in `block in deliver'
* /app/vendor/bundle/ruby/3.2.0/gems/noticed-1.6.3/lib/noticed/delivery_methods/fcm.rb:20:in `each'
* /app/vendor/bundle/ruby/3.2.0/gems/noticed-1.6.3/lib/noticed/delivery_methods/fcm.rb:20:in `deliver'
* /app/vendor/bundle/ruby/3.2.0/gems/noticed-1.6.3/lib/noticed/delivery_methods/base.rb:55:in `block in perform'