### PR TITLE
close #1316 refactor for the platform telegram integration

### DIFF
--- a/app/controllers/spree/admin/product_completion_steps_controller.rb
+++ b/app/controllers/spree/admin/product_completion_steps_controller.rb
@@ -1,0 +1,58 @@
+module Spree
+  module Admin
+    class ProductCompletionStepsController < ResourceController
+      belongs_to 'spree/product', find_by: :slug
+
+      before_action :load_step_types, if: :member_action?
+
+      def load_step_types
+        @step_types = [
+          'SpreeCmCommissioner::ProductCompletionSteps::ChatraceTelegram'
+        ]
+      end
+
+      # override
+      def permitted_resource_params
+        key = ActiveModel::Naming.param_key(@object)
+        permit_keys = params.require(key).keys
+
+        params.require(key).permit(permit_keys)
+      end
+
+      # @overrided
+      def collection
+        parent.product_completion_steps
+      end
+
+      # @overrided
+      def model_class
+        SpreeCmCommissioner::ProductCompletionStep
+      end
+
+      # @overrided
+      def new_object_url(options = {})
+        new_admin_product_product_completion_step_url(options)
+      end
+
+      # @overrided
+      def edit_object_url(object, options = {})
+        edit_admin_product_product_completion_step_url(parent, object, options)
+      end
+
+      # @overrided
+      def object_url(object, options = {})
+        admin_product_product_completion_step_url(parent, object, options)
+      end
+
+      # @overrided
+      def collection_url(options = {})
+        admin_product_product_completion_steps_url(options)
+      end
+
+      # override
+      def location_after_save
+        edit_object_url(@object)
+      end
+    end
+  end
+end

--- a/app/controllers/spree/api/chatrace/base_controller.rb
+++ b/app/controllers/spree/api/chatrace/base_controller.rb
@@ -1,0 +1,13 @@
+module Spree
+  module Api
+    module Chatrace
+      class BaseController < ::Spree::Api::V2::BaseController
+        before_action :validate_token_client
+
+        def validate_token_client
+          raise Doorkeeper::Errors::DoorkeeperError if doorkeeper_token&.application.nil?
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/spree/api/chatrace/check_ins_controller.rb
+++ b/app/controllers/spree/api/chatrace/check_ins_controller.rb
@@ -1,0 +1,20 @@
+module Spree
+  module Api
+    module Chatrace
+      class CheckInsController < BaseController
+        def guest
+          @guest ||= SpreeCmCommissioner::Guest.complete.find_by!(token: params[:guest_token])
+        end
+
+        def create
+          context = SpreeCmCommissioner::CheckInBulkCreator.call(guest_ids: [guest.id])
+          if context.success?
+            render json: { checked_in_at: context.check_ins[0].confirmed_at }, status: :ok
+          else
+            render_error_payload(context.message)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/spree/api/chatrace/guests_controller.rb
+++ b/app/controllers/spree/api/chatrace/guests_controller.rb
@@ -1,0 +1,54 @@
+module Spree
+  module Api
+    module Chatrace
+      class GuestsController < BaseController
+        def scope
+          SpreeCmCommissioner::Guest.complete
+        end
+
+        def show
+          guest = scope.find_by!(token: params[:id])
+
+          render_serialized_payload { serialize_resource(guest) }
+        end
+
+        def update
+          guest = scope.find_by!(token: params[:id])
+
+          guest.preferred_telegram_user_id = params[:telegram_user_id]
+          guest.preferred_telegram_user_verified_at = DateTime.current
+
+          if guest.save
+            render_serialized_payload { serialize_resource(guest) }
+          else
+            render_error_payload(guest.errors)
+          end
+        end
+
+        def serialize_resource(guest)
+          order = guest.line_item.order
+
+          {
+            token: guest.token,
+            first_name: guest.first_name,
+            last_name: guest.last_name,
+            dob: guest.dob,
+            gender: guest.gender,
+            occupation: guest.occupation&.name || guest.other_occupation,
+            entry_type: guest.entry_type,
+            organization: guest.other_organization,
+            expectation: guest.expectation,
+            telegram_user_id: guest.preferred_telegram_user_id,
+            telegram_user_verified_at: guest.preferred_telegram_user_verified_at,
+            order_number: order.number,
+            order_email: order.email,
+            order_first_name: order.customer_address.firstname,
+            order_last_name: order.customer_address.lastname,
+            order_phone_number: order.intel_phone_number || order.customer_address.phone,
+            checked_in_at: guest.check_in&.confirmed_at
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/spree/api/v2/storefront/guests_controller.rb
+++ b/app/controllers/spree/api/v2/storefront/guests_controller.rb
@@ -59,7 +59,19 @@ module Spree
           end
 
           def guest_params
-            params.permit(:first_name, :last_name, :dob, :gender, :occupation_id, :nationality_id, :other_occupation)
+            params.permit(
+              :first_name,
+              :last_name,
+              :dob,
+              :gender,
+              :occupation_id,
+              :nationality_id,
+              :other_occupation,
+              :age,
+              :emergency_contact,
+              :other_organization,
+              :expectation
+            )
           end
         end
       end

--- a/app/helpers/spree_cm_commissioner/admin/kycable_helper.rb
+++ b/app/helpers/spree_cm_commissioner/admin/kycable_helper.rb
@@ -2,9 +2,7 @@ module SpreeCmCommissioner
   module Admin
     module KycableHelper
       def calculate_kyc_value(params)
-        kyc_params = params.slice(:guest_name, :guest_gender, :guest_dob, :guest_occupation, :guest_id_card,
-                                  :guest_nationality, :guest_age, :guest_emergency_contact
-        )
+        kyc_params = params.slice(*SpreeCmCommissioner::KycBitwise::BIT_FIELDS.keys)
         return nil unless kyc_params.values.any?(&:present?)
 
         kyc_params.values.each_with_index.sum do |value, index|

--- a/app/models/concerns/spree_cm_commissioner/kyc_bitwise.rb
+++ b/app/models/concerns/spree_cm_commissioner/kyc_bitwise.rb
@@ -2,6 +2,7 @@ module SpreeCmCommissioner
   module KycBitwise
     extend ActiveSupport::Concern
 
+    # must add migration to cm_guests when adding new field.
     BIT_FIELDS = {
       guest_name: 0b1,
       guest_gender: 0b10,
@@ -10,7 +11,9 @@ module SpreeCmCommissioner
       guest_id_card: 0b10000,
       guest_nationality: 0b100000,
       guest_age: 0b1000000,
-      guest_emergency_contact: 0b10000000
+      guest_emergency_contact: 0b10000000,
+      guest_organization: 0b100000000,
+      guest_expectation: 0b1000000000
     }.freeze
 
     def kyc? = kyc != 0

--- a/app/models/concerns/spree_cm_commissioner/variant_option_values_concern.rb
+++ b/app/models/concerns/spree_cm_commissioner/variant_option_values_concern.rb
@@ -2,12 +2,23 @@ module SpreeCmCommissioner
   module VariantOptionValuesConcern
     extend ActiveSupport::Concern
 
+    # TODO: extract value from this.
     def started_at_option_value
       option_value('started-at')
     end
 
     def reminder_option_value
       option_value('reminder')
+    end
+
+    def max_quantity_per_order_option_value
+      @max_quantity_option_value ||= option_value('max-quantity-per-order')
+    end
+
+    # Some vendors restrict the quantity per order. This value is used to validate when user add item to cart.
+    # if null, users can add unlimited quantity as long as items are in stock.
+    def max_quantity_per_order
+      max_quantity_per_order_option_value&.to_i
     end
   end
 end

--- a/app/models/spree_cm_commissioner/product_completion_step.rb
+++ b/app/models/spree_cm_commissioner/product_completion_step.rb
@@ -1,0 +1,27 @@
+module SpreeCmCommissioner
+  class ProductCompletionStep < Base
+    acts_as_list column: :position
+
+    belongs_to :product, class_name: '::Spree::Product', optional: false
+
+    def action_url_for(_line_item)
+      nil
+    end
+
+    def completed?(_line_item)
+      raise 'completed? should be implemented in a sub-class of ProductCompletionStep'
+    end
+
+    def construct_hash(line_item:)
+      {
+        title: title,
+        type: type&.underscore,
+        position: position,
+        description: description,
+        action_label: action_label,
+        action_url: action_url_for(line_item),
+        completed: completed?(line_item)
+      }
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/product_completion_steps/chatrace_telegram.rb
+++ b/app/models/spree_cm_commissioner/product_completion_steps/chatrace_telegram.rb
@@ -1,0 +1,25 @@
+module SpreeCmCommissioner
+  module ProductCompletionSteps
+    class ChatraceTelegram < ProductCompletionStep
+      # eg. https://t.me/ThePlatformKHBot?start=bookmeplus
+      preference :entry_point_link, :string
+
+      # override
+      def action_url_for(line_item)
+        return nil if preferred_entry_point_link.blank?
+        return nil unless line_item.guests.any?
+
+        "#{preferred_entry_point_link}--#{line_item.guests[0].token}"
+      end
+
+      # consider completed when telegram_user_id is set to guest by bot
+      # via update: /api/chatrace/guests
+      def completed?(line_item)
+        return false if preferred_entry_point_link.blank?
+        return false unless line_item.guests.any?
+
+        line_item.guests[0].preferred_telegram_user_id.present?
+      end
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/product_decorator.rb
+++ b/app/models/spree_cm_commissioner/product_decorator.rb
@@ -22,6 +22,9 @@ module SpreeCmCommissioner
                     class_name: 'SpreeCmCommissioner::HomepageSectionRelatable',
                     dependent: :destroy, as: :relatable
 
+      # after finish purchase an order, user must complete these steps
+      base.has_many :product_completion_steps, class_name: 'SpreeCmCommissioner::ProductCompletionStep', dependent: :destroy
+
       base.has_one :default_state, through: :vendor
 
       base.has_many :complete_line_items, through: :classifications, source: :line_items

--- a/app/overrides/spree/admin/shared/_product_tabs/product_completion_steps.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/product_completion_steps.html.erb.deface
@@ -1,0 +1,8 @@
+<!-- insert_after "erb[silent]:contains('Spree::Digital')" -->
+
+<%= content_tag :li, class: 'nav-item' do %>
+  <%= link_to_with_icon 'adjust.svg',
+    Spree.t(:completion_steps),
+    admin_product_product_completion_steps_url(@product),
+    class: "nav-link #{'active' if current == :product_completion_steps}" %>
+<% end if can?(:admin, SpreeCmCommissioner::ProductCompletionStep) %>

--- a/app/overrides/spree/admin/webhooks_subscribers/index/table.html.erb.deface
+++ b/app/overrides/spree/admin/webhooks_subscribers/index/table.html.erb.deface
@@ -32,8 +32,8 @@
         <td><%= link_to Spree.t(:view), admin_webhooks_subscriber_path(webhooks_subscriber) %></td>
         <td class="actions">
         <span class="d-flex justify-content-end">
-          <%= link_to_with_icon 'list-check.svg', Spree.t(:order).pluralize, admin_webhooks_subscriber_orders_path(webhooks_subscriber), class: 'btn btn-light btn-sm', no_text: true %>
-          <%= link_to_with_icon 'activity.svg', Spree.t(:event).pluralize, admin_webhooks_events_path({q: {subscriber_id_eq: webhooks_subscriber}}), class: 'btn btn-light btn-sm', no_text: true %>
+          <%= link_to_with_icon 'list-check.svg', Spree.t(:orders), admin_webhooks_subscriber_orders_path(webhooks_subscriber), class: 'btn btn-light btn-sm', no_text: true %>
+          <%= link_to_with_icon 'activity.svg', Spree.t(:events), admin_webhooks_events_path({q: {subscriber_id_eq: webhooks_subscriber}}), class: 'btn btn-light btn-sm', no_text: true %>
           <%= link_to_edit(webhooks_subscriber, no_text: true) if can? :edit, webhooks_subscriber %>
           <%= link_to_delete(webhooks_subscriber, no_text: true) if can? :delete, webhooks_subscriber %>
         </span>

--- a/app/serializers/spree/v2/storefront/line_item_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/line_item_serializer_decorator.rb
@@ -4,13 +4,17 @@ module Spree
       module LineItemSerializerDecorator
         def self.prepended(base)
           base.attributes :from_date, :to_date, :need_confirmation, :product_type, :event_status, :amount, :display_amount,
-                          :kyc, :kyc_fields, :remaining_total_guests, :number_of_guests
+                          :kyc, :kyc_fields, :remaining_total_guests, :number_of_guests,
+                          :completion_steps
 
           base.has_one :vendor
 
           base.belongs_to :order, serializer: Spree::V2::Storefront::LineItemOrderSerializer
 
           base.has_many :guests, serializer: SpreeCmCommissioner::V2::Storefront::GuestSerializer
+
+          # completion_steps updates frequently
+          base.cache_options store: nil
         end
       end
     end

--- a/app/serializers/spree/v2/storefront/variant_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/variant_serializer_decorator.rb
@@ -3,7 +3,9 @@ module Spree
     module Storefront
       module VariantSerializerDecorator
         def self.prepended(base)
-          base.attributes :permanent_stock, :need_confirmation, :product_type, :kyc, :reminder_option_value, :started_at_option_value
+          base.attributes :permanent_stock, :need_confirmation, :product_type, :kyc,
+                          :reminder_option_value, :started_at_option_value,
+                          :number_of_guests, :max_quantity_per_order
 
           base.has_many :stock_locations
         end

--- a/app/serializers/spree_cm_commissioner/v2/storefront/guest_serializer.rb
+++ b/app/serializers/spree_cm_commissioner/v2/storefront/guest_serializer.rb
@@ -4,12 +4,16 @@ module SpreeCmCommissioner
       class GuestSerializer < BaseSerializer
         set_type :guest
 
-        attributes :first_name, :last_name, :dob, :gender, :kyc_fields, :other_occupation, :created_at, :updated_at
+        attributes :first_name, :last_name, :dob, :gender, :kyc_fields, :other_occupation, :created_at, :updated_at,
+                   :age, :emergency_contact, :other_organization, :expectation
+
         attribute :allowed_checkout, &:allowed_checkout?
 
         belongs_to :occupation, serializer: Spree::V2::Storefront::TaxonSerializer
         belongs_to :nationality, serializer: Spree::V2::Storefront::TaxonSerializer
+
         has_one :id_card, serializer: Spree::V2::Storefront::IdCardSerializer
+        has_one :check_in
 
         # allowed_checkout updates frequently
         cache_options store: nil

--- a/app/services/spree_cm_commissioner/cart/add_guest.rb
+++ b/app/services/spree_cm_commissioner/cart/add_guest.rb
@@ -4,7 +4,7 @@ module SpreeCmCommissioner
       prepend Spree::ServiceModule::Base
 
       def call(order:, line_item:)
-        ActiveRecord::Base.transaction do
+        ApplicationRecord.transaction do
           create_blank_guest(line_item)
           increase_quantity(line_item) if should_increase_quantity?(line_item)
           recalculate_cart(order, line_item)
@@ -21,7 +21,7 @@ module SpreeCmCommissioner
 
       def increase_quantity(line_item)
         line_item.quantity += 1
-        line_item.save
+        line_item.save!
       end
 
       def should_increase_quantity?(line_item)

--- a/app/views/spree/admin/kyc/_form.html.erb
+++ b/app/views/spree/admin/kyc/_form.html.erb
@@ -62,6 +62,22 @@
       <%= form.error_message_on :guest_emergency_contact, class: 'text-danger' %>
     <% end %>
   </div>
+
+  <div class="form-check form-check-inline">
+    <%= form.field_container :guest_organization do %>
+      <%= form.check_box :guest_organization, class: 'form-check-input', checked: form.object.guest_organization? %>
+      <%= form.label :guest_organization, Spree.t(:guest_organization), class: 'form-check-label' %>
+      <%= form.error_message_on :guest_organization, class: 'text-danger' %>
+    <% end %>
+  </div>
+
+  <div class="form-check form-check-inline">
+    <%= form.field_container :guest_expectation do %>
+      <%= form.check_box :guest_expectation, class: 'form-check-input', checked: form.object.guest_expectation? %>
+      <%= form.label :guest_expectation, Spree.t(:guest_expectation), class: 'form-check-label' %>
+      <%= form.error_message_on :guest_expectation, class: 'text-danger' %>
+    <% end %>
+  </div>
 </div>
 
 

--- a/app/views/spree/admin/product_completion_steps/_form.html.erb
+++ b/app/views/spree/admin/product_completion_steps/_form.html.erb
@@ -1,0 +1,54 @@
+<div data-hook="admin_product_completion_step_form_fields">
+  <div data-hook="product_completion_step" class="row">
+    <div class="col-12 col-md-6">
+      <div class="card mb-3">
+        <div class="card-header">
+          <h5 class="mb-0"><%= Spree.t(:settings) %></h5>
+        </div>
+        <div class="card-body">
+          <%= f.field_container :type, 'data-hook' => 'type' do %>
+            <%= f.label :type, Spree.t(:type) %>
+            <%= f.select(:type, SpreeCmCommissioner::ProductCompletionStep.descendants.map { |v| [v.to_s.demodulize, v.to_s] }, {}, { class: 'select2' }) %>
+          <% end %>
+
+          <%= f.field_container :title, 'data-hook' => 'title' do %>
+            <%= f.label :title, Spree.t(:title) %>
+            <%= f.text_field :title, class: 'form-control', placeholder: 'eg. Link with Telegram Bot' %>
+            <%= f.error_message_on :title %>
+          <% end %>
+
+          <%= f.field_container :description, 'data-hook' => 'description' do %>
+            <%= f.label :description, Spree.t(:description) %>
+            <%= f.text_area :description, cols: 60, rows: 6, class: 'form-control', placeholder: 'eg. This product required to complete following step.' %>
+          <% end %>
+
+          <%= f.field_container :action_label, 'data-hook' => 'action_label' do %>
+            <%= f.label :action_label, Spree.t(:action_label) %>
+            <%= f.text_field :action_label, class: 'form-control', placeholder: 'eg. Continue' %>
+            <%= f.error_message_on :action_label %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-12 col-md-6">
+      <div class="card mb-3">
+        <div class="card-header">
+          <h5 class="mb-0"><%= Spree.t(:completion_settings) %></h5>
+        </div>
+        <div class="card-body">
+          <div id="preference-settings" class="form-group">
+            <% if preference_fields(@object, f).empty? %>
+              <%= Spree.t('no_settings_message') %>
+            <% else %>
+              <%= preference_fields(@object, f) %>
+            <% end %>
+            <% if @object.respond_to?(:preferences) %>
+              <div id="gateway-settings-warning" class="info warning"><%= Spree.t(:provider_settings_warning) %></div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/spree/admin/product_completion_steps/edit.html.erb
+++ b/app/views/spree/admin/product_completion_steps/edit.html.erb
@@ -1,0 +1,9 @@
+<%= render partial: 'spree/admin/shared/product_tabs', locals: { current: :product_completion_steps } %>
+<%= render partial: 'spree/admin/shared/error_messages', locals: { target: @object } %>
+
+<%= form_for @object, url: admin_product_product_completion_step_url do |f| %>
+  <fieldset>
+    <%= render partial: 'form', locals: { f: f } %>
+    <%= render partial: 'spree/admin/shared/edit_resource_links' %>
+  </fieldset>
+<% end %>

--- a/app/views/spree/admin/product_completion_steps/index.html.erb
+++ b/app/views/spree/admin/product_completion_steps/index.html.erb
@@ -1,0 +1,56 @@
+<%= render partial: 'spree/admin/shared/product_tabs', locals: { current: :product_completion_steps } %>
+
+<% content_for :page_actions do %>
+  <%= button_link_to Spree.t(:new), new_object_url, class: "btn-success", icon: 'add.svg' %>
+<% end if can? :create, SpreeCmCommissioner::ProductCompletionStep %>
+
+<div class="alert alert-info">
+  <%= 'After making a purchase, users are required to complete these steps.' %>
+</div>
+
+<% if @product_completion_steps.any? %>
+<div class="table-responsive border rounded bg-white">
+  <table class="table sortable" id='listing_product_completion_steps' data-hook data-sortable-link="<%= update_positions_admin_product_product_completion_steps_url %>">
+    <thead class="text-muted">
+      <tr data-hook="admin_product_completion_steps_index_headers">
+        <th></th>
+        <th><%= Spree.t(:id) %></th>
+        <th><%= Spree.t(:type) %></th>
+        <th><%= Spree.t(:title) %></th>
+        <th><%= Spree.t(:action_label) %></th>
+        <th><%= Spree.t(:created_at) %></th>
+        <th><%= Spree.t(:updated_at) %></th>
+        <th data-hook="admin_product_completion_steps_index_header_actions" class="actions"></th>
+      </tr>
+    </thead>
+    <tbody id="sortVert">
+      <% @product_completion_steps.each do |completion_step| %>
+        <tr id="<%= spree_dom_id completion_step %>" data-hook="admin_product_completion_steps_index_rows">
+          <td class="move-handle text-center">
+            <% if can?(:edit, completion_step) %>
+              <%= svg_icon name: "grip-vertical.svg", width: '18', height: '18' %>
+            <% end %>
+          </td>
+          <td><%= completion_step.id %></td>
+          <td><%= completion_step.type %></td>
+          <td><%= completion_step.title %></td>
+          <td><%= completion_step.action_label %></td>
+          <td><%= completion_step.created_at %></td>
+          <td><%= completion_step.updated_at %></td>
+          <td data-hook="admin_product_completion_steps_index_row_actions" class="actions">
+            <span class="d-flex justify-content-end">
+              <%= link_to_edit(completion_step, no_text: true) if can? :edit, completion_step %>
+              <%= link_to_delete(completion_step, no_text: true) if can? :delete, completion_step %>
+            </span>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+  </div>
+<% else %>
+  <div class="text-center no-objects-found m-5">
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(SpreeCmCommissioner::ProductCompletionStep)) %>,
+    <%= link_to(Spree.t(:add_one), new_object_url) if can? :create, SpreeCmCommissioner::ProductCompletionStep %>!
+  </div>
+<% end %>

--- a/app/views/spree/admin/product_completion_steps/new.html.erb
+++ b/app/views/spree/admin/product_completion_steps/new.html.erb
@@ -1,0 +1,9 @@
+<%= render partial: 'spree/admin/shared/product_tabs', locals: { current: :product_completion_steps } %>
+<%= render partial: 'spree/admin/shared/error_messages', locals: { target: @object } %>
+
+<%= form_for @object, url: collection_url do |f| %>
+  <fieldset>
+    <%= render partial: 'form', locals: { f: f } %>
+    <%= render partial: 'spree/admin/shared/new_resource_links' %>
+  </fieldset>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,6 +77,12 @@ Spree::Core::Engine.add_routes do
           patch :update
         end
       end
+
+      resources :product_completion_steps do
+        collection do
+          post :update_positions
+        end
+      end
     end
 
     namespace :calendars do
@@ -337,6 +343,11 @@ Spree::Core::Engine.add_routes do
 
     namespace :webhook do
       resources :orders, only: [:show]
+    end
+
+    namespace :chatrace do
+      resources :guests, only: %i[show update]
+      resources :check_ins, only: [:create]
     end
   end
 end

--- a/db/migrate/20240306071028_add_nationality_data_to_taxons.rb
+++ b/db/migrate/20240306071028_add_nationality_data_to_taxons.rb
@@ -1,5 +1,7 @@
 class AddNationalityDataToTaxons < ActiveRecord::Migration[7.0]
   def change
+    return if Rails.env.test?
+
     nationalities_taxonomy = Spree::Store.default.taxonomies.where(name: 'Nationalities', kind: Spree::Taxon.kinds[:nationality]).first_or_create
 
     nationalities_data = YAML.load_file(Rails.root.join('config', 'data', 'nationalities.yml'))

--- a/db/migrate/20240417085917_enable_pgcrypto.rb
+++ b/db/migrate/20240417085917_enable_pgcrypto.rb
@@ -1,0 +1,6 @@
+class EnablePgcrypto < ActiveRecord::Migration[7.0]
+  # https://medium.com/@technoblogueur/adding-uuid-column-to-rails-and-postgresql-table-46669a3b4d13
+  def change
+    enable_extension 'pgcrypto' unless extension_enabled?('pgcrypto')
+  end
+end

--- a/db/migrate/20240417085929_add_fields_to_cm_guests.rb
+++ b/db/migrate/20240417085929_add_fields_to_cm_guests.rb
@@ -1,0 +1,8 @@
+class AddFieldsToCmGuests < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cm_guests, :token, :uuid, default: "gen_random_uuid()", null: false, if_not_exists: true
+    add_column :cm_guests, :other_organization, :string, if_not_exists: true
+    add_column :cm_guests, :expectation, :string, if_not_exists: true
+    add_column :cm_guests, :preferences, :text, if_not_exists: true
+  end
+end

--- a/db/migrate/20240422074448_create_cm_product_completion_steps.rb
+++ b/db/migrate/20240422074448_create_cm_product_completion_steps.rb
@@ -1,0 +1,18 @@
+class CreateCmProductCompletionSteps < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cm_product_completion_steps, if_not_exists: true do |t|
+      t.string :type
+      t.string :title
+      t.string :action_label
+
+      t.integer :position, default: 0, null: false
+
+      t.text :description
+      t.text :preferences
+
+      t.references :product, foreign_key: { to_table: :spree_products }, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/spree_cm_commissioner/test_helper/factories/guest_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/guest_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :guest, class: SpreeCmCommissioner::Guest do
-    line_item { create(:line_item) }
+    line_item { |a| a.association(:line_item) }
     first_name { FFaker::Name.name }
     last_name { FFaker::Name.name }
     gender { 1 }

--- a/lib/spree_cm_commissioner/test_helper/factories/option_type_factory .rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/option_type_factory .rb
@@ -48,6 +48,12 @@ FactoryBot.define do
       presentation { 'Allowed extra kids' }
     end
 
+    trait :max_quantity_per_order do
+      attr_type { 'integer' }
+      name { 'max-quantity-per-order' }
+      presentation { 'Max quantity per order' }
+    end
+
     initialize_with { Spree::OptionType.where(name: name).first_or_initialize }
   end
 end

--- a/lib/spree_cm_commissioner/test_helper/factories/product_completion_step_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/product_completion_step_factory.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :cm_product_completion_step, class: SpreeCmCommissioner::ProductCompletionStep do
+    title { 'Must complete this step' }
+    description { 'Click link now to complete' }
+    action_label { 'Link' }
+
+    factory :cm_chatrace_tg_product_completion_step, class: SpreeCmCommissioner::ProductCompletionSteps::ChatraceTelegram do
+      preferred_entry_point_link { 'https://t.me/ThePlatformKHBot?start=bookmeplus' }
+    end
+  end
+end

--- a/spec/interactors/spree_cm_commissioner/admin/kycable_helper_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/admin/kycable_helper_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe SpreeCmCommissioner::Admin::KycableHelper do
         guest_id_card: '0',                 #2**4  = 16
         guest_nationality: '0',             #2**5  = 32
         guest_age: '0',                     #2**6 = 64
-        guest_emergency_contact: '0'        #2**7 = 128
+        guest_emergency_contact: '0',       #2**7 = 128
+        guest_organization: '0',            #2**8 = 256
+        guest_expectation: '0',             #2**9 = 512
       }
     end
 
@@ -66,8 +68,20 @@ RSpec.describe SpreeCmCommissioner::Admin::KycableHelper do
       expect(dummy_class.calculate_kyc_value(params)).to eq(128)
     end
 
-    it 'return value 255 if value params is selected' do
-      expected_value = 2**0 + 2**1 + 2**2 + 2**3 + 2**4 + 2**5 + 2**6 + 2**7
+    it 'return value 256 if guest_organization is selected' do
+      params[:guest_organization] = '1'
+
+      expect(dummy_class.calculate_kyc_value(params)).to eq(256)
+    end
+
+    it 'return value 512 if guest_expectation is selected' do
+      params[:guest_expectation] = '1'
+
+      expect(dummy_class.calculate_kyc_value(params)).to eq(512)
+    end
+
+    it 'return value 1023 if every kyc is selected' do
+      expected_value = 2**0 + 2**1 + 2**2 + 2**3 + 2**4 + 2**5 + 2**6 + 2**7 + 2**8 + 2**9
       params.transform_values! { '1' }
 
       expect(dummy_class.calculate_kyc_value(params)).to eq(expected_value)

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -182,5 +182,24 @@ RSpec.describe Spree::Variant, type: :model do
         expect(subject.allowed_extra_kids).to eq 2
       end
     end
+
+    describe '#max_quantity_per_order' do
+      context 'when has option type/value' do
+        let(:option_type) { create(:cm_option_type, :max_quantity_per_order) }
+        let(:option_value) { create(:option_value, name: '1-quantity', presentation: '1', option_type: option_type) }
+
+        it 'return result of presentation in integer' do
+          expect(subject.max_quantity_per_order).to eq 1
+        end
+      end
+
+      context 'when does not have optino type/value' do
+        subject { create(:variant) }
+
+        it 'return null indicate no limited' do
+          expect(subject.max_quantity_per_order).to eq nil
+        end
+      end
+    end
   end
 end

--- a/spec/models/spree_cm_commissioner/product_completion_step_spec.rb
+++ b/spec/models/spree_cm_commissioner/product_completion_step_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::ProductCompletionStep, type: :model do
+  it { is_expected.to belong_to(:product).class_name('Spree::Product') }
+
+  describe '#action_url_for' do
+    it 'returns nil' do
+      expect(subject.action_url_for(nil)).to be_nil
+    end
+  end
+
+  describe '#completed?' do
+    it 'raises an error' do
+      expect { subject.completed?(nil) }
+        .to raise_error(RuntimeError)
+        .with_message("completed? should be implemented in a sub-class of ProductCompletionStep")
+    end
+  end
+
+  describe '#construct_hash' do
+    subject { described_class.new(title: 'title', description: 'description', action_label: 'link-now')}
+    let(:line_item) { create(:line_item) }
+
+    it 'constructs the hash correctly' do
+      allow(subject).to receive(:action_url_for).and_return('https://example.com')
+      allow(subject).to receive(:completed?).and_return(true)
+
+      expect(subject.construct_hash(line_item: line_item)).to eq({
+        title: 'title',
+        type: nil,
+        position: 0,
+        description: 'description',
+        action_label: 'link-now',
+        action_url: 'https://example.com',
+        completed: true
+      })
+    end
+  end
+end

--- a/spec/models/spree_cm_commissioner/product_completion_steps/chatrace_telegram_spec.rb
+++ b/spec/models/spree_cm_commissioner/product_completion_steps/chatrace_telegram_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::ProductCompletionSteps::ChatraceTelegram, type: :model do
+  subject { described_class.new }
+
+  describe '#action_url_for' do
+    let(:line_item) { create(:line_item) }
+
+    context 'when entry_point_link is present and line_item has guests' do
+      before do
+        subject.preferred_entry_point_link = 'https://t.me/ThePlatformKHBot?start=bookmeplus'
+
+        guest = create(:guest, line_item: line_item)
+        line_item.reload
+      end
+
+      it 'return url of the first guest' do
+        expected_url = "#{subject.preferred_entry_point_link}--#{line_item.guests.first.token}"
+        expect(subject.action_url_for(line_item)).to eq(expected_url)
+      end
+    end
+
+    context 'when entry_point_link is blank' do
+      before { subject.preferred_entry_point_link = nil }
+
+      it 'returns nil' do
+        expect(subject.action_url_for(line_item)).to be_nil
+      end
+    end
+
+    context 'when line_item does not have guests' do
+      it 'returns nil' do
+        expect(subject.action_url_for(line_item)).to be_nil
+      end
+    end
+  end
+
+  describe '#completed?' do
+    let(:line_item) { create(:line_item) }
+
+    context 'when entry_point_link is present and line_item has guests' do
+      before do
+        subject.preferred_entry_point_link = 'https://t.me/ThePlatformKHBot?start=bookmeplus'
+
+        guest = create(:guest, preferred_telegram_user_id: '12345', line_item: line_item)
+        line_item.reload
+      end
+
+      it 'returns completed true if preferred_telegram_user_id is present' do
+        expect(subject.completed?(line_item)).to be_truthy
+      end
+
+      it 'returns false if preferred_telegram_user_id is absent' do
+        line_item.guests.first.update(preferred_telegram_user_id: nil)
+
+        expect(subject.completed?(line_item)).to be_falsy
+      end
+    end
+
+    context 'when entry_point_link is blank' do
+      before { subject.preferred_entry_point_link = nil }
+
+      it 'returns false' do
+        expect(subject.completed?(line_item)).to be_falsy
+      end
+    end
+
+    context 'when line_item does not have guests' do
+      it 'returns false' do
+        expect(subject.completed?(line_item)).to be_falsy
+      end
+    end
+  end
+end

--- a/spec/serializers/spree/v2/storefront/line_item_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/line_item_serializer_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe Spree::V2::Storefront::LineItemSerializer, type: :serializer do
         :kyc,
         :kyc_fields,
         :remaining_total_guests,
-        :number_of_guests
+        :number_of_guests,
+        :completion_steps
       )
     end
 

--- a/spec/serializers/spree/v2/storefront/variant_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/variant_serializer_spec.rb
@@ -38,7 +38,9 @@ describe Spree::V2::Storefront::VariantSerializer, type: :serializer do
         :need_confirmation,
         :product_type,
         :reminder_option_value,
-        :started_at_option_value
+        :started_at_option_value,
+        :max_quantity_per_order,
+        :number_of_guests,
       )
     end
 


### PR DESCRIPTION
## Requirement
1. Single variant purchase
   - No need to select a variant or quantity
2. New KYC fields:
   - organization, expectation
3. Connecting with Chatrace Telegram Bot after purchase.
   - Require API for chatrace to connect to us

## In this PR (no rspec yet)
This PR has made changes for each requirement accordingly. For 3rd requirement, I added a product completion step table:
- I'm thinking of other case that can be used beside "the Platform" event. I looking the figma & though of steps, admin can add some extra steps to product for user to do after purchase. These steps can be:
  - Integrate with chat bot
  - Invite friend, etc.
- table_name: product_completion_steps
- product has_many :product_completion_steps
- after purchased, user must complete these step like following demo:

<br>

[Overall completed flow DEMO for the Platform > ](https://github.com/bookmebus/cm-market-app/pull/1346)

<img src="https://github.com/channainfo/commissioner/assets/29684683/873af686-e3bc-4ea8-9290-e6756026866d" width="300px" />


----


Beside this, I also added new guest.token column, which will use to redirect to chatrace to verify user ticket. I also added chatrace API:
- guests: get & update telegram id
- check-in: allow bot to request to check-in

