### PR TITLE
close #1064 api for dashboard_crew_events

### DIFF
--- a/app/controllers/spree/api/v2/operator/dashboard_crew_events_controller.rb
+++ b/app/controllers/spree/api/v2/operator/dashboard_crew_events_controller.rb
@@ -1,0 +1,25 @@
+module Spree
+  module Api
+    module V2
+      module Operator
+        class DashboardCrewEventsController < ::Spree::Api::V2::ResourceController
+          before_action :require_spree_current_user
+
+          def collection
+            # spree_current_user.line_items.complete.paid.filter_by_event(params[:event])
+            @collection = SpreeCmCommissioner::DashboardCrewEventQuery.new(
+              user_id: spree_current_user.id,
+              section: params[:section] || 'incoming'
+            ).call
+
+            @collection = @collection.page(params[:page]).per(params[:per_page])
+          end
+
+          def collection_serializer
+            SpreeCmCommissioner::V2::Operator::DashboardCrewEventSerializer
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/spree/api/v2/operator/event_ticket_aggregators_controller.rb
+++ b/app/controllers/spree/api/v2/operator/event_ticket_aggregators_controller.rb
@@ -1,0 +1,20 @@
+module Spree
+  module Api
+    module V2
+      module Operator
+        class EventTicketAggregatorsController < ::Spree::Api::V2::ResourceController
+          def resource
+            @resource = SpreeCmCommissioner::EventTicketAggregatorQuery.new(
+              taxon_id: params[:taxon_id],
+              refreshed: params[:refreshed] || false
+            ).call
+          end
+
+          def resource_serializer
+            SpreeCmCommissioner::V2::Operator::EventTicketAggregatorSerializer
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/spree_cm_commissioner/admin/payments_controller_decorator.rb
+++ b/app/controllers/spree_cm_commissioner/admin/payments_controller_decorator.rb
@@ -1,0 +1,14 @@
+module SpreeCmCommissioner
+  module Admin
+    module PaymentsControllerDecorator
+      def self.prepended(base)
+        # spree call order.next on new which might set some data to database.
+        base.around_action :set_writing_role, only: %i[new]
+      end
+    end
+  end
+end
+
+unless Spree::Admin::PaymentsController.ancestors.include?(SpreeCmCommissioner::Admin::PaymentsControllerDecorator)
+  Spree::Admin::PaymentsController.prepend(SpreeCmCommissioner::Admin::PaymentsControllerDecorator)
+end

--- a/app/queries/spree_cm_commissioner/dashboard_crew_event_query.rb
+++ b/app/queries/spree_cm_commissioner/dashboard_crew_event_query.rb
@@ -1,0 +1,31 @@
+module SpreeCmCommissioner
+  class DashboardCrewEventQuery
+    attr_reader :user_id, :section
+
+    # user_id:, section: 'incoming | previous'
+    def initialize(user_id:, section:)
+      @user_id = user_id
+      @section = section
+    end
+
+    def call
+      events
+    end
+
+    def events
+      taxons = Spree::Taxon.select('spree_taxons.id AS taxon_id, spree_taxons.name, spree_taxons.permalink, spree_taxons.from_date, spree_taxons.to_date, spree_taxons.updated_at') # rubocop:disable Layout/LineLength
+                           .joins('INNER JOIN cm_user_taxons ON spree_taxons.id = cm_user_taxons.taxon_id')
+                           .where(cm_user_taxons: { user_id: user_id, type: 'SpreeCmCommissioner::UserEvent' })
+
+      if section == 'incoming'
+        taxons = taxons.where('spree_taxons.from_date >= ?', Time.zone.now)
+        taxons = taxons.order(from_date: :asc)
+      else
+        taxons = taxons.where('spree_taxons.from_date < ?', Time.zone.now)
+        taxons = taxons.order(to_date: :desc)
+      end
+
+      taxons
+    end
+  end
+end

--- a/app/queries/spree_cm_commissioner/event_ticket_aggregator_query.rb
+++ b/app/queries/spree_cm_commissioner/event_ticket_aggregator_query.rb
@@ -1,0 +1,63 @@
+module SpreeCmCommissioner
+  class EventTicketAggregatorQuery
+    attr_reader :taxon_id, :refreshed
+
+    # taxon_id:, refreshed: false
+    def initialize(taxon_id:, refreshed: false)
+      @taxon_id = taxon_id
+      @refreshed = refreshed
+    end
+
+    def call
+      cache_key = "event-ticket-aggregator-query-#{taxon_id}"
+      Rails.cache.delete(cache_key) if refreshed
+
+      value = Rails.cache.fetch(cache_key, expires_in: 5.minutes) do
+        product_aggregators
+      end
+
+      SpreeCmCommissioner::EventTicketAggregator.new(
+        id: taxon_id,
+        value: value
+      )
+    end
+
+    # SELECT
+    #     spree_products.id as product_id,
+    #     SUM(spree_line_items.quantity) AS total_ticket,
+    #     COUNT(*) AS total_items
+    # FROM spree_products
+    # INNER JOIN spree_variants ON spree_products.id = spree_variants.product_id
+    # INNER JOIN spree_line_items ON spree_variants.id = spree_line_items.variant_id
+    # INNER JOIN spree_orders ON spree_orders.id = spree_line_items.order_id
+    # INNER JOIN spree_products_taxons ON spree_products.id = spree_products_taxons.product_id
+    # WHERE
+    #     spree_orders.state = 'complete' AND
+    #     spree_products_taxons.taxon_id = 18
+    # GROUP BY spree_products.id;
+
+    def product_aggregators
+      select_fields = [
+        'spree_products.id  as product_id',
+        'SUM(spree_line_items.quantity) AS total_tickets',
+        'COUNT(*) AS total_items'
+      ]
+
+      Spree::Product
+        .select(select_fields)
+        .joins('INNER JOIN spree_variants ON spree_products.id = spree_variants.product_id')
+        .joins('LEFT JOIN spree_line_items ON spree_variants.id = spree_line_items.variant_id')
+        .joins('INNER JOIN spree_orders ON spree_orders.id = spree_line_items.order_id')
+        .joins('INNER JOIN spree_products_taxons ON spree_products.id = spree_products_taxons.product_id')
+        .where(spree_orders: { state: 'complete' }, spree_products_taxons: { taxon_id: taxon_id })
+        .group('spree_products.id')
+        .map do |record|
+          record.slice(
+            :product_id,
+            :total_tickets,
+            :total_items
+          )
+        end
+    end
+  end
+end

--- a/app/serializables/spree_cm_commissioner/event_ticket_aggregator.rb
+++ b/app/serializables/spree_cm_commissioner/event_ticket_aggregator.rb
@@ -1,0 +1,10 @@
+module SpreeCmCommissioner
+  class EventTicketAggregator
+    attr_accessor :id, :value
+
+    def initialize(id:, value:)
+      @id = id
+      @value = value
+    end
+  end
+end

--- a/app/serializers/spree_cm_commissioner/v2/operator/dashboard_crew_event_serializer.rb
+++ b/app/serializers/spree_cm_commissioner/v2/operator/dashboard_crew_event_serializer.rb
@@ -1,0 +1,13 @@
+module SpreeCmCommissioner
+  module V2
+    module Operator
+      class DashboardCrewEventSerializer < BaseSerializer
+        attributes :taxon_id, :name, :permalink, :from_date, :to_date
+
+        set_id do |event, _params|
+          event.taxon_id
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/spree_cm_commissioner/v2/operator/event_ticket_aggregator_serializer.rb
+++ b/app/serializers/spree_cm_commissioner/v2/operator/event_ticket_aggregator_serializer.rb
@@ -1,0 +1,9 @@
+module SpreeCmCommissioner
+  module V2
+    module Operator
+      class EventTicketAggregatorSerializer < BaseSerializer
+        attributes :id, :value
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -280,6 +280,10 @@ Spree::Core::Engine.add_routes do
         resources :line_items, only: %i[index show]
         resources :check_ins, only: %i[index create]
         resource :check_in_bulks, only: %i[index create]
+        resources :dashboard_crew_events, only: %i[index]
+        resources :taxons do
+          resource :event_ticket_aggregators, only: %i[show]
+        end
       end
     end
 


### PR DESCRIPTION
#### GET : {{BASE_URL}}/api/v2/operator/dashboard_crew_events?section=incoming

```json
{
    "data": [
        {
            "id": "115",
            "type": "dashboard_crew_event",
            "attributes": {
                "taxon_id": 115,
                "name": "🔺TEDxPhnomPenh 2024!",
                "permalink": "events/tedxphnompenh-2024",
                "from_date": "2024-02-21T00:00:00.000+07:00",
                "to_date": "2024-04-30T00:00:00.000+07:00"
            }
        },
        {
            "id": "18",
            "type": "dashboard_crew_event",
            "attributes": {
                "taxon_id": 18,
                "name": "RUN WITH SAI",
                "permalink": "events/run-with-sai",
                "from_date": "2024-03-31T00:00:00.000+07:00",
                "to_date": "2024-04-03T00:00:00.000+07:00"
            }
        }
    ],
    "meta": {
        "count": 2,
        "total_count": 2,
        "total_pages": 1
    },
    "links": {
        "self": "http://127.0.0.1:4000/api/v2/operator/dashboard_crew_events?section=incoming",
        "next": "http://127.0.0.1:4000/api/v2/operator/dashboard_crew_events?page=1",
        "prev": "http://127.0.0.1:4000/api/v2/operator/dashboard_crew_events?page=1",
        "last": "http://127.0.0.1:4000/api/v2/operator/dashboard_crew_events?page=1",
        "first": "http://127.0.0.1:4000/api/v2/operator/dashboard_crew_events?page=1"
    }
}
```
#### GET : {{BASE_URL}}/api/v2/operator/dashboard_crew_events?section=previous

```json
{
    "data": [
        {
            "id": "78",
            "type": "dashboard_crew_event",
            "attributes": {
                "taxon_id": 78,
                "name": "Garden City Splash Night",
                "permalink": "events/garden-city-splash-night",
                "from_date": "2023-12-24T00:00:00.000+07:00",
                "to_date": "2023-12-31T00:00:00.000+07:00"
            }
        },
        {
            "id": "74",
            "type": "dashboard_crew_event",
            "attributes": {
                "taxon_id": 74,
                "name": "បុណ្យភូមិមានជើង",
                "permalink": "events/bonnphum-on-the-move",
                "from_date": "2023-12-01T00:00:00.000+07:00",
                "to_date": "2023-12-10T00:00:00.000+07:00"
            }
        }
    ],
    "meta": {
        "count": 2,
        "total_count": 2,
        "total_pages": 1
    },
    "links": {
        "self": "http://127.0.0.1:4000/api/v2/operator/dashboard_crew_events?section=previous",
        "next": "http://127.0.0.1:4000/api/v2/operator/dashboard_crew_events?page=1",
        "prev": "http://127.0.0.1:4000/api/v2/operator/dashboard_crew_events?page=1",
        "last": "http://127.0.0.1:4000/api/v2/operator/dashboard_crew_events?page=1",
        "first": "http://127.0.0.1:4000/api/v2/operator/dashboard_crew_events?page=1"
    }
}
```
#### GET : {{BASE_URL}}/api/v2/operator/taxons/115/event_ticket_aggregators

```json

{
    "data": {
        "id": "115",
        "type": "event_ticket_aggregator",
        "attributes": {
            "id": "115",
            "value": [
                {
                    "product_id": 124,
                    "total_tickets": 9,
                    "total_items": 7
                },
                {
                    "product_id": 126,
                    "total_tickets": 1,
                    "total_items": 1
                },
                {
                    "product_id": 128,
                    "total_tickets": 2,
                    "total_items": 1
                }
            ]
        }
    }
}
```