### PR TITLE
close #950 add kyc fields to guest line item api

### DIFF
--- a/app/models/concerns/spree_cm_commissioner/kyc_bitwise.rb
+++ b/app/models/concerns/spree_cm_commissioner/kyc_bitwise.rb
@@ -15,5 +15,11 @@ module SpreeCmCommissioner
         kyc & bit_value != 0
       end
     end
+
+    def kyc_fields
+      BIT_FIELDS.filter_map do |field, bit_value|
+        field if kyc & bit_value != 0
+      end
+    end
   end
 end

--- a/app/models/spree_cm_commissioner/line_item_decorator.rb
+++ b/app/models/spree_cm_commissioner/line_item_decorator.rb
@@ -4,6 +4,7 @@ module SpreeCmCommissioner
       base.include SpreeCmCommissioner::LineItemDurationable
       base.include SpreeCmCommissioner::LineItemsFilterScope
       base.include SpreeCmCommissioner::ProductDelegation
+      base.include SpreeCmCommissioner::KycBitwise
 
       base.belongs_to :accepter, class_name: 'Spree::User', optional: true
       base.belongs_to :rejecter, class_name: 'Spree::User', optional: true

--- a/app/serializers/spree_cm_commissioner/v2/storefront/guest_line_item_serializer.rb
+++ b/app/serializers/spree_cm_commissioner/v2/storefront/guest_line_item_serializer.rb
@@ -4,7 +4,7 @@ module SpreeCmCommissioner
       class GuestLineItemSerializer < BaseSerializer
         set_type :line_item
 
-        attributes :remaining_total_guests, :quantity, :kyc
+        attributes :remaining_total_guests, :quantity, :kyc, :kyc_fields
 
         belongs_to :vendor, serializer: Spree::V2::Storefront::VendorSerializer
         has_many :guests, serializer: :guest


### PR DESCRIPTION
```json
{
    "data": [
        {
            "id": "2045",
            "type": "line_item",
            "attributes": {
                "remaining_total_guests": 1,
                "quantity": 1,
                "kyc": 15,
                "kyc_fields": [
                    "guest_name",
                    "guest_gender",
                    "guest_dob",
                    "guest_occupation"
                ]
            },
            "relationships": {
                "vendor": {
                    "data": {
                        "id": "64",
                        "type": "vendor"
                    }
                },
                "guests": {
                    "data": []
                }
            }
        },
        {
            "id": "2046",
            "type": "line_item",
            "attributes": {
                "remaining_total_guests": 1,
                "quantity": 1,
                "kyc": 9,
                "kyc_fields": [
                    "guest_name",
                    "guest_occupation"
                ]
            },
            "relationships": {
                "vendor": {
                    "data": {
                        "id": "103",
                        "type": "vendor"
                    }
                },
                "guests": {
                    "data": []
                }
            }
        }
    ]
}
```