### PR TITLE
close #1121 fixed ActiveRecord::ReadOnlyError on /transit/route

### DIFF
--- a/app/controllers/spree/transit/places_controller.rb
+++ b/app/controllers/spree/transit/places_controller.rb
@@ -5,9 +5,7 @@ module Spree
       helper 'spree/transit/sortable_tree'
 
       def load_place_taxonomy
-        ActiveRecord::Base.connected_to(role: :writing) do
-          @place_taxonomy = Spree::Taxonomy.place
-        end
+        @place_taxonomy = Spree::Taxonomy.place
       end
 
       before_action :set_permalink_part, only: [:edit]

--- a/app/controllers/spree/transit/routes_controller.rb
+++ b/app/controllers/spree/transit/routes_controller.rb
@@ -15,8 +15,7 @@ module Spree
         @option_types = OptionType.order(:name)
         @shipping_categories = ShippingCategory.order(:name)
         @selected_option_type_ids = Spree::OptionType.where(name: %w[origin destination]).ids
-        taxonomies = Spree::Taxonomy.where(kind: :transit)
-        @taxons = taxonomies.map(&:taxons).flatten
+        @taxons = Spree::Taxonomy.place.taxons
       end
 
       def collection
@@ -32,8 +31,8 @@ module Spree
         @search = current_vendor.products.where(product_type: :transit).ransack(params[:q].reject { |k, _v| k.to_s == 'deleted_at_null' })
 
         @collection = @search.result
-                      .page(params[:page])
-                      .per(params[:per_page] || Spree::Backend::Config[:variants_per_page])
+                             .page(params[:page])
+                             .per(params[:per_page] || Spree::Backend::Config[:variants_per_page])
         @collection
       end
 

--- a/app/models/spree_cm_commissioner/taxonomy_decorator.rb
+++ b/app/models/spree_cm_commissioner/taxonomy_decorator.rb
@@ -4,7 +4,9 @@ module SpreeCmCommissioner
       base.include SpreeCmCommissioner::TaxonomyKind
 
       def base.place
-        Spree::Taxonomy.find_or_create_by(name: 'Place', kind: 'transit', store: Spree::Store.default)
+        ActiveRecord::Base.connected_to(role: :writing) do
+          Spree::Taxonomy.find_or_create_by(name: 'Place', kind: 'transit', store: Spree::Store.default)
+        end
       end
     end
   end


### PR DESCRIPTION
Problem: Trying to create "place" taxonomy in read-only mode
<img width="1440" alt="image" src="https://github.com/channainfo/commissioner/assets/87005466/bf096ffc-3ab5-4e3b-974f-469edb014901">
