### PR TITLE
close #1286 reassign event id for guest when assigned wrong

### DIFF
--- a/app/jobs/spree_cm_commissioner/ensure_event_id_for_guests_job.rb
+++ b/app/jobs/spree_cm_commissioner/ensure_event_id_for_guests_job.rb
@@ -1,7 +1,7 @@
 module SpreeCmCommissioner
   class EnsureEventIdForGuestsJob < ApplicationJob
     def perform
-      SpreeCmCommissioner::Guest.complete.unassigned_event.find_each do |guest|
+      SpreeCmCommissioner::Guest.complete.find_each do |guest|
         guest.set_event_id
         guest.save!
       end

--- a/spec/jobs/spree_cm_commissioner/ensure_event_id_for_guests_job_spec.rb
+++ b/spec/jobs/spree_cm_commissioner/ensure_event_id_for_guests_job_spec.rb
@@ -21,12 +21,11 @@ RSpec.describe SpreeCmCommissioner::EnsureEventIdForGuestsJob, type: :job do
     # set it to null as it auto-assign event_id on save.
     before do
       guest1.update_columns(event_id: nil)
-      guest2.update_columns(event_id: nil)
     end
 
-    it "save event_id for guests when it nil" do
+    it "reassign event_id for guests" do
       expect(guest1.reload.event_id).to eq nil
-      expect(guest2.reload.event_id).to eq nil
+      expect(guest2.reload.event_id).not_to eq nil
 
       perform_enqueued_jobs { described_class.perform_now }
 


### PR DESCRIPTION
Make sure to re-assign event id even it is not null to ensure correct event id.

For example, we happen to assign wrong event id here. Event id should be 39 instead of 9. This will break check-in app.

![image](https://github.com/channainfo/commissioner/assets/29684683/ebd57878-70be-485d-9a05-02bf0966432b)
