### PR TITLE
close #868 fix redirect and load data

### DIFF
--- a/app/controllers/spree/admin/line_items_controller.rb
+++ b/app/controllers/spree/admin/line_items_controller.rb
@@ -32,7 +32,9 @@ module Spree
 
       def load_data
         scope = current_store.orders
-        @order = scope.find(params[:order_id])
+
+        @order = scope.find_by(number: params[:order_id])
+
         @line_item = @order.line_items.find(params[:id])
       end
     end

--- a/app/views/spree/admin/line_items/_form.html.erb
+++ b/app/views/spree/admin/line_items/_form.html.erb
@@ -12,7 +12,7 @@
       <div data-hook="admin_line_item_form_date">
         <%= f.field_container :from_date do %>
           <%= f.label :from_date, raw(Spree.t(:from_date) + required_span_tag) %>
-          <%= f.text_field :from_date, class: 'form-control datePickerFrom mb-2', 'data-input': '', value: @line_item.from_date.to_date %>
+          <%= f.text_field :from_date, class: 'form-control datePickerFrom mb-2', 'data-input': '', value: (@line_item.from_date ? @line_item.from_date.to_date : nil) %>
           <%= f.error_message_on :from_date %>
         <% end %>
       </div>
@@ -20,10 +20,11 @@
       <div data-hook="admin_line_item_to_date">
         <%= f.field_container :to_date do %>
           <%= f.label :to_date, raw(Spree.t(:to_date) + required_span_tag) %>
-          <%= f.text_field :to_date, class: 'form-control datePickerTo', 'data-input': '', value: @line_item.to_date.to_date, 'data-min-date': @line_item.from_date.to_date %>
+          <%= f.text_field :to_date, class: 'form-control datePickerTo', 'data-input': '', value: (@line_item.to_date ? @line_item.to_date.to_date : nil), 'data-min-date': (@line_item.from_date ? @line_item.from_date.to_date : nil) %>
           <%= f.error_message_on :to_date %>
         <% end %>
       </div>
     </div>
   </div>
 </div>
+


### PR DESCRIPTION
In the load_data method of line_items_controller.rb, we're currently using find_by to retrieve the order based on the number attribute. This method returns nil if no record is found, which could potentially lead to a nil error in the subsequent line where we're trying to access line_items on @order. We need to refactor this method to handle the case where @order might be nil.