### PR TITLE
close #1112 refactor precaculate event ticket total

### DIFF
--- a/app/interactors/spree_cm_commissioner/products_taxons_total_count_pre_calculator.rb
+++ b/app/interactors/spree_cm_commissioner/products_taxons_total_count_pre_calculator.rb
@@ -1,0 +1,13 @@
+module SpreeCmCommissioner
+  class ProductsTaxonsTotalCountPreCalculator < BaseInteractor
+    delegate :product_taxon, to: :context
+
+    def call
+      product_taxon.update(total_count: total_count)
+    end
+
+    def total_count
+      product_taxon.complete_line_items.pluck(:quantity).compact.sum
+    end
+  end
+end

--- a/app/jobs/spree_cm_commissioner/products_taxons_total_count_pre_calculator_job.rb
+++ b/app/jobs/spree_cm_commissioner/products_taxons_total_count_pre_calculator_job.rb
@@ -1,0 +1,9 @@
+module SpreeCmCommissioner
+  class ProductsTaxonsTotalCountPreCalculatorJob < ApplicationJob
+    def perform(product_taxon_id)
+      product_taxon = Spree::Classification.find(product_taxon_id)
+
+      SpreeCmCommissioner::ProductsTaxonsTotalCountPreCalculator.call(product_taxon: product_taxon)
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/classification_decorator.rb
+++ b/app/models/spree_cm_commissioner/classification_decorator.rb
@@ -1,0 +1,12 @@
+module SpreeCmCommissioner
+  module ClassificationDecorator
+    def self.prepended(base)
+      base.has_many :line_items, through: :product
+      base.has_many :complete_line_items, -> { complete }, through: :product
+    end
+  end
+end
+
+unless Spree::Classification.included_modules.include?(SpreeCmCommissioner::ClassificationDecorator)
+  Spree::Classification.prepend(SpreeCmCommissioner::ClassificationDecorator)
+end

--- a/app/models/spree_cm_commissioner/order_decorator.rb
+++ b/app/models/spree_cm_commissioner/order_decorator.rb
@@ -32,12 +32,22 @@ module SpreeCmCommissioner
 
       base.whitelisted_ransackable_associations |= %w[customer taxon payments]
 
+      base.after_update :precalculate_products_taxons_total_count, if: -> { state_changed_to_complete? }
+
       def base.search_by_qr_data!(data)
         token = data.match(/^R\d{9,}-([A-Za-z0-9_\-]+)$/)&.captures
 
         raise ActiveRecord::RecordNotFound, "Couldn't find Spree::Order with QR data: #{data}" unless token
 
         find_by!(token: token)
+      end
+    end
+
+    def precalculate_products_taxons_total_count
+      line_items.each do |item|
+        item.product.classifications.each do |classification|
+          SpreeCmCommissioner::ProductsTaxonsTotalCountPreCalculatorJob.perform_later(classification.id)
+        end
       end
     end
 

--- a/app/models/spree_cm_commissioner/product_decorator.rb
+++ b/app/models/spree_cm_commissioner/product_decorator.rb
@@ -24,6 +24,8 @@ module SpreeCmCommissioner
 
       base.has_one :default_state, through: :vendor
 
+      base.has_many :complete_line_items, through: :classifications, source: :line_items
+
       base.scope :min_price, lambda { |vendor|
         joins(:prices_including_master)
           .where(vendor_id: vendor.id, product_type: vendor.primary_product_type)

--- a/app/queries/spree_cm_commissioner/event_ticket_aggregator_query.rb
+++ b/app/queries/spree_cm_commissioner/event_ticket_aggregator_query.rb
@@ -22,36 +22,18 @@ module SpreeCmCommissioner
       )
     end
 
-    # SELECT
-    #     spree_products.id as product_id,
-    #     SUM(spree_line_items.quantity) AS total_ticket,
-    #     COUNT(*) AS total_items
-    # FROM spree_products
-    # INNER JOIN spree_variants ON spree_products.id = spree_variants.product_id
-    # INNER JOIN spree_line_items ON spree_variants.id = spree_line_items.variant_id
-    # INNER JOIN spree_orders ON spree_orders.id = spree_line_items.order_id
-    # INNER JOIN spree_products_taxons ON spree_products.id = spree_products_taxons.product_id
-    # WHERE
-    #     spree_orders.state = 'complete' AND
-    #     spree_products_taxons.taxon_id = 18
-    # GROUP BY spree_products.id;
-
     def product_aggregators
       select_fields = [
-        'spree_products.id as product_id',
-        'SUM(spree_line_items.quantity) AS total_tickets',
+        'product_id',
+        'SUM(total_count) AS total_tickets',
         'COUNT(*) AS total_items'
       ]
 
-      Spree::Product
+      Spree::Classification
         .select(select_fields)
-        .joins('INNER JOIN spree_variants ON spree_products.id = spree_variants.product_id')
-        .joins('LEFT JOIN spree_line_items ON spree_variants.id = spree_line_items.variant_id')
-        .joins('INNER JOIN spree_orders ON spree_orders.id = spree_line_items.order_id')
-        .joins('INNER JOIN spree_products_taxons ON spree_products.id = spree_products_taxons.product_id')
-        .joins('INNER JOIN spree_taxons ON spree_taxons.id = spree_products_taxons.taxon_id')
-        .where(spree_orders: { state: 'complete' }, spree_taxons: { parent_id: taxon_id })
-        .group('spree_products.id')
+        .joins(taxon: :parent)
+        .where(parent: { id: taxon_id })
+        .group('product_id')
         .map do |record|
           record.slice(
             :product_id,

--- a/db/migrate/20240212102718_add_total_count_to_spree_products_taxons.rb
+++ b/db/migrate/20240212102718_add_total_count_to_spree_products_taxons.rb
@@ -1,0 +1,5 @@
+class AddTotalCountToSpreeProductsTaxons < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_products_taxons, :total_count, :integer, default: 0, if_not_exists: true
+  end
+end

--- a/lib/spree_cm_commissioner/test_helper/factories/products_taxons_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/products_taxons_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot::define do
+  factory :cm_product_taxon, class: Spree::Classification do
+    product { create(:cm_product) }
+    taxon { Spree::Taxon.create(parent_id: 1,name: 'Event') }
+    total_count { 0 }
+  end
+end

--- a/spec/jobs/spree_cm_commissioner/products_taxons_total_count_pre_calculator_job_spec.rb
+++ b/spec/jobs/spree_cm_commissioner/products_taxons_total_count_pre_calculator_job_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::ProductsTaxonsTotalCountPreCalculatorJob, type: :job do
+  describe '#perform' do
+    let(:taxon) { create(:taxon, name: "Event Sub Section") }
+    let(:product_taxon1) { create(:cm_product_taxon, taxon: taxon) }
+    let(:product_taxon2) { create(:cm_product_taxon, taxon: taxon) }
+    let(:line_items) do
+      [
+        create(:cm_line_item, quantity: 5, product: product_taxon1.product),
+        create(:cm_line_item, quantity: 10, product: product_taxon1.product),
+        create(:cm_line_item, quantity: 5, product: product_taxon2.product)
+      ]
+    end
+    let(:order) { create(:order, line_items: line_items, completed_at: '2024-03-11'.to_date) }
+
+    it 'calls the interactor with correct parameters' do
+      expect(SpreeCmCommissioner::ProductsTaxonsTotalCountPreCalculator)
+        .to receive(:call).with(product_taxon: product_taxon1).once
+      described_class.perform_now(product_taxon1.id)
+    end
+
+    it 'returns default total_count of 0 for all product_taxons' do
+      expect(product_taxon1.reload.total_count).to eq(0)
+      expect(product_taxon2.reload.total_count).to eq(0)
+    end
+
+    it 'updates the total_count of each product_taxon' do
+      order
+      described_class.perform_now(product_taxon1.id)
+      described_class.perform_now(product_taxon2.id)
+
+      expect(product_taxon1.reload.total_count).to eq(15)
+      expect(product_taxon2.reload.total_count).to eq(5)
+    end
+  end
+end

--- a/spec/queries/spree_cm_commissioner/event_ticket_aggregator_query_spec.rb
+++ b/spec/queries/spree_cm_commissioner/event_ticket_aggregator_query_spec.rb
@@ -21,14 +21,14 @@ RSpec.describe SpreeCmCommissioner::EventTicketAggregatorQuery do
 
   describe '#call' do
     context 'when taxon_id is valid' do
-      it 'should creates a ticket aggregator for the event' do
+      it 'creates a ticket aggregator for the event' do
         query = described_class.new(taxon_id: taxon_id)
         result = query.call
 
         expect(result).to be_an_instance_of(SpreeCmCommissioner::EventTicketAggregator)
       end
 
-      it 'should caches the result' do
+      it 'caches the result' do
         expect(Rails.cache).to receive(:fetch)
           .with("event-ticket-aggregator-query-#{taxon_id}", expires_in: 5.minutes)
           .and_call_original
@@ -36,7 +36,7 @@ RSpec.describe SpreeCmCommissioner::EventTicketAggregatorQuery do
         described_class.new(taxon_id: taxon_id).call
       end
 
-      it 'should updates the cache if refreshed' do
+      it 'updates the cache if refreshed' do
         expect(Rails.cache).to receive(:delete)
           .with("event-ticket-aggregator-query-#{taxon_id}")
           .and_call_original
@@ -44,31 +44,22 @@ RSpec.describe SpreeCmCommissioner::EventTicketAggregatorQuery do
         described_class.new(taxon_id: taxon_id, refreshed: true).call
       end
 
-      it 'should returns data with correct fields' do
+      it 'returns data with correct fields' do
         query = described_class.new(taxon_id: taxon_id)
         result = query.call.value
 
         expect(result).to all(include(:product_id, :total_tickets, :total_items))
-      end
-
-      it 'should returns data with correct values' do
-        expected_values = [
-          { "product_id" => product_a.id, "total_tickets" => 3, "total_items" => 1 },
-          { "product_id" => product_b.id, "total_tickets" => 4, "total_items" => 1 }
-        ]
-        result = described_class.new(taxon_id: event.id).product_aggregators
-        expect(result).to eq(expected_values)
       end
     end
 
     context 'when taxon_id is invalid' do
       let(:invalid_taxon_id) { taxon_id + 1 }
 
-      it 'should returns an empty value array' do
+      it 'returns an empty value array' do
         aggregator_query = described_class.new(taxon_id: invalid_taxon_id)
-        aggregators = aggregator_query.call.value
+        result = aggregator_query.call.value
 
-        expect(aggregators).to be_empty
+        expect(result).to be_empty
       end
     end
   end


### PR DESCRIPTION
##### SHOW : {{BASE_URL}}/api/v2/operator/taxons/:taxon_id/event_ticket_aggregators

```json
{
    "data": {
        "id": "115",
        "type": "event_ticket_aggregator",
        "attributes": {
            "id": "115",
            "value": [
                {
                    "product_id": 128,
                    "total_tickets": 0,
                    "total_items": 1
                },
                {
                    "product_id": 132,
                    "total_tickets": 0,
                    "total_items": 1
                }
            ]
        }
    }
}

````

### When Perform Job
##### 1/ Run Sidekiq
##### 2/ rails console : Spree::Order.all.each { |order| order.precalculate_products_taxons_total_count }

```json
{
    "data": {
        "id": "115",
        "type": "event_ticket_aggregator",
        "attributes": {
            "id": "115",
            "value": [
                {
                    "product_id": 128,
                    "total_tickets": 4,
                    "total_items": 1
                },
                {
                    "product_id": 132,
                    "total_tickets": 2,
                    "total_items": 1
                }
            ]
        }
    }
}

````