### PR TITLE
close #1208 add seat selection availability flag on route

### DIFF
--- a/app/queries/spree_cm_commissioner/trip_seat_layout_query.rb
+++ b/app/queries/spree_cm_commissioner/trip_seat_layout_query.rb
@@ -10,35 +10,51 @@ module SpreeCmCommissioner
       @vehicle_type = SpreeCmCommissioner::VehicleType.find_by(id: vehicle.vehicle_type_id)
     end
 
-    SeatLayout = Struct.new(:total_sold, :remaining_seats, :layout)
-
     def call
+      allow_seat_selection = @route.trip.allow_seat_selection
+      total_sold, remaining_seats, layout = process_seat_selection(allow_seat_selection)
+
+      SpreeCmCommissioner::TripSeatLayoutResult.new({ trip_id: trip_id, total_sold: total_sold,
+                                                      total_seats: vehicle.number_of_seats,
+                                                      remaining_seats: remaining_seats,
+                                                      layout: layout,
+                                                      allow_seat_selection: allow_seat_selection
+                                                    }
+      )
+    end
+
+    def process_seat_selection(allow_seat_selection)
       # layout_structure
       # {"First_Layer" => {"Row_1" => [{seat1}, {seat2}, {seat3}, {seat4}],
       #                   {"Row_2" => [{seat5}, {seat6}, {seat7}, {seat8}],
       # }
-      vehicle_seats = seats.to_a
-      total_sold = vehicle_seats.count { |s| s.seat_id.present? }
-      remaining_seats = vehicle.number_of_seats - total_sold
-      layout = vehicle_seats.group_by(&:layer).transform_values do |s|
-                      s.group_by(&:row).transform_values do |r|
-                        r.sort_by(&:column).map do |seat|
-                          {
-                            row: seat.row,
-                            column: seat.column,
-                            label: seat.label,
-                            layer: seat.layer,
-                            seat_type: seat.seat_type,
-                            created_at: seat.created_at,
-                            seat_id: seat.seat_id,
-                            vehicle_type_id: seat.vehicle_type_id
-                          }
-                        end
-                      end
-                    end
-      SpreeCmCommissioner::TripSeatLayoutResult.new({ trip_id: trip_id, total_sold: total_sold,
-                                                    total_seats: vehicle.number_of_seats,
-                                                    remaining_seats: remaining_seats, layout: layout})
+      if allow_seat_selection
+        vehicle_seats = seats.to_a
+        total_sold = vehicle_seats.count { |s| s.seat_id.present? }
+        remaining_seats = vehicle.number_of_seats - total_sold
+        layout = vehicle_seats.group_by(&:layer).transform_values do |s|
+          s.group_by(&:row).transform_values do |r|
+            r.sort_by(&:column).map do |seat|
+              {
+                row: seat.row,
+                column: seat.column,
+                label: seat.label,
+                layer: seat.layer,
+                seat_type: seat.seat_type,
+                created_at: seat.created_at,
+                seat_id: seat.seat_id,
+                vehicle_type_id: seat.vehicle_type_id
+              }
+            end
+          end
+        end
+      else
+        total_sold = Spree::LineItem.where(variant_id: trip_id, date: date).sum(:quantity)
+        remaining_seats = vehicle.number_of_seats - total_sold
+        layout = nil
+      end
+
+      [total_sold, remaining_seats, layout]
     end
 
     def seats

--- a/db/migrate/20240314035607_add_allow_seat_selection_to_cm_trips.rb
+++ b/db/migrate/20240314035607_add_allow_seat_selection_to_cm_trips.rb
@@ -1,0 +1,5 @@
+class AddAllowSeatSelectionToCmTrips < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cm_trips, :allow_seat_selection, :boolean, default: true, if_not_exists: true
+  end
+end

--- a/lib/spree_cm_commissioner/test_helper/factories/line_item_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/line_item_factory.rb
@@ -20,14 +20,15 @@ FactoryBot.define do
     price    { BigDecimal('10.00') }
     currency { order.currency }
 
-    transient do
-      seats {[]}
-    end
-
-    after(:create) do |line_item, evaluator|
-      evaluator.seats.each_with_index do |seat, index|
-      create(:line_item_seat, line_item: line_item , seat: seat, date: evaluator.date, variant_id: evaluator.variant_id)
-      line_item.line_item_seats.reload
+    trait :with_seats do
+      transient do
+        seats {[]}
+      end
+      after(:create) do |line_item, evaluator|
+        evaluator.seats.each_with_index do |seat, index|
+        create(:line_item_seat, line_item: line_item , seat: seat, date: evaluator.date, variant_id: evaluator.variant_id)
+        line_item.line_item_seats.reload
+        end
       end
     end
   end

--- a/lib/spree_cm_commissioner/trip_seat_layout_result.rb
+++ b/lib/spree_cm_commissioner/trip_seat_layout_result.rb
@@ -1,6 +1,7 @@
 module SpreeCmCommissioner
   class TripSeatLayoutResult
-    attr_accessor :trip_id, :total_sold, :total_seats, :remaining_seats, :layout
+    attr_accessor :trip_id, :total_sold, :total_seats, :remaining_seats, :layout, :allow_seat_selection
+
     def initialize(options = {})
       options.each do |key, value|
         instance_variable_set("@#{key}", value)

--- a/spec/queries/spree_cm_commissioner/trip_search_query_spec.rb
+++ b/spec/queries/spree_cm_commissioner/trip_search_query_spec.rb
@@ -4,11 +4,13 @@ RSpec.describe SpreeCmCommissioner::TripSearchQuery do
   #vendor
   let!(:vet_airbus) {create(:vendor, name: 'Vet Airbus', code:"VET")}
   let!(:larryta) {create(:vendor, name: 'Larryta', code: 'LTA')}
+  let!(:buva_sea) {create(:vendor, name:'Buva Sea', code:"BS")}
 
   #location
   let!(:phnom_penh) { create(:transit_place, name: 'Phnom Penh', data_type:4) }
   let!(:siem_reap) { create(:transit_place, name: 'Siem Reap', data_type:4) }
   let!(:sihanoukville) { create(:transit_place, name: 'Sihanoukville', data_type:4) }
+  let!(:koh_rong) {create(:transit_place, name: 'Koh Rong', data_type:4)}
 
   #Vehicle Type
   let!(:airbus) {create(:vehicle_type,
@@ -25,10 +27,21 @@ RSpec.describe SpreeCmCommissioner::TripSearchQuery do
                         row: 5,
                         column: 5)}
 
+  let!(:ferry) {create(:vehicle_type,
+                        :with_seats,
+                        code: 'ferry',
+                        vendor: buva_sea,
+                        row: 5,
+                        column: 5,
+                        empty: [[0,2],[1,2],[2,2],[3,2],[4,2]]
+                        )}
+
   let!(:bus1) {create(:vehicle, vehicle_type: airbus, vendor: vet_airbus)}
   let!(:bus2) {create(:vehicle, vehicle_type: airbus, vendor: vet_airbus)}
   let!(:minivan1) {create(:vehicle, vehicle_type: minivan, vendor: larryta)}
   let!(:minivan2) {create(:vehicle, vehicle_type: minivan, vendor: larryta)}
+  let!(:ferry1) {create(:vehicle, vehicle_type: ferry, vendor: buva_sea)}
+  let!(:ferry2) {create(:vehicle, vehicle_type: ferry, vendor: buva_sea)}
 
   #routes
   let!(:vet_phnom_penh_siem_reap_1) { create(:route,
@@ -39,7 +52,7 @@ RSpec.describe SpreeCmCommissioner::TripSearchQuery do
                                                   duration: 6,
                                                   vehicle_id: bus1.id
                                                 },
-                                                name: 'VET Airbus Phnom Penh to Siem Reap 10:00',
+                                                name: 'VET Airbus Phnom Penh Siem Reap 10:00',
                                                 short_name:"PP-SR-10:00-6",
                                                 vendor: vet_airbus
                                                 ) }
@@ -51,7 +64,7 @@ RSpec.describe SpreeCmCommissioner::TripSearchQuery do
                                                   duration: 7,
                                                   vehicle_id: bus2.id
                                                 },
-                                                name: 'VET Airbus Phnom Penh to Siem Reap 15:00',
+                                                name: 'VET Airbus Phnom Penh Siem Reap 15:00',
                                                 short_name:"PP-SR-15:00-7",
                                                 vendor: vet_airbus
                                               ) }
@@ -64,7 +77,7 @@ RSpec.describe SpreeCmCommissioner::TripSearchQuery do
                                                       duration: 4,
                                                       vehicle_id: minivan1.id
                                                     },
-                                                    name: 'Larryta Airbus Phnom Penh to Siem Reap 13:00',
+                                                    name: 'Larryta Airbus Phnom Penh Siem Reap 13:00',
                                                     short_name:"PP-SR-13:00-4",
                                                     vendor: larryta
                                                     ) }
@@ -77,10 +90,35 @@ RSpec.describe SpreeCmCommissioner::TripSearchQuery do
                                                       duration: 5,
                                                       vehicle_id: minivan2.id
                                                     },
-                                                    name: 'Larryta Airbus Phnom Penh to Siem Reap 20:00',
+                                                    name: 'Larryta Airbus Phnom Penh Siem Reap 20:00',
                                                     short_name:"PP-SR-20:00-5",
                                                     vendor: larryta
                                                     ) }
+  let!(:sihanoukville_to_koh_rong_by_ferry) {create(:route,
+                                                    trip_attributes: {
+                                                      origin_id: sihanoukville.id,
+                                                      destination_id: koh_rong.id,
+                                                      departure_time: '10:00',
+                                                      duration: 6,
+                                                      vehicle_id: ferry1.id,
+                                                      allow_seat_selection: false
+                                                    },
+                                                    name: "Buva Sea Sihanoukville to Koh Rong 10",
+                                                    short_name: "SV-KR10-00-6",
+                                                    vendor: buva_sea)}
+
+  let!(:sihanoukville_to_koh_rong_by_ferry_2) {create(:route,
+                                                    trip_attributes: {
+                                                      origin_id: sihanoukville.id,
+                                                      destination_id: koh_rong.id,
+                                                      departure_time: '15:00',
+                                                      duration: 3,
+                                                      vehicle_id: ferry2.id,
+                                                      allow_seat_selection: false
+                                                    },
+                                                    name: "Buva Sea Sihanoukville to Koh Rong 15",
+                                                    short_name: "SV-KR-15-00-3",
+                                                    vendor: buva_sea)}
 #date
 let!(:today) {Date.today}
 let!(:tomorrow) {today + 1.day}
@@ -116,7 +154,7 @@ let!(:tomorrow) {today + 1.day}
   let!(:order4) {create(:transit_order, variant: larryta_phnom_penh_siemreap_1.master, seats: [mvn_f3_seat,mvn_f4_seat], date: today)}
   let!(:order5) {create(:transit_order, variant: vet_phnom_penh_siem_reap_2.master, seats: [arb_f1_seat,arb_f6_seat,arb_f4_seat], date: today)}
   let!(:order6) {create(:transit_order, variant: larryta_phnom_penh_siemreap_2.master, seats: [mvn_f7_seat,mvn_f8_seat], date: today)}
-
+  let!(:order8) {create(:transit_order, variant: sihanoukville_to_koh_rong_by_ferry.master, date: tomorrow, quantity: 4)}
 
   describe"#trips_info" do
     context "display table" do
@@ -196,6 +234,17 @@ let!(:tomorrow) {today + 1.day}
         expect(search_result.last.trip_id).to eq(larryta_phnom_penh_siemreap_2.master.id)
         expect(search_result.first.remaining_seats).to eq(7)
         expect(search_result.last.remaining_seats).to eq(22)
+      end
+    end
+    context "return trip result of SV-KR for today " do
+      let(:result) {described_class.new(origin_id: sihanoukville, destination_id: koh_rong, date: tomorrow)}
+      it "return trip result for today" do
+        search_result = result.call.sort_by(&:trip_id)
+        expect(search_result.count).to eq(2)
+        expect(search_result.first.trip_id).to eq(sihanoukville_to_koh_rong_by_ferry.master.id)
+        expect(search_result.last.trip_id).to eq(sihanoukville_to_koh_rong_by_ferry_2.master.id)
+        expect(search_result.first.remaining_seats).to eq(15)
+        expect(search_result.last.remaining_seats).to eq(19)
       end
     end
     context "return trip result for tomorrow" do


### PR DESCRIPTION
**Added new column "allow_seat_selection" to cm_trips**

**quantity is required instead of seats when allow_seat_selection==false**

**seat layout  will be nil for trip that doesn't allow seat selection**

<img width="286" alt="image" src="https://github.com/channainfo/commissioner/assets/87005466/56331406-5981-4774-9364-25ad129d0ae8">