### PR TITLE
close #1078 add notification type to request order payload

### DIFF
--- a/app/notifications/spree_cm_commissioner/order_accepted_notification.rb
+++ b/app/notifications/spree_cm_commissioner/order_accepted_notification.rb
@@ -12,7 +12,8 @@ module SpreeCmCommissioner
       {
         order_number: order.number,
         title: notification_title,
-        message: notification_message
+        message: notification_message,
+        notification_type: type
 
       }
     end

--- a/app/notifications/spree_cm_commissioner/order_rejected_notification.rb
+++ b/app/notifications/spree_cm_commissioner/order_rejected_notification.rb
@@ -16,7 +16,8 @@ module SpreeCmCommissioner
       {
         order_number: order.number,
         title: notification_title,
-        message: notification_message
+        message: notification_message,
+        notification_type: type
 
       }
     end

--- a/app/notifications/spree_cm_commissioner/order_requested_notification.rb
+++ b/app/notifications/spree_cm_commissioner/order_requested_notification.rb
@@ -16,7 +16,8 @@ module SpreeCmCommissioner
       {
         order_number: order.number,
         title: notification_title,
-        message: notification_message
+        message: notification_message,
+        notification_type: type
 
       }
     end


### PR DESCRIPTION
      {
        order_number: order.number,
        title: notification_title,
        message: notification_message,
        notification_type: type

      }
- use notification_type to navigate to its corresponding screen when handle background click even