### PR TITLE
close #1195 export guest data to csv

### DIFF
--- a/app/controllers/spree/events/guests_controller.rb
+++ b/app/controllers/spree/events/guests_controller.rb
@@ -11,16 +11,35 @@ module Spree
         SpreeCmCommissioner::Guest
       end
 
+      def index
+        file_name = Rails.root.join('tmp', csv_name)
+
+        respond_with(collection) do |format|
+          format.csv do
+            SpreeCmCommissioner::GenerateGuestsCsv.call(
+              collection: collection,
+              file_name: file_name
+            )
+
+            send_file file_name
+          end
+        end
+      end
+
       def edit
         @guest = SpreeCmCommissioner::Guest.find(params[:id])
         @event = @guest.event
       end
 
+      private
+
+      def csv_name
+        @csv_name ||= "guests-data-#{current_event.name.downcase.gsub(' ', '-')}-#{Time.current.to_i}.csv"
+      end
+
       def permitted_resource_params
         params.required(:spree_cm_commissioner_guest).permit(:entry_type)
       end
-
-      protected
 
       def collection
         scope = model_class.where(event_id: current_event.id)

--- a/app/interactors/spree_cm_commissioner/generate_guests_csv.rb
+++ b/app/interactors/spree_cm_commissioner/generate_guests_csv.rb
@@ -1,0 +1,25 @@
+module SpreeCmCommissioner
+  class GenerateGuestsCsv < BaseInteractor
+    delegate :collection, :file_name, to: :context
+
+    def call
+      headers = ['Full Name', 'Date of Birth', 'Gender', 'Occupation', 'ID Card Type', 'Entry Type']
+
+      CSV.open(file_name, 'w') do |csv|
+        csv << headers
+
+        collection.find_each do |guest|
+          entry_type_key = SpreeCmCommissioner::CheckIn.entry_types.key(guest.entry_type)
+          csv << [
+            guest.full_name,
+            guest.dob&.strftime('%d %b %Y'),
+            guest.gender&.titleize,
+            guest.other_occupation&.titleize || guest.occupation&.name,
+            guest.id_card&.card_type&.titleize,
+            entry_type_key ? entry_type_key.titleize : nil
+          ]
+        end
+      end
+    end
+  end
+end

--- a/app/views/spree/events/guests/index.html.erb
+++ b/app/views/spree/events/guests/index.html.erb
@@ -1,5 +1,20 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:guests) %>
+  <%= Spree.t(:register_guests) %>
+  <%= link_to 'Export CSV', event_guests_path(format: :csv, params: params.permit!), class: 'btn btn-primary float-right' %>
+<% end %>
+
+<% content_for :page_tabs do %>
+  <% occupations = Spree::Taxon.where(kind: Spree::Taxon.kinds[:occupation]).order(:position) %>
+  <li class="nav-item">
+    <%= link_to 'All', spree.event_guests_path(q: { occupation_id_eq: nil }),
+                class: "nav-link #{'active' if params.dig(:q, :occupation_id_eq).nil?}" %>
+  </li>
+  <% occupations.each do |occupation| %>
+    <li class="nav-item">
+      <%= link_to occupation.name, spree.event_guests_path(q: { occupation_id_eq: occupation.id }),
+                  class: "nav-link #{'active' if params.dig(:q, :occupation_id_eq).to_s == occupation.id.to_s}" %>
+    </li>
+  <% end %>
 <% end %>
 
 <% content_for :table_filter do %>
@@ -11,23 +26,20 @@
   <table class="table" id="listing_products">
     <thead class="text-muted">
       <tr data-hook="admin_products_index_headers">
-        <th scope="col" class="text-left"><%= Spree.t(:id) %></th>
         <th scope="col" class="text-left"><%= Spree.t(:full_name) %></th>
         <th scope="col" class="text-left"><%= Spree.t(:date_of_birth) %></th>
         <th scope="col" class="text-left"><%= Spree.t(:gender) %></th>
         <th scope="col" class="text-left"><%= Spree.t(:occupation) %></th>
         <th scope="col" class="text-left"><%= Spree.t(:id_card_type) %></th>
-        <th scope="col" class="text-left"><%= Spree.t(:id_cards) %></th>
+        <th scope="col" class="text-left"><%= Spree.t(:id_card_image) %></th>
         <th scope="col" class="text-left"><%= Spree.t(:entry_type) %></th>
+        <th scope="col" class="text-left"><%= Spree.t(:created_at) %></th>
         <th scope="col" class="text-left"><%= Spree.t(:action) %></th>
       </tr>
     </thead>
     <tbody>
       <% @collection.each do |guest| %>
         <tr id="<%= spree_dom_id guest %>" data-hook="event_guests_index_rows">
-        <td class="text-left">
-            <%= guest.id %>
-          </td>
           <td class="text-left">
             <%= guest.full_name %>
           </td>
@@ -40,7 +52,7 @@
             <% end %>
           </td>
           <td class="text-left">
-            <%= guest.occupation&.name %>
+            <%= guest.other_occupation&.titleize || guest.occupation&.name %>
           </td>
           <td class="text-left">
             <%= content_tag(:strong, class: "badge #{badge_color_base_on_id_card_status(guest.id_card&.card_type)} font-weight-bold") do %>
@@ -71,6 +83,9 @@
             <%= content_tag(:strong, class: "badge #{badge_color_base_on_entry_type(guest.entry_type)} font-weight-bold uppercase") do %>
               <%= SpreeCmCommissioner::CheckIn.entry_types.key(guest.entry_type).titleize %>
             <% end %>
+          </td>
+          <td class="text-left">
+            <%= guest.created_at&.strftime('%d %b %Y %I:%M:%S %p') %>
           </td>
           <td class="text-left">
             <%= link_to_edit guest, url: edit_event_guest_url(current_event.slug, guest), no_text: true, class: 'edit' %>

--- a/app/views/spree/events/shared/_filters.html.erb
+++ b/app/views/spree/events/shared/_filters.html.erb
@@ -11,7 +11,7 @@
 
         <div class="date-range-filter col-12 col-lg-6">
           <div class="form-group">
-            <%= f.label :last_name_cont, Spree.t(:first_name) %>
+            <%= f.label :last_name_cont, Spree.t(:last_name) %>
             <%= f.search_field :last_name_cont, class: "form-control js-filterable", placeholder: Spree.t(:last_name) %>
           </div>
         </div>
@@ -27,14 +27,14 @@
         <div class="col-12 col-lg-6">
           <div class="form-group">
             <%= f.label :occupation_id_eq, Spree.t(:occupation) %>
-            <%= f.select :occupation_id_eq, options_for_select(Spree::Taxon.where(parent_id: 82).map { |t| [Spree.t("#{t.name}"), t.id] }), { include_blank: true, prompt: Spree.t(:select_occupation) }, class: "form-control js-filterable" %>
+            <%= f.select :occupation_id_eq, options_for_select(Spree::Taxon.where(kind: Spree::Taxon.kinds[:occupation]).order(:position).map { |t| [Spree.t("#{t.name}"), t.id] }), { include_blank: true, prompt: Spree.t(:select_occupation) }, class: "form-control js-filterable" %>
           </div>
         </div>
       </div>
       <div class="row">
         <div class="col-12 col-lg-6">
           <div class="form-group">
-            <%= f.label :id_card_card_type_eq, Spree.t(:card_type) %>
+            <%= f.label :id_card_card_type_eq, Spree.t(:id_card_type) %>
             <%= f.select :id_card_card_type_eq, options_for_select(SpreeCmCommissioner::IdCard.card_types.map { |k, v| [Spree.t("spree.card_type.#{k}"), v] }), { include_blank: true, prompt: Spree.t(:select_card_type) }, class: "form-control js-filterable" %>
           </div>
         </div>

--- a/spec/interactors/spree_cm_commissioner/generate_guests_csv_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/generate_guests_csv_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+require 'csv'
+
+RSpec.describe SpreeCmCommissioner::GenerateGuestsCsv, '.call' do
+  subject(:context) { described_class.call(collection: collection, file_name: file_name) }
+
+  let(:guest1) { create(:guest, first_name: 'John', last_name: 'Doe', dob: Date.new(1990, 1, 1), gender: 1, occupation: create(:taxon, name: 'Engineer'), id_card: create(:id_card, card_type: 0), entry_type: 1) }
+  let(:guest2) { create(:guest, first_name: 'Jane', last_name: 'Smith', dob: Date.new(1985, 5, 5), gender: 2, occupation: create(:taxon, name: 'Doctor'), id_card: create(:id_card, card_type: 1), entry_type: 0) }
+  let(:collection) { SpreeCmCommissioner::Guest.where(id: [guest1.id, guest2.id]) }
+  let(:file_name) { Rails.root.join('tmp', 'csv_file.csv') }
+  let(:csv_file) { CSV.read(Rails.root.join(file_name)) }
+
+  describe ".call" do
+    it 'creates the CSV file with correct path and filename and data' do
+      expect(context).to be_a_success
+      expect(context.file_name).to eq(file_name)
+
+      expect(csv_file.first).to eq(['Full Name', 'Date of Birth', 'Gender', 'Occupation', 'ID Card Type', 'Entry Type'])
+      expect(csv_file[1]).to eq([guest1.full_name, '01 Jan 1990', 'Male', 'Engineer', 'National Id Card', 'Vip'])
+      expect(csv_file[2]).to eq([guest2.full_name, '05 May 1985', 'Female', 'Doctor', 'Passport', 'Normal'])
+    end
+  end
+end


### PR DESCRIPTION
User can get the csv file by adding extension of **.csv**.  Example: _http://127.0.0.1:4000/events/events-tedxphnompenh-2024/guests.csv_

Raw file in text editor after export:
![image](https://github.com/channainfo/commissioner/assets/109834020/3a7b3506-18af-4d6f-95c2-24314c7d7cf4)

In google sheet:
![image](https://github.com/channainfo/commissioner/assets/109834020/597a30e6-de22-4cc0-8477-9a04efdb7c6b)
