### PR TITLE
close #1215 allow user to input actual guests & validate extra guests

### DIFF
--- a/app/models/concerns/spree_cm_commissioner/line_item_guests_concern.rb
+++ b/app/models/concerns/spree_cm_commissioner/line_item_guests_concern.rb
@@ -1,0 +1,71 @@
+module SpreeCmCommissioner
+  module LineItemGuestsConcern
+    extend ActiveSupport::Concern
+
+    included do
+      validate :validate_total_adults, if: -> { public_metadata[:number_of_adults].present? }
+      validate :validate_total_kids, if: -> { public_metadata[:number_of_kids].present? }
+    end
+
+    def remaining_total_guests = number_of_guests - guests.size
+    def number_of_guests = number_of_adults + number_of_kids
+
+    def allowed_extra_adults = variant.allowed_extra_adults * quantity
+    def allowed_extra_kids = variant.allowed_extra_kids * quantity
+
+    def allowed_total_adults = (variant.number_of_adults * quantity) + allowed_extra_adults
+    def allowed_total_kids = (variant.number_of_kids * quantity) + allowed_extra_kids
+
+    def number_of_adults = public_metadata[:number_of_adults] || (variant.number_of_adults * quantity)
+    def number_of_kids = public_metadata[:number_of_kids] || (variant.number_of_kids * quantity)
+
+    def extra_adults
+      return 0 unless extra_adults?
+
+      public_metadata[:number_of_adults] - (variant.number_of_adults * quantity)
+    end
+
+    def extra_kids
+      return 0 unless extra_kids?
+
+      public_metadata[:number_of_kids] - (variant.number_of_kids * quantity)
+    end
+
+    def guest_options
+      @guest_options ||= {
+        remaining_total_guests: remaining_total_guests,
+        number_of_guests: number_of_guests,
+        allowed_extra_adults: allowed_extra_adults,
+        allowed_extra_kids: allowed_extra_kids,
+        allowed_total_adults: allowed_total_adults,
+        allowed_total_kids: allowed_total_kids,
+        number_of_adults: number_of_adults,
+        number_of_kids: number_of_kids,
+        extra_adults: extra_adults,
+        extra_kids: extra_kids
+      }
+    end
+
+    def extra_adults?
+      public_metadata[:number_of_adults].present? && public_metadata[:number_of_adults] > variant.number_of_adults * quantity
+    end
+
+    def extra_kids?
+      public_metadata[:number_of_kids].present? && public_metadata[:number_of_kids] > variant.number_of_kids * quantity
+    end
+
+    private
+
+    def validate_total_adults
+      return if public_metadata[:number_of_adults] <= allowed_total_adults
+
+      errors.add(:quantity, 'exceed_total_adults')
+    end
+
+    def validate_total_kids
+      return if public_metadata[:number_of_kids] <= allowed_total_kids
+
+      errors.add(:quantity, 'exceed_total_kids')
+    end
+  end
+end

--- a/app/models/concerns/spree_cm_commissioner/variant_guests_concern.rb
+++ b/app/models/concerns/spree_cm_commissioner/variant_guests_concern.rb
@@ -6,15 +6,23 @@ module SpreeCmCommissioner
     DEFAULT_NUMBER_OF_GUESTS = 1
 
     def adults_option_value
-      option_value('adults')
+      @adults_option_value ||= option_value('adults')
     end
 
     def kids_option_value
-      option_value('kids')
+      @kids_option_value ||= option_value('kids')
     end
 
     def kids_age_max_option_value
-      option_value('kids-age-max')
+      @kids_age_max_option_value ||= option_value('kids-age-max')
+    end
+
+    def allowed_extra_adults_option_value
+      @allowed_extra_adults_option_value ||= option_value('allowed-extra-adults')
+    end
+
+    def allowed_extra_kids_option_value
+      @allowed_extra_kids_option_value ||= option_value('allowed-extra-kids')
     end
 
     # can consider as customers.
@@ -29,6 +37,14 @@ module SpreeCmCommissioner
 
     def number_of_kids
       kids_option_value&.to_i || 0
+    end
+
+    def allowed_extra_adults
+      allowed_extra_adults_option_value&.to_i || 0
+    end
+
+    def allowed_extra_kids
+      allowed_extra_kids_option_value&.to_i || 0
     end
 
     # <= 17

--- a/app/models/spree_cm_commissioner/line_item_decorator.rb
+++ b/app/models/spree_cm_commissioner/line_item_decorator.rb
@@ -3,6 +3,7 @@ module SpreeCmCommissioner
     def self.prepended(base)
       base.include SpreeCmCommissioner::LineItemDurationable
       base.include SpreeCmCommissioner::LineItemsFilterScope
+      base.include SpreeCmCommissioner::LineItemGuestsConcern
       base.include SpreeCmCommissioner::ProductDelegation
       base.include SpreeCmCommissioner::KycBitwise
 
@@ -64,14 +65,6 @@ module SpreeCmCommissioner
         accepted_at: Time.current,
         accepter: user
       )
-    end
-
-    def remaining_total_guests
-      number_of_guests - guests.size
-    end
-
-    def number_of_guests
-      variant.number_of_guests * quantity
     end
 
     def rejected_by(user)

--- a/lib/spree_cm_commissioner/test_helper/factories/option_type_factory .rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/option_type_factory .rb
@@ -19,18 +19,33 @@ FactoryBot.define do
     end
 
     trait :adults do
+      attr_type { 'integer' }
       name { 'adults' }
       presentation { 'Adults' }
     end
 
     trait :kids do
+      attr_type { 'integer' }
       name { 'kids' }
       presentation { 'Kids' }
     end
 
     trait :kids_age_max do
+      attr_type { 'integer' }
       name { 'kids-age-max' }
       presentation { 'Kids age max' }
+    end
+
+    trait :allowed_extra_adults do
+      attr_type { 'integer' }
+      name { 'allowed-extra-adults' }
+      presentation { 'Allowed extra adults' }
+    end
+
+    trait :allowed_extra_kids do
+      attr_type { 'integer' }
+      name { 'allowed-extra-kids' }
+      presentation { 'Allowed extra kids' }
     end
 
     initialize_with { Spree::OptionType.where(name: name).first_or_initialize }

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -159,5 +159,23 @@ RSpec.describe Spree::Variant, type: :model do
         expect(subject.kids_age_max).to eq 14
       end
     end
+
+    describe '#allowed_extra_adults' do
+      let(:option_type) { create(:cm_option_type, :allowed_extra_adults) }
+      let(:option_value) { create(:option_value, name: 'allowed-2-adults', presentation: '2', option_type: option_type) }
+
+      it 'return result of presentation in integer' do
+        expect(subject.allowed_extra_adults).to eq 2
+      end
+    end
+
+    describe '#allowed_extra_kids' do
+      let(:option_type) { create(:cm_option_type, :allowed_extra_kids) }
+      let(:option_value) { create(:option_value, name: '2-kids', presentation: '2', option_type: option_type) }
+
+      it 'return result of presentation in integer' do
+        expect(subject.allowed_extra_kids).to eq 2
+      end
+    end
   end
 end


### PR DESCRIPTION

When users add a room to cart, allow them to input actual guest number. This will later be used to calculate extra guest rates and pricing models.

## Breakdown:
- Input actual adults or kids with public_metadata
  public_metadata is only set on first created, after that, modify line item such as quantity does not affect it. 
- Allow variant to have allowed_extra_adults & allowed_extra_kids