### PR TITLE
close #1118 segment homepage image background for specific page

### DIFF
--- a/app/controllers/spree/admin/homepage_background_controller.rb
+++ b/app/controllers/spree/admin/homepage_background_controller.rb
@@ -1,6 +1,8 @@
 module Spree
   module Admin
     class HomepageBackgroundController < Spree::Admin::ResourceController
+      helper SpreeCmCommissioner::Admin::HomepageSegmentHelper
+
       before_action :build_images, only: :create
       before_action :create_images, only: :update
 

--- a/app/controllers/spree/admin/homepage_section_controller.rb
+++ b/app/controllers/spree/admin/homepage_section_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Admin
     class HomepageSectionController < Spree::Admin::ResourceController
-      include SpreeCmCommissioner::Admin::HomepageSegmentHelper
+      helper SpreeCmCommissioner::Admin::HomepageSegmentHelper
 
       def model_class
         SpreeCmCommissioner::HomepageSection
@@ -46,7 +46,7 @@ module Spree
 
       # overrided
       def permitted_resource_params
-        segment_value = calculate_segment_value(params[:spree_cm_commissioner_homepage_section])
+        segment_value = helpers.calculate_segment_value(params[:spree_cm_commissioner_homepage_section])
 
         params.require(:spree_cm_commissioner_homepage_section).permit(:title, :description, :active).merge(segment: segment_value)
       end

--- a/app/controllers/spree/api/v2/storefront/homepage_background_controller.rb
+++ b/app/controllers/spree/api/v2/storefront/homepage_background_controller.rb
@@ -1,0 +1,21 @@
+module Spree
+  module Api
+    module V2
+      module Storefront
+        class HomepageBackgroundController < ::Spree::Api::V2::ResourceController
+          def model_class
+            SpreeCmCommissioner::HomepageBackground
+          end
+
+          def resource_serializer
+            SpreeCmCommissioner::V2::Storefront::HomepageBackgroundSerializer
+          end
+
+          def resource
+            @resource ||= model_class.active.where(segment: params[:homepage_id] || :general).order(priority: :asc).first
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/spree_cm_commissioner/admin/homepage_segment_helper.rb
+++ b/app/helpers/spree_cm_commissioner/admin/homepage_segment_helper.rb
@@ -1,7 +1,7 @@
 module SpreeCmCommissioner
   module Admin
     module HomepageSegmentHelper
-      def self.badge_class_for_segment(segment_name)
+      def badge_class_for_segment(segment_name)
         case segment_name.to_sym
         when :general
           'badge badge-primary text-uppercase'

--- a/app/models/concerns/spree_cm_commissioner/homepage_section_bitwise.rb
+++ b/app/models/concerns/spree_cm_commissioner/homepage_section_bitwise.rb
@@ -6,7 +6,8 @@ module SpreeCmCommissioner
       general: 0b00001,
       ticket: 0b00010,
       tour: 0b00100,
-      accommodation: 0b01000
+      accommodation: 0b01000,
+      things_to_do: 0b10000
     }.freeze
 
     BIT_SEGMENT.each do |segment, bit_value|

--- a/app/models/spree_cm_commissioner/homepage_background.rb
+++ b/app/models/spree_cm_commissioner/homepage_background.rb
@@ -10,6 +10,8 @@ module SpreeCmCommissioner
 
     scope :active, -> { where(active: true) }
 
+    enum segment: SpreeCmCommissioner::HomepageSectionBitwise::BIT_SEGMENT.keys
+
     def toggle_status!
       self.active = !active?
 

--- a/app/serializers/spree_cm_commissioner/v2/storefront/homepage_background_serializer.rb
+++ b/app/serializers/spree_cm_commissioner/v2/storefront/homepage_background_serializer.rb
@@ -2,7 +2,7 @@ module SpreeCmCommissioner
   module V2
     module Storefront
       class HomepageBackgroundSerializer < BaseSerializer
-        attributes :title, :active, :priority
+        attributes :title, :segment, :active, :priority
 
         has_one :app_image, serializer: :asset
         has_one :web_image, serializer: :asset

--- a/app/views/spree/admin/homepage_background/_form.html.erb
+++ b/app/views/spree/admin/homepage_background/_form.html.erb
@@ -3,6 +3,17 @@
     <%= f.label :title %>
     <%= f.text_field :title, class: 'form-control' %>
   <% end %>
+  <%= f.field_container :segment do %>
+    <%= f.label :segment %>
+    <% SpreeCmCommissioner::HomepageBackground.segments.keys.each do |segment| %>
+      <div class="radio" data-id="<%= segment.to_s %>">
+        <label data-hook="segment_field">
+          <%= f.radio_button :segment, segment, class: "segments_radios" %>
+          <%= segment.to_s.capitalize %>
+        </label>
+      </div>
+    <% end %>
+  <% end %>
   <%= f.field_container :app_image do %>
     <%= f.label :mobile_image %> <span>(750x270)</span>
     <%= f.file_field :app_image %>

--- a/app/views/spree/admin/homepage_background/index.html.erb
+++ b/app/views/spree/admin/homepage_background/index.html.erb
@@ -16,7 +16,7 @@
           </th>
           <th><%= Spree.t(:app_image) %></th>
           <th><%= Spree.t(:web_image) %></th>
-          <th><%= Spree.t(:created_at) %></th>
+          <th><%= Spree.t(:segment) %></th>
           <th><%= Spree.t(:active) %></th>
           <th></th>
         </tr>
@@ -39,7 +39,9 @@
             </div>
           </td>
           <td>
-            <%= pretty_time(homepage_background.created_at) %>
+            <%= content_tag(:strong, class: badge_class_for_segment(homepage_background.segment)) do %>
+              <%= homepage_background.segment.to_s.capitalize %>
+            <% end %>
           </td>
           <td>
             <%= active_badge(homepage_background.active?) %>

--- a/app/views/spree/admin/homepage_section/index.html.erb
+++ b/app/views/spree/admin/homepage_section/index.html.erb
@@ -34,7 +34,7 @@
             <td>
               <% SpreeCmCommissioner::HomepageSectionBitwise::BIT_SEGMENT.each do |segment_name, bit_value| %>
                 <% if homepage_section.segment & bit_value != 0 %>
-                  <%= content_tag(:strong, class: SpreeCmCommissioner::Admin::HomepageSegmentHelper.badge_class_for_segment(segment_name)) do %>
+                  <%= content_tag(:strong, class: badge_class_for_segment(segment_name)) do %>
                     <%= segment_name.to_s.capitalize %>
                   <% end %>
                 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -276,7 +276,7 @@ Spree::Core::Engine.add_routes do
 
         resources :homepage, only: [] do
           resources :homepage_sections, only: [:index]
-          resource :homepage_background, only: [:show]
+          resource :homepage_background, controller: :homepage_background, only: [:show]
         end
 
         resources :guest_qrs, only: [:show]

--- a/db/migrate/20240216024911_add_segment_to_homepage_background.rb
+++ b/db/migrate/20240216024911_add_segment_to_homepage_background.rb
@@ -1,0 +1,5 @@
+class AddSegmentToHomepageBackground < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cm_homepage_backgrounds, :segment, :integer, default: 0
+  end
+end

--- a/spec/models/spree_cm_commissioner/homepage_background_spec.rb
+++ b/spec/models/spree_cm_commissioner/homepage_background_spec.rb
@@ -5,22 +5,22 @@ RSpec.describe SpreeCmCommissioner::HomepageBackground, type: :model do
     it { should have_one(:app_image).class_name('SpreeCmCommissioner::HomepageBackgroundAppImage').dependent(:destroy) }
     it { should have_one(:web_image).class_name('SpreeCmCommissioner::HomepageBackgroundWebImage').dependent(:destroy) }
   end
-  
+
   describe '#toggle_status' do
     context 'when active is false' do
       it 'return true' do
         background = create(:cm_homepage_background, active: false)
         background.toggle_status!
-        
+
         expect(background.active).to eq true
       end
     end
-    
+
     context 'when active is true' do
       it 'return false' do
         background = create(:cm_homepage_background, active: true)
         background.toggle_status!
-        
+
         expect(background.active).to eq false
       end
     end


### PR DESCRIPTION
- Previously we can only upload image for home screen. 
- In this PR, we added new field call `segment` to homepage_backgrounds, and allow frontend to fetch that image for a specific screen.

[Screencast from 2024-02-16 10-48-24.webm](https://github.com/channainfo/commissioner/assets/109834020/7c64cafd-2c2e-4003-97d4-3c7affeb6210)
