### PR TITLE
close #1102 allow api filter homepage sections by segment

### DIFF
--- a/app/controllers/spree/api/v2/storefront/homepage_sections_controller.rb
+++ b/app/controllers/spree/api/v2/storefront/homepage_sections_controller.rb
@@ -7,16 +7,16 @@ module Spree
             SpreeCmCommissioner::HomepageSection
           end
 
-          def collection
-            model_class.active
-          end
-
           def collection_serializer
             Spree::V2::Storefront::HomepageSectionSerializer
           end
 
           def resource_serializer
             Spree::V2::Storefront::HomepageSectionSerializer
+          end
+
+          def collection
+            @collection ||= model_class.filter_by_segment(params[:homepage_id] || :general).active.order(position: :asc)
           end
         end
       end

--- a/app/models/concerns/spree_cm_commissioner/homepage_section_bitwise.rb
+++ b/app/models/concerns/spree_cm_commissioner/homepage_section_bitwise.rb
@@ -11,17 +11,17 @@ module SpreeCmCommissioner
 
     BIT_SEGMENT.each do |segment, bit_value|
       define_method "#{segment}?" do
-        homepage_section_value_enabled?(bit_value)
+        segment_enabled?(bit_value)
       end
     end
 
     def segments
       BIT_SEGMENT.filter_map do |segment_value, bit_value|
-        segment_value if homepage_section_value_enabled?(bit_value)
+        segment_value if segment_enabled?(bit_value)
       end
     end
 
-    def homepage_section_value_enabled?(bit_value)
+    def segment_enabled?(bit_value)
       segment & bit_value != 0
     end
   end

--- a/app/models/spree_cm_commissioner/homepage_section.rb
+++ b/app/models/spree_cm_commissioner/homepage_section.rb
@@ -9,5 +9,7 @@ module SpreeCmCommissioner
     has_many :homepage_section_relatables, -> { active }, inverse_of: :homepage_section, dependent: :destroy
 
     scope :active, -> { where(active: true).order(:position) }
+
+    scope :filter_by_segment, -> (segment) { where('segment & ? > 0', BIT_SEGMENT[segment.to_sym]) }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -274,6 +274,11 @@ Spree::Core::Engine.add_routes do
         resources :homepage_sections, only: [:index]
         resources :order_qrs, only: [:show]
 
+        resources :homepage, only: [] do
+          resources :homepage_sections, only: [:index]
+          resource :homepage_background, only: [:show]
+        end
+
         resources :guest_qrs, only: [:show]
         resources :guests, only: %i[create update show] do
           resources :id_cards

--- a/spec/models/spree_cm_commissioner/homepage_section_spec.rb
+++ b/spec/models/spree_cm_commissioner/homepage_section_spec.rb
@@ -36,4 +36,18 @@ RSpec.describe SpreeCmCommissioner::HomepageSection, type: :model do
       expect(homepage_section.homepage_section_relatables_count).to eq 1
     end
   end
+
+  describe '.filter_by_segment' do
+    it 'should return sections with the given segment' do
+      general_section = create(:cm_homepage_section, segment: 1)
+      ticket_section = create(:cm_homepage_section, segment: 2)
+      tour_section = create(:cm_homepage_section, segment: 4)
+      accommodation = create(:cm_homepage_section, segment: 8)
+
+      expect(described_class.filter_by_segment(:general).to_a).to eq [general_section]
+      expect(described_class.filter_by_segment(:ticket).to_a).to eq [ticket_section]
+      expect(described_class.filter_by_segment(:tour).to_a).to eq [tour_section]
+      expect(described_class.filter_by_segment(:accommodation).to_a).to eq [accommodation]
+    end
+  end
 end


### PR DESCRIPTION
Old app api **{{BASE_URL}}/api/v2/storefront/homepage_sections** will only get general section.

```json
"data": [
        {
            "id": "5",
            "type": "homepage_section",
            "attributes": {
                "id": 5,
                "title": "Become our partner",
                "segments": [
                    "general"
                ],
                "description": "",
                "active": true,
                "position": 3,
                "created_at": "2024-01-30T14:59:04.453+07:00",
                "updated_at": "2024-02-15T15:17:06.391+07:00"
            },
            "relationships": {
                "homepage_section_relatables": {
                    "data": [
                        {
                            "id": "19",
                            "type": "homepage_section_relatable"
                        }
                    ]
                }
            }
        },
        {
            "id": "10",
            "type": "homepage_section",
            "attributes": {
                "id": 10,
                "title": "General  + Ticket Section",
                "segments": [
                    "general",
                    "ticket"
                ],
                "description": "",
                "active": true,
                "position": 4,
                "created_at": "2024-02-15T15:18:34.064+07:00",
                "updated_at": "2024-02-15T15:19:00.196+07:00"
            },
            "relationships": {
                "homepage_section_relatables": {
                    "data": [
                        {
                            "id": "28",
                            "type": "homepage_section_relatable"
                        }
                    ]
                }
            }
        }
    ],
```

New api route **{{BASE_URL}}/api/v2/storefront/homepage/:homepage_id/homepage_sections** will get section filter by homepage_id such as ticket, accomodation, car rental, etc.

```json
 "data": [
        {
            "id": "10",
            "type": "homepage_section",
            "attributes": {
                "id": 10,
                "title": "wow",
                "segments": [
                    "general",
                    "ticket"
                ],
                "description": "",
                "active": true,
                "position": 6,
                "created_at": "2024-02-13T23:08:38.072+07:00",
                "updated_at": "2024-02-13T23:08:38.072+07:00"
            },
            "relationships": {
                "homepage_section_relatables": {
                    "data": []
                }
            }
        },
        {
            "id": "15",
            "type": "homepage_section",
            "attributes": {
                "id": 15,
                "title": "General + Ticket Section",
                "segments": [
                    "general",
                    "ticket"
                ],
                "description": "",
                "active": true,
                "position": 7,
                "created_at": "2024-02-15T09:42:08.778+07:00",
                "updated_at": "2024-02-15T09:42:22.946+07:00"
            },
            "relationships": {
                "homepage_section_relatables": {
                    "data": []
                }
            }
        },
        {
            "id": "16",
            "type": "homepage_section",
            "attributes": {
                "id": 16,
                "title": "Only ticket",
                "segments": [
                    "ticket"
                ],
                "description": "",
                "active": true,
                "position": 8,
                "created_at": "2024-02-15T09:51:18.410+07:00",
                "updated_at": "2024-02-15T09:51:18.410+07:00"
            },
            "relationships": {
                "homepage_section_relatables": {
                    "data": []
                }
            }
        }
    ],
```