### PR TITLE
close #1143 reload order before recaculate

### DIFF
--- a/app/services/spree_cm_commissioner/cart/recalculate_decorator.rb
+++ b/app/services/spree_cm_commissioner/cart/recalculate_decorator.rb
@@ -1,0 +1,18 @@
+module SpreeCmCommissioner
+  module Cart
+    module RecalculateDecorator
+      # override
+      def call(order:, line_item:, line_item_created: false, options: {})
+        # recaculate is called after update quantity, add or remove line items.
+        # order should be reload before recaculate to avoid wrong caculation.
+        order.reload
+
+        super
+      end
+    end
+  end
+end
+
+unless Spree::Cart::Recalculate.included_modules.include?(SpreeCmCommissioner::Cart::RecalculateDecorator)
+  Spree::Cart::Recalculate.prepend(SpreeCmCommissioner::Cart::RecalculateDecorator)
+end

--- a/spec/services/spree/cart/remove_line_item_spec.rb
+++ b/spec/services/spree/cart/remove_line_item_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe Spree::Cart::RemoveLineItem do
+  describe '#call' do
+    let(:order) { create(:order) }
+    let!(:line_item_a) { create(:line_item, order: order, price: BigDecimal('10.00'), quantity: 1) }
+    let!(:line_item_b) { create(:line_item, order: order, price: BigDecimal('12.00'), quantity: 1) }
+
+    it 'should recaculate correct order total after line items is removed' do
+      result = Spree::Cart::RemoveLineItem.new.call(order: order, line_item: line_item_a)
+
+      expect(order.total).to eq line_item_b.amount
+    end
+  end
+end


### PR DESCRIPTION
This change is making sure that cart has an accurate calculation when there is any change to cart or its line items.