### PR TITLE
close #1216 allow Spree::Price to belong to polymophic instead of variant

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,7 @@ name: Commissioner Gem
 
 on:
   pull_request:
-    branches:
-      - master
-      - develop
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/app/models/concerns/spree_cm_commissioner/priceable_concern.rb
+++ b/app/models/concerns/spree_cm_commissioner/priceable_concern.rb
@@ -1,0 +1,24 @@
+module SpreeCmCommissioner
+  module PriceableConcern
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :prices, as: :priceable, class_name: 'Spree::Price', dependent: :destroy
+    end
+
+    def price_in(currency)
+      currency = currency&.upcase
+      cache_key = "spree/prices/#{cache_key_with_version}/price_in/#{currency}"
+
+      Rails.cache.fetch(cache_key) { find_or_build_price(currency) } || find_or_build_price(currency)
+    end
+
+    def find_or_build_price(currency)
+      if prices.loaded?
+        prices.detect { |price| price.currency == currency } || prices.build(currency: currency)
+      else
+        prices.find_or_initialize_by(currency: currency)
+      end
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/price_decorator.rb
+++ b/app/models/spree_cm_commissioner/price_decorator.rb
@@ -1,0 +1,10 @@
+# Following decoration will detach price from variant. Allow price to belong to priceable instead.
+module SpreeCmCommissioner
+  module PriceDecorator
+    def self.prepended(base)
+      base.belongs_to :priceable, polymorphic: true, inverse_of: :prices, touch: true, optional: false
+    end
+  end
+end
+
+Spree::Price.prepend(SpreeCmCommissioner::PriceDecorator) unless Spree::Price.included_modules.include?(SpreeCmCommissioner::PriceDecorator)

--- a/app/models/spree_cm_commissioner/variant_decorator.rb
+++ b/app/models/spree_cm_commissioner/variant_decorator.rb
@@ -4,10 +4,16 @@ module SpreeCmCommissioner
       base.include SpreeCmCommissioner::ProductDelegation
       base.include SpreeCmCommissioner::VariantGuestsConcern
       base.include SpreeCmCommissioner::VariantOptionValuesConcern
+      base.include SpreeCmCommissioner::PriceableConcern
 
       base.after_commit :update_vendor_price
       base.after_save   :update_vendor_total_inventory, if: :saved_change_to_permanent_stock?
       base.validate     :validate_option_types
+
+      # override
+      base.has_one :default_price, lambda {
+                                     with_deleted.where(currency: Spree::Store.default.default_currency)
+                                   }, as: :priceable, class_name: 'Spree::Price', dependent: :destroy
 
       base.has_many :visible_option_values, lambda {
                                               joins(:option_type).where(spree_option_types: { hidden: false })

--- a/db/migrate/20240306071028_add_nationality_data_to_taxons.rb
+++ b/db/migrate/20240306071028_add_nationality_data_to_taxons.rb
@@ -1,5 +1,8 @@
 class AddNationalityDataToTaxons < ActiveRecord::Migration[7.0]
   def change
+    return if Rails.env.test?
+
+    ::Spree::Seeds::Stores.call
     nationalities_taxonomy = Spree::Store.default.taxonomies.where(name: 'Nationalities', kind: Spree::Taxon.kinds[:nationality]).first_or_create
 
     nationalities_data = YAML.load_file(Rails.root.join('config', 'data', 'nationalities.yml'))

--- a/db/migrate/20240315074637_add_priceable_to_spree_prices.rb
+++ b/db/migrate/20240315074637_add_priceable_to_spree_prices.rb
@@ -1,0 +1,13 @@
+class AddPriceableToSpreePrices < ActiveRecord::Migration[7.0]
+  def self.up
+    unless column_exists?(:spree_prices, :priceable_id)
+      add_reference :spree_prices, :priceable, polymorphic: true
+    end
+  end
+
+  def self.down
+    if column_exists?(:spree_prices, :priceable_id)
+      remove_reference :spree_prices, :priceable, polymorphic: true
+    end
+  end
+end

--- a/db/migrate/20240315074711_generate_default_value_for_priceable_in_spree_prices.rb
+++ b/db/migrate/20240315074711_generate_default_value_for_priceable_in_spree_prices.rb
@@ -1,0 +1,7 @@
+class GenerateDefaultValueForPriceableInSpreePrices < ActiveRecord::Migration[7.0]
+  def change
+    if column_exists?(:spree_prices, :variant_id)
+      Spree::Price.unscoped.update_all("priceable_id = spree_prices.variant_id, priceable_type = 'Spree::Variant'")
+    end
+  end
+end

--- a/db/migrate/20240315074750_change_variant_id_to_nullable_in_spree_prices.rb
+++ b/db/migrate/20240315074750_change_variant_id_to_nullable_in_spree_prices.rb
@@ -1,0 +1,7 @@
+class ChangeVariantIdToNullableInSpreePrices < ActiveRecord::Migration[7.0]
+  def change
+    # even Spree::Price detace variant from it, and have migrated its data to priceable.
+    # variant_id should still be there for reference old data or rollback. variant_id be kept as not required.
+    change_column :spree_prices, :variant_id, :integer, null: true
+  end
+end

--- a/db/migrate/20240315074812_change_priceable_to_required_in_spree_prices.rb
+++ b/db/migrate/20240315074812_change_priceable_to_required_in_spree_prices.rb
@@ -1,0 +1,6 @@
+class ChangePriceableToRequiredInSpreePrices < ActiveRecord::Migration[7.0]
+  def change
+    change_column :spree_prices, :priceable_id, :integer, null: false
+    change_column :spree_prices, :priceable_type, :string, null: false
+  end
+end

--- a/spec/models/spree/price_spec.rb
+++ b/spec/models/spree/price_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Price, type: :model do
+  describe 'associations' do
+    it { should belong_to(:priceable).required(true) }
+    it { should belong_to(:variant).required(false) }
+  end
+end

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe Spree::Variant, type: :model do
+  describe 'associations' do
+    it { should have_many(:prices).class_name('Spree::Price').dependent(:destroy) }
+  end
+
   describe 'validations' do
     context 'saving option values to variants' do
       let(:product_kind_option_type) { create(:option_type, kind: :product, presentation: 'Bathroom & Toiletries', name: 'bathroom-toiletries') }


### PR DESCRIPTION
Spree::Price will be later used for other models like pricing rate. Following are prices after migration.

<img width="1000" alt="image" src="https://github.com/channainfo/commissioner/assets/29684683/734402e2-3080-4727-8efc-0ad41e53b7dc">

## Reference
- https://github.com/SpreeTravel/spree_travel_core/blob/master/app/models/spree/price_decorator.rb