### PR TITLE
wip #1107 add started_at to spree_product

### DIFF
--- a/app/models/concerns/spree_cm_commissioner/product_delegation.rb
+++ b/app/models/concerns/spree_cm_commissioner/product_delegation.rb
@@ -4,7 +4,7 @@ module SpreeCmCommissioner
 
     included do
       delegate :product_type,
-               :need_confirmation?, :need_confirmation, :kyc,
+               :need_confirmation?, :need_confirmation, :kyc, :started_at,
                :accommodation?, :service?, :ecommerce?,
                to: :product
     end

--- a/app/overrides/spree/admin/products/_form/started_at.html.erb.deface
+++ b/app/overrides/spree/admin/products/_form/started_at.html.erb.deface
@@ -1,0 +1,17 @@
+<!-- insert_after "[data-hook='admin_product_form_subscribable']" -->
+
+  <div class="col-lg-12 col-sm-12 px-0 pb-3 ">
+    <%= f.label :started_at, class: "text-md" %>
+    <div class="input-group datePickerTo"
+          data-wrap="true"
+          data-alt-input="true"
+          data-enable-time="true"
+    >
+      <%= f.text_field :started_at,
+                        value: @object.started_at,
+                        placeholder: Spree.t(:select_a_date),
+                        class: 'form-control shadow-none ',
+                        'data-input':'' %>
+      <%= render partial: 'spree/admin/shared/cal_close' %>
+    </div>
+</div>

--- a/app/overrides/spree/admin/products/new/started_at.html.erb.deface
+++ b/app/overrides/spree/admin/products/new/started_at.html.erb.deface
@@ -1,0 +1,17 @@
+<!-- insert_after "[data-hook='product-from-prototype']" -->
+
+  <div class="col-lg-4 col-sm-12 px-0  pb-4 ">
+    <%= f.label :started_at, class: "text-md" %>
+    <div class="input-group datePickerTo"
+          data-wrap="true"
+          data-alt-input="true"
+          data-enable-time="true"
+    >
+      <%= f.text_field :started_at,
+                        value: @object.started_at,
+                        placeholder: Spree.t(:select_a_date),
+                        class: 'form-control shadow-none ',
+                        'data-input':'' %>
+      <%= render partial: 'spree/admin/shared/cal_close' %>
+    </div>
+</div>

--- a/app/serializers/spree/v2/storefront/line_item_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/line_item_serializer_decorator.rb
@@ -4,7 +4,7 @@ module Spree
       module LineItemSerializerDecorator
         def self.prepended(base)
           base.attributes :from_date, :to_date, :need_confirmation, :product_type, :event_status, :amount, :display_amount,
-                          :kyc, :kyc_fields, :remaining_total_guests, :number_of_guests
+                          :kyc, :kyc_fields, :started_at, :remaining_total_guests, :number_of_guests
 
           base.has_one :vendor
 

--- a/app/serializers/spree/v2/storefront/product_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/product_serializer_decorator.rb
@@ -9,7 +9,7 @@ module Spree
           base.has_many :possible_promotions, serializer: ::SpreeCmCommissioner::V2::Storefront::PromotionSerializer
 
           base.has_one :default_state, serializer: :state
-          base.attributes :need_confirmation, :product_type, :kyc
+          base.attributes :need_confirmation, :product_type, :kyc, :started_at
           base.attributes :reveal_description
         end
       end

--- a/db/migrate/20240209034620_add_started_at_to_spree_product.rb
+++ b/db/migrate/20240209034620_add_started_at_to_spree_product.rb
@@ -1,0 +1,6 @@
+class AddStartedAtToSpreeProduct < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_products, :started_at, :datetime, if_not_exists: true
+    add_index :spree_products, :started_at, if_not_exists: true
+  end
+end

--- a/spec/serializers/spree/v2/storefront/line_item_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/line_item_serializer_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe Spree::V2::Storefront::LineItemSerializer, type: :serializer do
         :event_status,
         :kyc,
         :kyc_fields,
+        :started_at,
         :remaining_total_guests,
         :number_of_guests
       )

--- a/spec/serializers/spree/v2/storefront/product_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/product_serializer_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Spree::V2::Storefront::ProductSerializer, type: :serializer do
         :display_compare_at_price,
         :need_confirmation,
         :kyc,
+        :started_at,
         :product_type,
         :reveal_description,
       )


### PR DESCRIPTION
<img width="1511" alt="image" src="https://github.com/channainfo/commissioner/assets/92453740/07d032a5-2b20-46ef-a626-fa8a53ad0eeb">

### Usage 
- This field is needed to keep track of time of upcoming product so that we can perform schedule push notification  to alert user 
