### PR TITLE
close #1171 enchance dashboard-crew-event classification_serializer

### DIFF
--- a/app/controllers/spree/api/v2/operator/dashboard_crew_events_controller.rb
+++ b/app/controllers/spree/api/v2/operator/dashboard_crew_events_controller.rb
@@ -6,10 +6,10 @@ module Spree
           before_action :require_spree_current_user
 
           def collection
-            @collection ||= SpreeCmCommissioner::DashboardCrewEventQuery.new(
+            SpreeCmCommissioner::DashboardCrewEventQuery.new(
               user_id: spree_current_user.id,
               section: params[:section] || 'incoming'
-            ).call
+            ).events
           end
 
           def collection_serializer

--- a/app/models/spree_cm_commissioner/taxon_decorator.rb
+++ b/app/models/spree_cm_commissioner/taxon_decorator.rb
@@ -21,7 +21,8 @@ module SpreeCmCommissioner
       base.has_one :app_banner, as: :viewable, dependent: :destroy, class_name: 'SpreeCmCommissioner::TaxonAppBanner'
       base.has_one :home_banner, as: :viewable, dependent: :destroy, class_name: 'SpreeCmCommissioner::TaxonHomeBanner'
 
-      base.attr_accessor :classification_ids
+      base.has_many :children, class_name: 'Spree::Taxon', foreign_key: :parent_id, dependent: :destroy
+      base.has_many :children_classifications, through: :children, source: :classifications, class_name: 'Spree::Classification'
 
       base.validates_associated :category_icon
       base.before_save :set_kind

--- a/app/queries/spree_cm_commissioner/dashboard_crew_event_query.rb
+++ b/app/queries/spree_cm_commissioner/dashboard_crew_event_query.rb
@@ -9,34 +9,14 @@ module SpreeCmCommissioner
       @start_from_date = start_from_date || Time.zone.today
     end
 
-    def call
-      events
-    end
-
     def events
-      select_fields = [
-        'spree_taxons.id AS taxon_id',
-        'spree_taxons.name',
-        'spree_taxons.permalink',
-        'spree_taxons.from_date',
-        'spree_taxons.to_date',
-        'spree_taxons.updated_at',
-        'ARRAY_AGG(spree_products_taxons.id) AS product_taxon_ids'
-      ]
-
-      taxons = Spree::Taxon
-               .select(select_fields)
-               .joins('INNER JOIN spree_taxons section ON section.parent_id = spree_taxons.id')
-               .joins('INNER JOIN spree_products_taxons ON spree_products_taxons.taxon_id = section.id')
-               .joins('INNER JOIN cm_user_taxons ON spree_taxons.id = cm_user_taxons.taxon_id')
-               .where(cm_user_taxons: { user_id: user_id, type: 'SpreeCmCommissioner::UserEvent' })
-               .group('spree_taxons.id')
+      taxons = Spree::Taxon.joins(:user_events).where(user_events: { user_id: user_id })
 
       if section == 'incoming'
-        taxons.where('spree_taxons.from_date >= ?', start_from_date)
+        taxons.where('from_date >= ?', start_from_date)
               .order(from_date: :asc)
       else
-        taxons.where('spree_taxons.from_date < ?', start_from_date)
+        taxons.where('from_date < ?', start_from_date)
               .order(to_date: :desc)
       end
     end

--- a/app/serializers/spree_cm_commissioner/v2/operator/dashboard_crew_event_serializer.rb
+++ b/app/serializers/spree_cm_commissioner/v2/operator/dashboard_crew_event_serializer.rb
@@ -2,15 +2,9 @@ module SpreeCmCommissioner
   module V2
     module Operator
       class DashboardCrewEventSerializer < BaseSerializer
-        attributes :taxon_id, :name, :permalink, :from_date, :to_date, :updated_at
+        attributes :id, :name, :permalink, :from_date, :to_date, :updated_at
 
-        has_many :classifications, serializer: :classification do |object|
-          Spree::Classification.where(id: object.product_taxon_ids)
-        end
-
-        set_id do |event, _params|
-          event.taxon_id
-        end
+        has_many :children_classifications, serializer: :classification
       end
     end
   end

--- a/spec/queries/spree_cm_commissioner/dashboard_crew_event_query_spec.rb
+++ b/spec/queries/spree_cm_commissioner/dashboard_crew_event_query_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe SpreeCmCommissioner::DashboardCrewEventQuery do
 
     it 'should return only incoming events that user has access to' do
       query_a = SpreeCmCommissioner::DashboardCrewEventQuery.new(user_id: user_a.id, section: 'incoming')
-      expect(query_a.events.map(&:taxon_id)).to eq([incoming_event_a.id, incoming_event_b.id])
+      expect(query_a.events.pluck(:taxon_id)).to eq([incoming_event_a.id, incoming_event_b.id])
     end
 
     it 'should return only previous events that user has access to' do
       query_b = SpreeCmCommissioner::DashboardCrewEventQuery.new(user_id: user_a.id, section: 'previous')
-      expect(query_b.events.map(&:taxon_id)).to eq([previous_event_a.id, previous_event_b.id])
+      expect(query_b.events.pluck(:taxon_id)).to eq([previous_event_a.id, previous_event_b.id])
     end
 
     context 'when section is incoming' do
@@ -32,7 +32,7 @@ RSpec.describe SpreeCmCommissioner::DashboardCrewEventQuery do
         expect(incoming_event_a.from_date).to be >= start_from_date
         expect(incoming_event_b.from_date).to be >= start_from_date
         expect(incoming_event_c.from_date).to be >= start_from_date
-        expect(subject.events.map(&:taxon_id)).to eq([incoming_event_a.id, incoming_event_b.id, incoming_event_c.id])
+        expect(subject.events.pluck(:taxon_id)).to eq([incoming_event_a.id, incoming_event_b.id, incoming_event_c.id])
       end
     end
 
@@ -45,7 +45,7 @@ RSpec.describe SpreeCmCommissioner::DashboardCrewEventQuery do
         expect(previous_event_a.from_date).to be < start_from_date
         expect(previous_event_b.from_date).to be < start_from_date
 
-        expect(subject.events.map(&:taxon_id)).to eq([previous_event_a.id, previous_event_b.id])
+        expect(subject.events.pluck(:taxon_id)).to eq([previous_event_a.id, previous_event_b.id])
       end
     end
   end


### PR DESCRIPTION
##### GET: {{BASE_URL}}/api/v2/operator/dashboard_crew_events?section=incoming&per_page=1&include=children_classifications.taxon
```
USE eager loading detected
  Spree::Classification => [:taxon]
  Add to your query: .includes([:taxon])
```

```json
{
    "data": [
        {
            "id": "115",
            "type": "dashboard_crew_event",
            "attributes": {
                "id": 115,
                "name": "🔺TEDxPhnomPenh 2024!",
                "permalink": "events/tedxphnompenh-2024",
                "from_date": "2024-03-09T00:00:00.000+07:00",
                "to_date": "2024-04-30T00:00:00.000+07:00",
                "updated_at": "2024-02-27T17:43:47.496+07:00"
            },
            "relationships": {
                "children_classifications": {
                    "data": [
                        {
                            "id": "170",
                            "type": "classification"
                        },
                        {
                            "id": "171",
                            "type": "classification"
                        }
                    ]
                }
            }
        }
    ],
    "included": [
        {
            "id": "116",
            "type": "taxon",
            "attributes": {
                "name": "🎟Ticket Types",
                "permalink": "events/tedxphnompenh-2024/ticket-types",
                "pretty_name": "Events -> 🔺TEDxPhnomPenh 2024! -> 🎟Ticket Types"
            }
        },
        {
            "id": "170",
            "type": "classification",
            "attributes": {
                "total_count": 4
            },
            "relationships": {
                "product": {
                    "data": {
                        "id": "128",
                        "type": "product"
                    }
                },
                "taxon": {
                    "data": {
                        "id": "116",
                        "type": "taxon"
                    }
                }
            }
        },
        {
            "id": "171",
            "type": "classification",
            "attributes": {
                "total_count": 4
            },
            "relationships": {
                "product": {
                    "data": {
                        "id": "132",
                        "type": "product"
                    }
                },
                "taxon": {
                    "data": {
                        "id": "116",
                        "type": "taxon"
                    }
                }
            }
        }
    ],
    "meta": {
        "count": 1,
        "total_count": 2,
        "total_pages": 2
    },
    "links": {
        "self": "http://127.0.0.1:4000/api/v2/operator/dashboard_crew_events?section=incoming&per_page=1&include=children_classifications.taxon",
        "next": "http://127.0.0.1:4000/api/v2/operator/dashboard_crew_events?include=children_classifications.taxon&page=2&per_page=1",
        "prev": "http://127.0.0.1:4000/api/v2/operator/dashboard_crew_events?include=children_classifications.taxon&page=1&per_page=1",
        "last": "http://127.0.0.1:4000/api/v2/operator/dashboard_crew_events?include=children_classifications.taxon&page=2&per_page=1",
        "first": "http://127.0.0.1:4000/api/v2/operator/dashboard_crew_events?include=children_classifications.taxon&page=1&per_page=1"
    }
}
```