### PR TITLE
close #1176 update started at attribute type validation format

### DIFF
--- a/app/models/concerns/spree_cm_commissioner/attr_type_validation.rb
+++ b/app/models/concerns/spree_cm_commissioner/attr_type_validation.rb
@@ -7,7 +7,7 @@ module SpreeCmCommissioner
         validates :presentation, numericality: { only_integer: true }, if: :integer
         validates :presentation, numericality: { only_float: true }, if: :float
         validates :presentation, inclusion: %w[1 0], if: :boolean
-        validate :presentation_format, if: :stated_at
+        validate :started_at_format, if: :started_at?
       end
     end
 
@@ -15,10 +15,10 @@ module SpreeCmCommissioner
       @option_type ||= Spree::OptionType.find_by(id: option_type_id)
     end
 
-    def presentation_format
-      return if presentation =~ /^\d{1,2}d\d{1,2}h\d{1,2}m\d{1,2}s$/
+    def started_at_format
+      return if presentation =~ /^\d{1,2}h\d{1,2}m$/
 
-      errors.add(:presentation, "Invalid format. Should be in '0d0h0m0s' format")
+      errors.add(:presentation, "Invalid format. Should be in '0h0m' format")
     end
 
     private
@@ -35,7 +35,7 @@ module SpreeCmCommissioner
       option_type&.attr_type == 'boolean'
     end
 
-    def stated_at
+    def started_at?
       option_type&.attr_type == 'started_at'
     end
   end

--- a/app/models/concerns/spree_cm_commissioner/variant_option_values_concern.rb
+++ b/app/models/concerns/spree_cm_commissioner/variant_option_values_concern.rb
@@ -1,0 +1,13 @@
+module SpreeCmCommissioner
+  module VariantOptionValuesConcern
+    extend ActiveSupport::Concern
+
+    def started_at_option_value
+      option_value('started-at')
+    end
+
+    def reminder_option_value
+      option_value('reminder')
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/option_type_decorator.rb
+++ b/app/models/spree_cm_commissioner/option_type_decorator.rb
@@ -1,6 +1,6 @@
 module SpreeCmCommissioner
   module OptionTypeDecorator
-    ATTRIBUTE_TYPES = %w[float integer string boolean date coordinate state_selection started_at].freeze
+    ATTRIBUTE_TYPES = %w[float integer string boolean date coordinate state_selection started_at reminder].freeze
 
     def self.prepended(base)
       base.include SpreeCmCommissioner::ParameterizeName

--- a/app/models/spree_cm_commissioner/variant_decorator.rb
+++ b/app/models/spree_cm_commissioner/variant_decorator.rb
@@ -3,6 +3,8 @@ module SpreeCmCommissioner
     def self.prepended(base)
       base.include SpreeCmCommissioner::ProductDelegation
       base.include SpreeCmCommissioner::VariantGuestsConcern
+      base.include SpreeCmCommissioner::VariantOptionValuesConcern
+
       base.after_commit :update_vendor_price
       base.after_save   :update_vendor_total_inventory, if: :saved_change_to_permanent_stock?
       base.validate     :validate_option_types

--- a/app/overrides/spree/admin/option_types/_form/attr_type.html.erb.deface
+++ b/app/overrides/spree/admin/option_types/_form/attr_type.html.erb.deface
@@ -11,6 +11,12 @@
     <%= f.field_container :attr_type, class: ['form-group'] do %>
       <%= f.label :attr_type, Spree.t(:attribute_type) %> <span class="required">*</span>
       <%= f.text_field :attr_type, disabled: true, class: "form-control" %>
+      <% case @option_type.attr_type %>
+        <% when 'reminder' %>
+          <small class="form-text text-muted">
+            <%= raw I18n.t('option_type.time_format_info', time_format: '0d0h0m0s') %>
+          </small>
+      <% end %>
       <%= f.error_message_on :attr_type %>
     <% end %>
   <% end %>

--- a/app/overrides/spree/admin/option_types/_option_value_fields/option_value_replacer.html.erb.deface
+++ b/app/overrides/spree/admin/option_types/_option_value_fields/option_value_replacer.html.erb.deface
@@ -33,6 +33,8 @@
     <td class="presentation"><%= f.text_field :presentation, class: "form-control", required: true %></td>
   <% when "started_at" %>
     <td class="presentation"><%= f.text_field :presentation, class: "form-control", required: true %></td>
+  <% when "reminder" %>
+    <td class="presentation"><%= f.text_field :presentation, class: "form-control", required: true %></td>
   <% end %>
 
   <td class="actions">

--- a/app/serializers/spree/v2/storefront/variant_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/variant_serializer_decorator.rb
@@ -3,7 +3,7 @@ module Spree
     module Storefront
       module VariantSerializerDecorator
         def self.prepended(base)
-          base.attributes :permanent_stock, :need_confirmation, :product_type, :kyc
+          base.attributes :permanent_stock, :need_confirmation, :product_type, :kyc, :reminder_option_value, :started_at_option_value
 
           base.has_many :stock_locations
           base.has_many :visible_option_values, serializer: Spree::V2::Storefront::OptionValueSerializer

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,7 @@ en:
     kind_info: "<b>Once set</b>, it can't be updated."
     kind_validation: "Attribute can't be updated for %{option_type_name}"
     empty_info: "No <b>Option Type</b> found for this kind"
+    time_format_info: "<b>Please Note:</b> option value must be in the format <b>%{time_format}</b> with multiple values separated by commas like <b>%{time_format},%{time_format}</b>"
 
   stock_location:
     lat:

--- a/config/locales/km.yml
+++ b/config/locales/km.yml
@@ -54,6 +54,7 @@ km:
     kind_info: "<b>បន្តាប់ពីកំណត់រួច</b> អ្នកមិនអាចកែប្រែបានទៀតទេ"
     kind_validation: "Attribute can't be updated for %{option_type_name}"
     empty_info: "រក <b>Option Type</b> មិនឃើញសម្រាប់ប្រភេទ"
+    time_format_info: "<b>សូម​ចំណាំ:</b>option value ត្រូវតែមានទម្រង់<b>%{time_format}</b> ជាមួយនឹងតម្លៃជាច្រើនត្រូវបំបែកដោយសញ្ញាក្បៀសដូច<b>%{time_format},%{time_format}</b>"
 
   stock_location:
     lat:

--- a/spec/models/concerns/spree_cm_commissioner/attr_type_validation_spec.rb
+++ b/spec/models/concerns/spree_cm_commissioner/attr_type_validation_spec.rb
@@ -104,11 +104,11 @@ RSpec.describe SpreeCmCommissioner::AttrTypeValidation do
     it 'invalid when input is in wrong format' do
       dummy = DummyClass.new(presentation: 'Invalid Presentation', option_type_id: option_type.id)
       expect(dummy.valid?).to be false
-      expect(dummy.errors[:presentation]).to eq ["Invalid format. Should be in '0d0h0m0s' format"]
+      expect(dummy.errors[:presentation]).to eq ["Invalid format. Should be in '0h0m' format"]
     end
 
     it 'valid when input is in right format' do
-      dummy = DummyClass.new(presentation: '3d2h0m0s', option_type_id: option_type.id)
+      dummy = DummyClass.new(presentation: '2h0m', option_type_id: option_type.id)
       expect(dummy.valid?).to be true
     end
   end

--- a/spec/serializers/spree/v2/storefront/variant_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/variant_serializer_spec.rb
@@ -36,7 +36,9 @@ describe Spree::V2::Storefront::VariantSerializer, type: :serializer do
         :permanent_stock,
         :kyc,
         :need_confirmation,
-        :product_type
+        :product_type,
+        :reminder_option_value,
+        :started_at_option_value
       )
     end
 


### PR DESCRIPTION
- start_at will store as 0h0m format 
- reminder will store as 0d0h0m0s format and seperate by comma if there are multiple values 

<img width="1510" alt="image" src="https://github.com/channainfo/commissioner/assets/92453740/343ab69b-1aae-451d-b4c8-91a861cc2501">

<img width="757" alt="image" src="https://github.com/channainfo/commissioner/assets/92453740/f5a7a40b-5bf2-4aea-a628-a6bd76126eeb">
