### PR TITLE
close #1146 notification title and message does not show the lated up…

### DIFF
--- a/app/models/spree_cm_commissioner/user_decorator.rb
+++ b/app/models/spree_cm_commissioner/user_decorator.rb
@@ -56,10 +56,12 @@ module SpreeCmCommissioner
 
       notification = recipient.notifications.where(options).first_or_initialize
 
-      return notification if notification.persisted?
-
-      notification.assign_attributes(attributes)
-      notification.save!
+      if notification.persisted?
+        notification.update(attributes)
+      else
+        notification.assign_attributes(attributes)
+        notification.save!
+      end
 
       notification
     end


### PR DESCRIPTION
Error occur when Admin edit the content of notification then when push again it still show the old data  


### Error Screen 
![screen](https://github.com/channainfo/commissioner/assets/92453740/689d9285-2e65-426e-a542-45358120a564)
