### PR TITLE
close #1313 setup pricing model/rate model migrations

### DIFF
--- a/app/models/concerns/spree_cm_commissioner/line_item_pricings_concern.rb
+++ b/app/models/concerns/spree_cm_commissioner/line_item_pricings_concern.rb
@@ -1,0 +1,21 @@
+module SpreeCmCommissioner
+  module LineItemPricingsConcern
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :applied_pricing_rates, class_name: 'SpreeCmCommissioner::AppliedPricingRate', dependent: :destroy
+      has_many :applied_pricing_models, class_name: 'SpreeCmCommissioner::AppliedPricingModel', dependent: :destroy
+
+      has_many :pricing_rates, class_name: 'SpreeCmCommissioner::PricingRate', through: :applied_pricing_rates, source: :pricing_rate
+      has_many :pricing_models, class_name: 'SpreeCmCommissioner::PricingModel', through: :applied_pricing_models, source: :pricing_model
+
+      validates :pricing_models_amount, allow_nil: true, numericality: true
+      with_options allow_nil: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: Spree::Price::MAXIMUM_AMOUNT } do
+        validates :pricing_rates_amount
+        validates :pricing_subtotal
+      end
+
+      money_methods :pricing_rates_amount, :pricing_models_amount, :pricing_subtotal
+    end
+  end
+end

--- a/app/models/concerns/spree_cm_commissioner/priceable.rb
+++ b/app/models/concerns/spree_cm_commissioner/priceable.rb
@@ -1,5 +1,5 @@
 module SpreeCmCommissioner
-  module PriceableConcern
+  module Priceable
     extend ActiveSupport::Concern
 
     included do
@@ -11,6 +11,11 @@ module SpreeCmCommissioner
       cache_key = "spree/prices/#{cache_key_with_version}/price_in/#{currency}"
 
       Rails.cache.fetch(cache_key) { find_or_build_price(currency) } || find_or_build_price(currency)
+
+    # it raised TypeError: singleton can't be dumped, mean that it can't cache singleton class.
+    # it happens only on rspec.
+    rescue TypeError
+      find_or_build_price(currency)
     end
 
     def find_or_build_price(currency)

--- a/app/models/concerns/spree_cm_commissioner/pricing_ruleable.rb
+++ b/app/models/concerns/spree_cm_commissioner/pricing_ruleable.rb
@@ -1,0 +1,33 @@
+# Module for pricing model & rate. It's expected to have following columns:
+# :match_policy, :effective_from, :effective_to, :priority
+module SpreeCmCommissioner
+  module PricingRuleable
+    extend ActiveSupport::Concern
+
+    included do
+      acts_as_list column: :priority
+
+      has_many :pricing_rules, as: :pricing_ruleable, class_name: 'SpreeCmCommissioner::PricingRule', dependent: :destroy
+
+      enum match_policy: %i[all any none].freeze, _prefix: true
+
+      scope :active, lambda {
+        where('effective_from IS NULL OR effective_from < ?', Time.current)
+          .where('effective_to IS NULL OR effective_to > ?', Time.current)
+      }
+    end
+
+    def eligible?(options)
+      applicable_rules = pricing_rules.select { |rule| rule.applicable?(options) }
+      return false if applicable_rules.none?
+
+      if match_policy_all?
+        applicable_rules.all? { |rule| rule.eligible?(options) }
+      elsif match_policy_any?
+        applicable_rules.any? { |rule| rule.eligible?(options) }
+      elsif match_policy_none?
+        applicable_rules.none? { |rule| rule.eligible?(options) }
+      end
+    end
+  end
+end

--- a/app/models/concerns/spree_cm_commissioner/product_delegation.rb
+++ b/app/models/concerns/spree_cm_commissioner/product_delegation.rb
@@ -4,7 +4,7 @@ module SpreeCmCommissioner
 
     included do
       delegate :product_type,
-               :need_confirmation?, :need_confirmation, :kyc,
+               :need_confirmation?, :need_confirmation, :kyc, :kyc?,
                :accommodation?, :service?, :ecommerce?,
                :associated_event,
                to: :product

--- a/app/models/spree_cm_commissioner/applied_pricing_model.rb
+++ b/app/models/spree_cm_commissioner/applied_pricing_model.rb
@@ -1,0 +1,12 @@
+module SpreeCmCommissioner
+  class AppliedPricingModel < Base
+    belongs_to :line_item, class_name: 'Spree::LineItem'
+    belongs_to :pricing_model, class_name: 'SpreeCmCommissioner::PricingModel'
+    belongs_to :pricing_rate, class_name: 'SpreeCmCommissioner::PricingRate', optional: true
+
+    extend ::Spree::DisplayMoney
+    money_methods :amount
+
+    delegate :currency, to: :line_item
+  end
+end

--- a/app/models/spree_cm_commissioner/applied_pricing_rate.rb
+++ b/app/models/spree_cm_commissioner/applied_pricing_rate.rb
@@ -1,0 +1,13 @@
+module SpreeCmCommissioner
+  class AppliedPricingRate < Base
+    belongs_to :line_item, class_name: 'Spree::LineItem'
+    belongs_to :pricing_rate, class_name: 'SpreeCmCommissioner::PricingRate'
+
+    delegate :currency, to: :line_item
+
+    extend ::Spree::DisplayMoney
+    money_methods :amount
+
+    validates :amount, presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: Spree::Price::MAXIMUM_AMOUNT }
+  end
+end

--- a/app/models/spree_cm_commissioner/line_item_decorator.rb
+++ b/app/models/spree_cm_commissioner/line_item_decorator.rb
@@ -4,6 +4,7 @@ module SpreeCmCommissioner
       base.include SpreeCmCommissioner::LineItemDurationable
       base.include SpreeCmCommissioner::LineItemsFilterScope
       base.include SpreeCmCommissioner::LineItemGuestsConcern
+      base.include SpreeCmCommissioner::LineItemPricingsConcern
       base.include SpreeCmCommissioner::ProductDelegation
       base.include SpreeCmCommissioner::KycBitwise
 
@@ -22,8 +23,6 @@ module SpreeCmCommissioner
 
       base.whitelisted_ransackable_associations |= %w[guests]
       base.whitelisted_ransackable_attributes |= %w[to_date from_date]
-
-      delegate :kyc?, to: :product
 
       def base.json_api_columns
         json_api_columns = column_names.reject { |c| c.match(/_id$|id|preferences|(.*)password|(.*)token|(.*)api_key/) }
@@ -55,6 +54,8 @@ module SpreeCmCommissioner
     #
     # override
     def amount
+      return pricing_subtotal if pricing_subtotal.present?
+
       base_price = price * quantity
 
       if reservation? && date_unit

--- a/app/models/spree_cm_commissioner/price_decorator.rb
+++ b/app/models/spree_cm_commissioner/price_decorator.rb
@@ -4,6 +4,24 @@ module SpreeCmCommissioner
     def self.prepended(base)
       base.belongs_to :priceable, polymorphic: true, inverse_of: :prices, touch: true, optional: false
     end
+
+    def tax_category
+      priceable.respond_to?(:tax_category) ? priceable.tax_category : nil
+    end
+
+    # override:
+    # to get tax_category from priceable instead of variant
+    def price_including_vat_for(price_options)
+      options = price_options.merge(tax_category: tax_category)
+      gross_amount(price, options)
+    end
+
+    # override:
+    # to get tax_category from priceable instead of variant
+    def compare_at_price_including_vat_for(price_options)
+      options = price_options.merge(tax_category: tax_category)
+      gross_amount(compare_at_price, options)
+    end
   end
 end
 

--- a/app/models/spree_cm_commissioner/pricing_action.rb
+++ b/app/models/spree_cm_commissioner/pricing_action.rb
@@ -1,0 +1,19 @@
+module SpreeCmCommissioner
+  class PricingAction < Base
+    acts_as_list column: :priority
+
+    belongs_to :pricing_model, optional: false, class_name: 'SpreeCmCommissioner::PricingModel'
+
+    def applicable?(_options)
+      raise 'Implement on sub-class of SpreeCmCommissioner::PricingAction'
+    end
+
+    def perform(_options = {})
+      raise 'Implement on sub-class of SpreeCmCommissioner::PricingAction'
+    end
+
+    def description
+      self.class.name.demodulize.underscore.humanize
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/pricing_model.rb
+++ b/app/models/spree_cm_commissioner/pricing_model.rb
@@ -1,0 +1,10 @@
+module SpreeCmCommissioner
+  class PricingModel < Base
+    include PricingRuleable
+
+    belongs_to :pricing_modelable, optional: false, polymorphic: true, inverse_of: :pricing_models, touch: true
+
+    has_many :pricing_actions, autosave: true, class_name: 'SpreeCmCommissioner::PricingAction', dependent: :destroy
+    has_many :applied_pricing_models, class_name: 'SpreeCmCommissioner::AppliedPricingModel', dependent: :restrict_with_error
+  end
+end

--- a/app/models/spree_cm_commissioner/pricing_rate.rb
+++ b/app/models/spree_cm_commissioner/pricing_rate.rb
@@ -1,0 +1,29 @@
+module SpreeCmCommissioner
+  class PricingRate < Base
+    include Priceable
+    include PricingRuleable
+
+    belongs_to :pricing_rateable, optional: false, polymorphic: true, inverse_of: :pricing_rates
+    has_many :applied_pricing_rates, class_name: 'SpreeCmCommissioner::AppliedPricingRate', dependent: :restrict_with_error
+
+    has_one :default_price,
+            -> { where(currency: Spree::Store.default.default_currency) },
+            class_name: 'Spree::Price',
+            as: :priceable
+
+    delegate :display_price, :display_amount, :price, :currency, :price=,
+             :price_including_vat_for, :currency=, :display_compare_at_price,
+             :compare_at_price, :compare_at_price=, to: :find_or_build_default_price
+
+    after_save -> { default_price.save }, if: -> { default_price.present? && (default_price.changed? || default_price.new_record?) }
+
+    def find_or_build_default_price
+      default_price || build_default_price
+    end
+
+    # spree_price required tax category for gross_amount calculation
+    def tax_category
+      pricing_rateable.respond_to?(:tax_category) ? pricing_rateable.tax_category : nil
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/pricing_rule.rb
+++ b/app/models/spree_cm_commissioner/pricing_rule.rb
@@ -1,0 +1,19 @@
+module SpreeCmCommissioner
+  class PricingRule < Base
+    acts_as_list column: :priority
+
+    belongs_to :pricing_ruleable, optional: false, polymorphic: true, inverse_of: :pricing_rules
+
+    def applicable?(_options = {})
+      raise 'Implement on sub-class of SpreeCmCommissioner::PricingRule'
+    end
+
+    def eligible?(_options = {})
+      raise 'Implement on sub-class of SpreeCmCommissioner::PricingRule'
+    end
+
+    def description
+      raise 'Implement on sub-class of SpreeCmCommissioner::PricingRule'
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/variant_decorator.rb
+++ b/app/models/spree_cm_commissioner/variant_decorator.rb
@@ -4,11 +4,14 @@ module SpreeCmCommissioner
       base.include SpreeCmCommissioner::ProductDelegation
       base.include SpreeCmCommissioner::VariantGuestsConcern
       base.include SpreeCmCommissioner::VariantOptionValuesConcern
-      base.include SpreeCmCommissioner::PriceableConcern
+      base.include SpreeCmCommissioner::Priceable
 
       base.after_commit :update_vendor_price
       base.after_save   :update_vendor_total_inventory, if: :saved_change_to_permanent_stock?
       base.validate     :validate_option_types
+
+      base.has_many :pricing_rates, as: :pricing_rateable, dependent: :destroy, class_name: 'SpreeCmCommissioner::PricingRate'
+      base.has_many :pricing_models, as: :pricing_modelable, dependent: :destroy, class_name: 'SpreeCmCommissioner::PricingModel'
 
       # override
       base.has_one :default_price, lambda {

--- a/db/migrate/20240317030612_create_spree_cm_commissioner_pricing_rates.rb
+++ b/db/migrate/20240317030612_create_spree_cm_commissioner_pricing_rates.rb
@@ -1,0 +1,19 @@
+class CreateSpreeCmCommissionerPricingRates < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cm_pricing_rates, if_not_exists: true do |t|
+      t.string :name
+      t.integer :priority
+      t.integer :match_policy, default: 0
+
+      t.references :pricing_rateable, polymorphic: true, index: true, null: false
+      t.datetime :effective_from, index: true
+      t.datetime :effective_to, index: true
+
+      t.text :preferences
+
+      t.index [:effective_from, :effective_to]
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240317030641_create_spree_cm_commissioner_pricing_models.rb
+++ b/db/migrate/20240317030641_create_spree_cm_commissioner_pricing_models.rb
@@ -1,0 +1,19 @@
+class CreateSpreeCmCommissionerPricingModels < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cm_pricing_models, if_not_exists: true do |t|
+      t.string :name
+      t.integer :priority
+      t.integer :match_policy, default: 0
+
+      t.references :pricing_modelable, polymorphic: true, index: true, null: false
+      t.datetime :effective_from, index: true
+      t.datetime :effective_to, index: true
+
+      t.text :preferences
+
+      t.index [:effective_from, :effective_to]
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240317030717_create_spree_cm_commissioner_pricing_actions.rb
+++ b/db/migrate/20240317030717_create_spree_cm_commissioner_pricing_actions.rb
@@ -1,0 +1,13 @@
+class CreateSpreeCmCommissionerPricingActions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cm_pricing_actions, if_not_exists: true do |t|
+      t.string :type, index: true
+      t.integer :priority
+      t.text :preferences
+
+      t.references :pricing_model, index: true, foreign_key: { to_table: :cm_pricing_models }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240317030909_create_spree_cm_commissioner_pricing_rules.rb
+++ b/db/migrate/20240317030909_create_spree_cm_commissioner_pricing_rules.rb
@@ -1,0 +1,13 @@
+class CreateSpreeCmCommissionerPricingRules < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cm_pricing_rules, if_not_exists: true do |t|
+      t.string :type, index: true
+      t.integer :priority
+      t.text :preferences
+
+      t.references :pricing_ruleable, polymorphic: true, index: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240318092658_add_pricings_columns_to_line_items.rb
+++ b/db/migrate/20240318092658_add_pricings_columns_to_line_items.rb
@@ -1,0 +1,7 @@
+class AddPricingsColumnsToLineItems < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_line_items, :pricing_rates_amount, :decimal, precision: 10, scale: 2, if_not_exists: true
+    add_column :spree_line_items, :pricing_models_amount, :decimal, precision: 10, scale: 2, if_not_exists: true
+    add_column :spree_line_items, :pricing_subtotal, :decimal, precision: 10, scale: 2, if_not_exists: true
+  end
+end

--- a/db/migrate/20240318114350_create_spree_cm_commissioner_applied_pricing_models.rb
+++ b/db/migrate/20240318114350_create_spree_cm_commissioner_applied_pricing_models.rb
@@ -1,0 +1,14 @@
+class CreateSpreeCmCommissionerAppliedPricingModels < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cm_applied_pricing_models, if_not_exists: true do |t|
+      t.references :line_item, foreign_key: { to_table: :spree_line_items }
+      t.references :pricing_model, foreign_key: { to_table: :cm_pricing_models }
+      t.references :pricing_rate, foreign_key: { to_table: :cm_pricing_rates }
+
+      t.decimal :amount, precision: 10, scale: 2, null: false
+      t.jsonb :options
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240318114449_create_spree_cm_commissioner_applied_pricing_rates.rb
+++ b/db/migrate/20240318114449_create_spree_cm_commissioner_applied_pricing_rates.rb
@@ -1,0 +1,13 @@
+class CreateSpreeCmCommissionerAppliedPricingRates < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cm_applied_pricing_rates, if_not_exists: true do |t|
+      t.references :line_item, foreign_key: { to_table: :spree_line_items }
+      t.references :pricing_rate, foreign_key: { to_table: :cm_pricing_rates }
+
+      t.decimal :amount, precision: 10, scale: 2, null: false
+      t.jsonb :options
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/spree_cm_commissioner/test_helper/factories/pricing_action_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/pricing_action_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :cm_pricing_action, class: SpreeCmCommissioner::PricingAction do
+    pricing_model { |a| a.association(:cm_pricing_model) }
+  end
+end

--- a/lib/spree_cm_commissioner/test_helper/factories/pricing_model_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/pricing_model_factory.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :cm_pricing_model, class: SpreeCmCommissioner::PricingModel do
+    match_policy { :all }
+    effective_from { nil }
+    effective_to { nil }
+    pricing_modelable { |r| r.association(:variant) }
+  end
+end

--- a/lib/spree_cm_commissioner/test_helper/factories/pricing_rate_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/pricing_rate_factory.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :cm_pricing_rate, class: SpreeCmCommissioner::PricingRate do
+    match_policy { :all }
+    effective_from { nil }
+    effective_to { nil }
+
+    pricing_rateable { |r| r.association(:variant) }
+  end
+end

--- a/lib/spree_cm_commissioner/test_helper/factories/pricing_rule_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/pricing_rule_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :cm_pricing_rule, class: SpreeCmCommissioner::PricingRule do
+    pricing_ruleable { |r| r.association(:cm_pricing_rate) }
+  end
+end

--- a/spec/models/concerns/spree_cm_commissioner/pricing_ruleable_spec.rb
+++ b/spec/models/concerns/spree_cm_commissioner/pricing_ruleable_spec.rb
@@ -1,0 +1,132 @@
+require 'spec_helper'
+
+class PricingRuleableDummyClass < Spree::Base
+  include SpreeCmCommissioner::PricingRuleable
+
+  self.table_name = "cm_pricing_rates"
+
+  after_initialize { self.pricing_rateable_id = 0 }
+  after_initialize { self.pricing_rateable_type = 'Any' }
+end
+
+RSpec.describe SpreeCmCommissioner::PricingRuleable do
+  let(:dummy_klass) { PricingRuleableDummyClass }
+
+  subject { dummy_klass.new }
+
+  describe 'associations' do
+    it { should have_many(:pricing_rules).class_name('SpreeCmCommissioner::PricingRule').dependent(:destroy) }
+  end
+
+  describe "scopes" do
+    describe ".active" do
+      let!(:active_rate) { dummy_klass.create(effective_from: 1.day.ago, effective_to: 1.day.from_now) }
+      let!(:permanent_rate) { dummy_klass.create(effective_from: nil, effective_to: nil) }
+
+      let!(:inactive_rate) { dummy_klass.create(effective_from: 2.days.ago, effective_to: 1.day.ago) }
+      let!(:future_rate) { dummy_klass.create(effective_from: 1.day.from_now, effective_to: 2.days.from_now) }
+
+      it "returns active & permanent rates" do
+        expect(dummy_klass.active).to include(active_rate, permanent_rate)
+        expect(dummy_klass.active).not_to include(inactive_rate, future_rate)
+      end
+    end
+  end
+
+  describe '#eligible?' do
+    let(:rule1) { build(:cm_pricing_rule) }
+    let(:rule2) { build(:cm_pricing_rule) }
+
+    subject { dummy_klass.new(pricing_rules: [rule1, rule2], match_policy: :all) }
+
+    it 'return false when no applicable rules' do
+      allow(rule1).to receive(:applicable?).with({}).and_return(false)
+      allow(rule2).to receive(:applicable?).with({}).and_return(false)
+
+      expect(subject.eligible?({})).to be false
+    end
+
+    context 'when pring rate is must match all rules' do
+      subject { dummy_klass.new(pricing_rules: [rule1, rule2], match_policy: :all) }
+
+      before do
+        allow(rule1).to receive(:applicable?).with({}).and_return(true)
+        allow(rule2).to receive(:applicable?).with({}).and_return(true)
+      end
+
+      it 'return false any of rules are not eligible' do
+        allow(rule1).to receive(:eligible?).with({}).and_return(true)
+        allow(rule2).to receive(:eligible?).with({}).and_return(false)
+
+        expect(subject.eligible?({})).to be false
+      end
+
+      it 'return true all rules are eligible' do
+        allow(rule1).to receive(:eligible?).with({}).and_return(true)
+        allow(rule2).to receive(:eligible?).with({}).and_return(true)
+
+        expect(subject.eligible?({})).to be true
+      end
+    end
+
+    context 'when pring rate is must match any rules' do
+      subject { dummy_klass.new(pricing_rules: [rule1, rule2], match_policy: :any) }
+
+      before do
+        allow(rule1).to receive(:applicable?).with({}).and_return(true)
+        allow(rule2).to receive(:applicable?).with({}).and_return(true)
+      end
+
+      it 'return false when all of rules are not eligible' do
+        allow(rule1).to receive(:eligible?).with({}).and_return(false)
+        allow(rule2).to receive(:eligible?).with({}).and_return(false)
+
+        expect(subject.eligible?({})).to be false
+      end
+
+      it 'return true any of rules are eligible' do
+        allow(rule1).to receive(:eligible?).with({}).and_return(true)
+        allow(rule2).to receive(:eligible?).with({}).and_return(false)
+
+        expect(subject.eligible?({})).to be true
+      end
+
+      it 'return true all of rules are eligible' do
+        allow(rule1).to receive(:eligible?).with({}).and_return(true)
+        allow(rule2).to receive(:eligible?).with({}).and_return(true)
+
+        expect(subject.eligible?({})).to be true
+      end
+    end
+
+    context 'when pring rate is must match none of rules' do
+      subject { dummy_klass.new(pricing_rules: [rule1, rule2], match_policy: :none) }
+
+      before do
+        allow(rule1).to receive(:applicable?).with({}).and_return(true)
+        allow(rule2).to receive(:applicable?).with({}).and_return(true)
+      end
+
+      it 'return false when all of rules are eligible' do
+        allow(rule1).to receive(:eligible?).with({}).and_return(true)
+        allow(rule2).to receive(:eligible?).with({}).and_return(true)
+
+        expect(subject.eligible?({})).to be false
+      end
+
+      it 'return false when some of rules are eligible' do
+        allow(rule1).to receive(:eligible?).with({}).and_return(true)
+        allow(rule2).to receive(:eligible?).with({}).and_return(false)
+
+        expect(subject.eligible?({})).to be false
+      end
+
+      it 'return true all of rules are not eligible' do
+        allow(rule1).to receive(:eligible?).with({}).and_return(false)
+        allow(rule2).to receive(:eligible?).with({}).and_return(false)
+
+        expect(subject.eligible?({})).to be true
+      end
+    end
+  end
+end

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -1,6 +1,14 @@
 require 'spec_helper'
 
 RSpec.describe Spree::LineItem, type: :model do
+  describe 'associations' do
+    it { is_expected.to have_many(:applied_pricing_rates).class_name('SpreeCmCommissioner::AppliedPricingRate').dependent(:destroy) }
+    it { is_expected.to have_many(:applied_pricing_models).class_name('SpreeCmCommissioner::AppliedPricingModel').dependent(:destroy) }
+
+    it { is_expected.to have_many(:pricing_rates).class_name('SpreeCmCommissioner::PricingRate').through(:applied_pricing_rates).source(:pricing_rate) }
+    it { is_expected.to have_many(:pricing_models).class_name('SpreeCmCommissioner::PricingModel').through(:applied_pricing_models).source(:pricing_model) }
+  end
+
   describe '#callback before_save' do
     let(:phnom_penh) { create(:state, name: 'Phnom Penh') }
     let!(:vendor) { create(:cm_vendor_with_product, name: 'Phnom Penh Hotel', default_state_id: phnom_penh.id) }
@@ -17,6 +25,22 @@ RSpec.describe Spree::LineItem, type: :model do
   end
 
   describe 'validations' do
+    it { is_expected.to validate_numericality_of(:pricing_models_amount).allow_nil }
+
+    it do
+      is_expected.to validate_numericality_of(:pricing_rates_amount)
+        .allow_nil
+        .is_greater_than_or_equal_to(0)
+        .is_less_than_or_equal_to(Spree::Price::MAXIMUM_AMOUNT)
+    end
+
+    it do
+      is_expected.to validate_numericality_of(:pricing_subtotal)
+        .allow_nil
+        .is_greater_than_or_equal_to(0)
+        .is_less_than_or_equal_to(Spree::Price::MAXIMUM_AMOUNT)
+    end
+
     context 'make sure quantity not exceed max-quantity-per-order' do
       let(:line_item) { create(:line_item) }
 

--- a/spec/models/spree/price_spec.rb
+++ b/spec/models/spree/price_spec.rb
@@ -5,4 +5,50 @@ RSpec.describe Spree::Price, type: :model do
     it { should belong_to(:priceable).required(true) }
     it { should belong_to(:variant).required(false) }
   end
+
+  describe '#price_including_vat_for' do
+    let(:price_options) { { tax_zone: ::Spree::Zone.default_tax } }
+
+    subject { create(:price, priceable: priceable, amount: 10) }
+
+    context 'when priceable is variant' do
+      let(:priceable) { build(:variant) }
+
+      it 'calls gross_amount with tax category from priceable' do
+        expect(subject).to receive(:gross_amount).with(subject.price, { tax_category: priceable.tax_category }).and_call_original
+
+        result = subject.price_including_vat_for({})
+
+        expect(result).to eq 10
+      end
+    end
+
+    context 'when priceable is pricing rate' do
+      let(:variant) { build(:variant) }
+      let(:priceable) { build(:cm_pricing_rate, pricing_rateable: variant) }
+
+      it 'calls gross_amount with tax category from variant of priceable' do
+        expect(subject).to receive(:gross_amount).with(subject.price, { tax_category: variant.tax_category }).and_call_original
+
+        result = subject.price_including_vat_for({})
+
+        expect(result).to eq 10
+      end
+    end
+  end
+
+  describe '#compare_at_price_including_vat_for' do
+    let(:priceable) { build(:variant) }
+
+    subject { create(:price, priceable: priceable, amount: 10) }
+
+    it 'call gross_amount and return money' do
+      expect(subject).to receive(:gross_amount).with(subject.price, { tax_category: priceable.tax_category }).and_call_original
+
+      result = subject.display_price_including_vat_for({})
+
+      expect(result).to be_an_instance_of(::Spree::Money)
+      expect(result.to_s).to eq "$10.00"
+    end
+  end
 end

--- a/spec/models/spree_cm_commissioner/applied_pricing_model_spec.rb
+++ b/spec/models/spree_cm_commissioner/applied_pricing_model_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::AppliedPricingModel, type: :model do
+  describe '#display_amount' do
+    let(:line_item) { create(:line_item) }
+    let(:pricing_model) { create(:cm_pricing_model, pricing_modelable: line_item.variant) }
+
+    subject { line_item.applied_pricing_models.create(pricing_model: pricing_model, amount: 10, line_item: line_item) }
+
+    it 'return correct display amount' do
+      expect(subject.display_amount.to_s).to eq '$10.00'
+    end
+  end
+end

--- a/spec/models/spree_cm_commissioner/applied_pricing_rate_spec.rb
+++ b/spec/models/spree_cm_commissioner/applied_pricing_rate_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::AppliedPricingRate, type: :model do
+  context 'validations' do
+    it { is_expected.to validate_presence_of(:amount) }
+
+    it 'validates numericality of amount' do
+      expect(subject).to validate_numericality_of(:amount).is_greater_than_or_equal_to(0)
+      expect(subject).to validate_numericality_of(:amount).is_less_than_or_equal_to(Spree::Price::MAXIMUM_AMOUNT)
+    end
+  end
+
+  describe '#display_amount' do
+    let(:line_item) { create(:line_item) }
+    let(:pricing_rate) { create(:cm_pricing_rate, pricing_rateable: line_item.variant) }
+
+    subject { line_item.applied_pricing_rates.create(pricing_rate: pricing_rate, amount: 10, line_item: line_item) }
+
+    it 'return correct display amount' do
+      expect(subject.display_amount.to_s).to eq '$10.00'
+    end
+  end
+end

--- a/spec/models/spree_cm_commissioner/pricing_action_spec.rb
+++ b/spec/models/spree_cm_commissioner/pricing_action_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::PricingAction, type: :model do
+  describe 'associations' do
+    it { should belong_to(:pricing_model).class_name('SpreeCmCommissioner::PricingModel').required }
+  end
+
+  describe '#applicable?' do
+    it 'raises an error' do
+      expect { subject.applicable?({}) }.to raise_error('Implement on sub-class of SpreeCmCommissioner::PricingAction')
+    end
+  end
+
+  describe '#perform' do
+    it 'raises an error' do
+      expect { subject.perform({}) }.to raise_error('Implement on sub-class of SpreeCmCommissioner::PricingAction')
+    end
+  end
+end

--- a/spec/models/spree_cm_commissioner/pricing_model_spec.rb
+++ b/spec/models/spree_cm_commissioner/pricing_model_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::PricingModel, type: :model do
+  describe 'associations' do
+    it { should belong_to(:pricing_modelable).inverse_of(:pricing_models).touch(true).required }
+    it { should have_many(:pricing_actions).autosave(true).class_name('SpreeCmCommissioner::PricingAction').dependent(:destroy) }
+    it { should have_many(:applied_pricing_models).class_name('SpreeCmCommissioner::AppliedPricingModel').dependent(:restrict_with_error) }
+  end
+end

--- a/spec/models/spree_cm_commissioner/pricing_rate_spec.rb
+++ b/spec/models/spree_cm_commissioner/pricing_rate_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::PricingRate, type: :model do
+  describe 'associations' do
+    it { should belong_to(:pricing_rateable).inverse_of(:pricing_rates).required }
+    it { should have_many(:applied_pricing_rates).class_name('SpreeCmCommissioner::AppliedPricingRate').dependent(:restrict_with_error) }
+    it { should have_one(:default_price).class_name('Spree::Price') }
+  end
+
+  describe "callbacks" do
+    it "saves default_price after save if it is present and changed or new" do
+      subject = build(:cm_pricing_rate, price: 10)
+
+      expect(subject.default_price.present?).to be true
+      expect(subject.default_price.changed?).to be true
+      expect(subject.default_price.new_record?).to be true
+
+      expect(subject.default_price).to receive(:save).and_call_original
+
+      subject.save
+
+      expect(subject.default_price.amount).to eq 10
+    end
+
+    it "does not save default_price after save if it is not present" do
+      RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+
+      subject = build(:cm_pricing_rate, default_price: nil)
+
+      expect(subject.default_price.present?).to be false
+      expect(subject.default_price).to_not receive(:save)
+
+      subject.save
+
+      RSpec::Mocks.configuration.allow_message_expectations_on_nil = false
+    end
+
+    it "does not save default_price after save if it is not changed or new record" do
+      price = build(:price, amount: 10)
+      subject = create(:cm_pricing_rate, default_price: price)
+
+      expect(subject.default_price.changed?).to eq false
+      expect(subject.default_price.new_record?).to eq false
+      expect(subject.default_price).to_not receive(:save)
+
+      subject.save
+    end
+  end
+
+  describe "#find_or_build_default_price" do
+    it "returns the default price if it exists" do
+      default_price = Spree::Price.new(amount: 10)
+
+      allow(subject).to receive(:default_price).and_return(default_price)
+      expect(subject.find_or_build_default_price).to eq(default_price)
+    end
+
+    it "builds a new default price if it doesn't exist" do
+      expect(subject.find_or_build_default_price).to be_a_new(Spree::Price)
+    end
+  end
+
+  describe "#tax_category" do
+    let(:tax_category) { create(:tax_category) }
+
+    it "returns the tax category of the rateable object if available" do
+      pricing_rateable = create(:variant, tax_category_id: tax_category.id)
+
+      pricing_rate = SpreeCmCommissioner::PricingRate.new(pricing_rateable: pricing_rateable)
+
+      expect(pricing_rate.tax_category).to eq tax_category
+    end
+
+    it "returns nil if the rateable object does not have a tax category" do
+      pricing_rateable = create(:variant, product: create(:product, tax_category_id: nil))
+
+      pricing_rate = SpreeCmCommissioner::PricingRate.new(pricing_rateable: pricing_rateable)
+
+      expect(pricing_rate.tax_category).to be_nil
+    end
+  end
+end

--- a/spec/models/spree_cm_commissioner/pricing_rule_spec.rb
+++ b/spec/models/spree_cm_commissioner/pricing_rule_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::PricingRule, type: :model do
+  describe 'associations' do
+    it { should belong_to(:pricing_ruleable).inverse_of(:pricing_rules).required }
+  end
+
+  describe '#applicable?' do
+    it 'raises an error instructing to implement on sub-class' do
+      pricing_rule = described_class.new
+      expect { pricing_rule.applicable? }.to raise_error('Implement on sub-class of SpreeCmCommissioner::PricingRule')
+    end
+  end
+
+  describe '#eligible?' do
+    it 'raises an error instructing to implement on sub-class' do
+      pricing_rule = described_class.new
+      expect { pricing_rule.eligible? }.to raise_error('Implement on sub-class of SpreeCmCommissioner::PricingRule')
+    end
+  end
+
+  describe '#description' do
+    it 'raises an error instructing to implement on sub-class' do
+      pricing_rule = described_class.new
+      expect { pricing_rule.description }.to raise_error('Implement on sub-class of SpreeCmCommissioner::PricingRule')
+    end
+  end
+end


### PR DESCRIPTION
![pricing model rate (2)](https://github.com/channainfo/commissioner/assets/29684683/748b98ec-b084-4b09-bcc0-9a7535dbb0f5)

## Introduce new tables
- cm_pricing_rates: belong to rateable (eg. variant)
- cm_pricing_models: belong to modelable (eg. variant)
- cm_pricing_rules: belong ruleable (in this case, it either belong to `cm_pricing_rates` or `cm_pricing_models`)
- cm_pricing_actions: belong `cm_pricing_models`
- cm_applied_pricing_models: created when model is applied.
   model cannot be deleted if there is a model applied.
- cm_applied_pricing_rates: created when rate is applied.
   rate cannot be deleted if there is a rate applied.

## New columns to line_items
- pricing_rates_amount
- pricing_models_amount
- pricing_subtotal (rate + model)