### PR TITLE
wip #1233 override variant option_values

### DIFF
--- a/app/serializers/spree/v2/storefront/variant_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/variant_serializer_decorator.rb
@@ -6,7 +6,10 @@ module Spree
           base.attributes :permanent_stock, :need_confirmation, :product_type, :kyc, :reminder_option_value, :started_at_option_value
 
           base.has_many :stock_locations
-          base.has_many :visible_option_values, serializer: Spree::V2::Storefront::OptionValueSerializer
+          # override
+          base.has_many :option_values do |object|
+            object.option_values.joins(:option_type).where(spree_option_types: { hidden: false })
+          end
         end
       end
     end

--- a/spec/serializers/spree/v2/storefront/variant_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/variant_serializer_spec.rb
@@ -49,7 +49,6 @@ describe Spree::V2::Storefront::VariantSerializer, type: :serializer do
         :option_values,
         :vendor,
         :stock_locations,
-        :visible_option_values
       )
     end
   end


### PR DESCRIPTION
In App we want to return only option values that its option_type type is not hidden , In doing so we don't have modify our app code 

<img src="https://github.com/channainfo/commissioner/assets/92453740/5d762763-d8d3-43f0-b28d-7cd64fee60d3" width="300" height="auto">
