### PR TITLE
close #1155 return event and total_count with single api request and rspec

### DIFF
--- a/app/controllers/spree/api/v2/operator/dashboard_crew_events_controller.rb
+++ b/app/controllers/spree/api/v2/operator/dashboard_crew_events_controller.rb
@@ -6,12 +6,10 @@ module Spree
           before_action :require_spree_current_user
 
           def collection
-            @collection = SpreeCmCommissioner::DashboardCrewEventQuery.new(
+            @collection ||= SpreeCmCommissioner::DashboardCrewEventQuery.new(
               user_id: spree_current_user.id,
               section: params[:section] || 'incoming'
             ).call
-
-            @collection = @collection.page(params[:page]).per(params[:per_page])
           end
 
           def collection_serializer

--- a/app/models/spree_cm_commissioner/taxon_decorator.rb
+++ b/app/models/spree_cm_commissioner/taxon_decorator.rb
@@ -20,6 +20,8 @@ module SpreeCmCommissioner
       base.has_one :app_banner, as: :viewable, dependent: :destroy, class_name: 'SpreeCmCommissioner::TaxonAppBanner'
       base.has_one :home_banner, as: :viewable, dependent: :destroy, class_name: 'SpreeCmCommissioner::TaxonHomeBanner'
 
+      base.attr_accessor :classification_ids
+
       base.validates_associated :category_icon
       base.before_save :set_kind
     end

--- a/app/queries/spree_cm_commissioner/dashboard_crew_event_query.rb
+++ b/app/queries/spree_cm_commissioner/dashboard_crew_event_query.rb
@@ -14,19 +14,31 @@ module SpreeCmCommissioner
     end
 
     def events
-      taxons = Spree::Taxon.select('spree_taxons.id AS taxon_id, spree_taxons.name, spree_taxons.permalink, spree_taxons.from_date, spree_taxons.to_date, spree_taxons.updated_at') # rubocop:disable Layout/LineLength
-                           .joins('INNER JOIN cm_user_taxons ON spree_taxons.id = cm_user_taxons.taxon_id')
-                           .where(cm_user_taxons: { user_id: user_id, type: 'SpreeCmCommissioner::UserEvent' })
+      select_fields = [
+        'spree_taxons.id AS taxon_id',
+        'spree_taxons.name',
+        'spree_taxons.permalink',
+        'spree_taxons.from_date',
+        'spree_taxons.to_date',
+        'spree_taxons.updated_at',
+        'ARRAY_AGG(spree_products_taxons.id) AS product_taxon_ids'
+      ]
+
+      taxons = Spree::Taxon
+               .select(select_fields)
+               .joins('INNER JOIN spree_taxons section ON section.parent_id = spree_taxons.id')
+               .joins('INNER JOIN spree_products_taxons ON spree_products_taxons.taxon_id = section.id')
+               .joins('INNER JOIN cm_user_taxons ON spree_taxons.id = cm_user_taxons.taxon_id')
+               .where(cm_user_taxons: { user_id: user_id, type: 'SpreeCmCommissioner::UserEvent' })
+               .group('spree_taxons.id')
 
       if section == 'incoming'
-        taxons = taxons.where('spree_taxons.from_date >= ?', start_from_date)
-        taxons = taxons.order(from_date: :asc)
+        taxons.where('spree_taxons.from_date >= ?', start_from_date)
+              .order(from_date: :asc)
       else
-        taxons = taxons.where('spree_taxons.from_date < ?', start_from_date)
-        taxons = taxons.order(to_date: :desc)
+        taxons.where('spree_taxons.from_date < ?', start_from_date)
+              .order(to_date: :desc)
       end
-
-      taxons
     end
   end
 end

--- a/app/serializers/spree_cm_commissioner/v2/operator/classification_serializer.rb
+++ b/app/serializers/spree_cm_commissioner/v2/operator/classification_serializer.rb
@@ -1,0 +1,12 @@
+module SpreeCmCommissioner
+  module V2
+    module Operator
+      class ClassificationSerializer < BaseSerializer
+        attributes :total_count
+
+        belongs_to :product, serializer: :product
+        belongs_to :taxon, serializer: :taxon
+      end
+    end
+  end
+end

--- a/app/serializers/spree_cm_commissioner/v2/operator/dashboard_crew_event_serializer.rb
+++ b/app/serializers/spree_cm_commissioner/v2/operator/dashboard_crew_event_serializer.rb
@@ -2,7 +2,11 @@ module SpreeCmCommissioner
   module V2
     module Operator
       class DashboardCrewEventSerializer < BaseSerializer
-        attributes :taxon_id, :name, :permalink, :from_date, :to_date
+        attributes :taxon_id, :name, :permalink, :from_date, :to_date, :updated_at
+
+        has_many :classifications, serializer: :classification do |object|
+          Spree::Classification.where(id: object.product_taxon_ids)
+        end
 
         set_id do |event, _params|
           event.taxon_id

--- a/app/serializers/spree_cm_commissioner/v2/operator/product_serializer.rb
+++ b/app/serializers/spree_cm_commissioner/v2/operator/product_serializer.rb
@@ -1,0 +1,9 @@
+module SpreeCmCommissioner
+  module V2
+    module Operator
+      class ProductSerializer < BaseSerializer
+        attributes :name, :slug
+      end
+    end
+  end
+end

--- a/app/serializers/spree_cm_commissioner/v2/operator/taxon_serializer.rb
+++ b/app/serializers/spree_cm_commissioner/v2/operator/taxon_serializer.rb
@@ -1,0 +1,9 @@
+module SpreeCmCommissioner
+  module V2
+    module Operator
+      class TaxonSerializer < BaseSerializer
+        attributes :name, :permalink, :pretty_name
+      end
+    end
+  end
+end

--- a/lib/spree_cm_commissioner/test_helper/factories/taxon_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/taxon_factory.rb
@@ -1,0 +1,28 @@
+FactoryBot.define do
+  factory :cm_taxon_event_section, parent: :taxon do
+    kind { :event }
+    sequence(:name) { |n| "Ticket Type #{n}" }
+  end
+
+  factory :cm_taxon_event, parent: :taxon do
+    kind { :event }
+    name { 'TedX' }
+
+    transient do
+      sections_count { 2 }
+      products_count_per_section { 2 }
+    end
+
+    after(:create) do |taxon, evaluator|
+      if evaluator.sections_count > 0
+        taxon.children = create_list(:cm_taxon_event_section, evaluator.sections_count, parent: taxon, taxonomy: taxon.taxonomy)
+
+        if evaluator.products_count_per_section > 0
+          taxon.children.each do |section|
+            section.products = create_list(:cm_product, evaluator.products_count_per_section, taxons: [section])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/queries/spree_cm_commissioner/dashboard_crew_event_query_spec.rb
+++ b/spec/queries/spree_cm_commissioner/dashboard_crew_event_query_spec.rb
@@ -1,12 +1,13 @@
 require 'spec_helper'
 
 RSpec.describe SpreeCmCommissioner::DashboardCrewEventQuery do
+
   let!(:start_from_date) { Time.zone.today }
-  let!(:incoming_event_a) { create(:taxon, name: 'Run with Sai', kind: :event, from_date: start_from_date, to_date: 2.day.from_now) }
-  let!(:incoming_event_b) { create(:taxon, name: 'BunPhum', kind: :event, from_date: 8.day.from_now, to_date: 11.day.from_now) }
-  let!(:incoming_event_c) { create(:taxon, name: 'TedX', kind: :event, from_date: 15.day.from_now, to_date: 18.day.from_now) }
-  let!(:previous_event_a) { create(:taxon, name: 'GardenSplash', kind: :event, from_date: start_from_date - 1.day, to_date: start_from_date - 3.day) }
-  let!(:previous_event_b) { create(:taxon, name: 'SangkranSR', kind: :event, from_date: 8.day.ago, to_date: 11.day.ago) }
+  let!(:incoming_event_a) { create(:cm_taxon_event, name: 'Run with Sai', from_date: start_from_date, to_date: 2.day.from_now) }
+  let!(:incoming_event_b) { create(:cm_taxon_event, name: 'BunPhum', from_date: 8.day.from_now, to_date: 11.day.from_now) }
+  let!(:incoming_event_c) { create(:cm_taxon_event, name: 'TedX', from_date: 15.day.from_now, to_date: 18.day.from_now) }
+  let!(:previous_event_a) { create(:cm_taxon_event, name: 'GardenSplash', from_date: start_from_date - 1.day, to_date: start_from_date - 3.day) }
+  let!(:previous_event_b) { create(:cm_taxon_event, name: 'SangkranSR', from_date: 8.day.ago, to_date: 11.day.ago) }
 
   describe '#events' do
     let(:user_a) { create(:cm_operator_user, events: [incoming_event_a, incoming_event_b, previous_event_a, previous_event_b]) }
@@ -14,12 +15,12 @@ RSpec.describe SpreeCmCommissioner::DashboardCrewEventQuery do
 
     it 'should return only incoming events that user has access to' do
       query_a = SpreeCmCommissioner::DashboardCrewEventQuery.new(user_id: user_a.id, section: 'incoming')
-      expect(query_a.events.pluck(:taxon_id)).to eq([incoming_event_a.id, incoming_event_b.id])
+      expect(query_a.events.map(&:taxon_id)).to eq([incoming_event_a.id, incoming_event_b.id])
     end
 
     it 'should return only previous events that user has access to' do
       query_b = SpreeCmCommissioner::DashboardCrewEventQuery.new(user_id: user_a.id, section: 'previous')
-      expect(query_b.events.pluck(:taxon_id)).to eq([previous_event_a.id, previous_event_b.id])
+      expect(query_b.events.map(&:taxon_id)).to eq([previous_event_a.id, previous_event_b.id])
     end
 
     context 'when section is incoming' do
@@ -31,7 +32,7 @@ RSpec.describe SpreeCmCommissioner::DashboardCrewEventQuery do
         expect(incoming_event_a.from_date).to be >= start_from_date
         expect(incoming_event_b.from_date).to be >= start_from_date
         expect(incoming_event_c.from_date).to be >= start_from_date
-        expect(subject.events.pluck(:taxon_id)).to eq([incoming_event_a.id, incoming_event_b.id, incoming_event_c.id])
+        expect(subject.events.map(&:taxon_id)).to eq([incoming_event_a.id, incoming_event_b.id, incoming_event_c.id])
       end
     end
 
@@ -44,7 +45,7 @@ RSpec.describe SpreeCmCommissioner::DashboardCrewEventQuery do
         expect(previous_event_a.from_date).to be < start_from_date
         expect(previous_event_b.from_date).to be < start_from_date
 
-        expect(subject.events.pluck(:taxon_id)).to eq([previous_event_a.id, previous_event_b.id])
+        expect(subject.events.map(&:taxon_id)).to eq([previous_event_a.id, previous_event_b.id])
       end
     end
   end


### PR DESCRIPTION
##### GET :  {{BASE_URL}}/api/v2/operator/dashboard_crew_events?section=incoming&per_page=1&include=classifications.taxon
```json
{
    "data": [
        {
            "id": "115",
            "type": "dashboard_crew_event",
            "attributes": {
                "taxon_id": 115,
                "name": "🔺TEDxPhnomPenh 2024!",
                "permalink": "events/tedxphnompenh-2024",
                "from_date": "2024-02-24T00:00:00.000+07:00",
                "to_date": "2024-04-30T00:00:00.000+07:00",
                "updated_at": "2024-02-22T10:17:57.951+07:00"
            },
            "relationships": {
                "classifications": {
                    "data": [
                        {
                            "id": "171",
                            "type": "classification"
                        },
                        {
                            "id": "170",
                            "type": "classification"
                        }
                    ]
                }
            }
        }
    ],
    "included": [
        {
            "id": "116",
            "type": "taxon",
            "attributes": {
                "name": "🎟Ticket Types",
                "permalink": "events/tedxphnompenh-2024/ticket-types",
                "pretty_name": "Events -> 🔺TEDxPhnomPenh 2024! -> 🎟Ticket Types"
            }
        },
        {
            "id": "171",
            "type": "classification",
            "attributes": {
                "total_count": 4
            },
            "relationships": {
                "product": {
                    "data": {
                        "id": "132",
                        "type": "product"
                    }
                },
                "taxon": {
                    "data": {
                        "id": "116",
                        "type": "taxon"
                    }
                }
            }
        },
        {
            "id": "170",
            "type": "classification",
            "attributes": {
                "total_count": 4
            },
            "relationships": {
                "product": {
                    "data": {
                        "id": "128",
                        "type": "product"
                    }
                },
                "taxon": {
                    "data": {
                        "id": "116",
                        "type": "taxon"
                    }
                }
            }
        }
    ],
    "meta": {
        "count": {
            "115": 2
        },
        "total_count": 2,
        "total_pages": 2
    },
    "links": {
        "self": "http://127.0.0.1:4000/api/v2/operator/dashboard_crew_events?section=incoming&per_page=1&include=classifications.taxon",
        "next": "http://127.0.0.1:4000/api/v2/operator/dashboard_crew_events?include=classifications.taxon&page=2&per_page=1",
        "prev": "http://127.0.0.1:4000/api/v2/operator/dashboard_crew_events?include=classifications.taxon&page=1&per_page=1",
        "last": "http://127.0.0.1:4000/api/v2/operator/dashboard_crew_events?include=classifications.taxon&page=2&per_page=1",
        "first": "http://127.0.0.1:4000/api/v2/operator/dashboard_crew_events?include=classifications.taxon&page=1&per_page=1"
    }
}
```