### PR TITLE
close #1379 add upload later field to guests table

### DIFF
--- a/app/controllers/spree/api/v2/storefront/guests_controller.rb
+++ b/app/controllers/spree/api/v2/storefront/guests_controller.rb
@@ -70,7 +70,8 @@ module Spree
               :age,
               :emergency_contact,
               :other_organization,
-              :expectation
+              :expectation,
+              :upload_later
             )
           end
         end

--- a/app/serializers/spree_cm_commissioner/v2/storefront/guest_serializer.rb
+++ b/app/serializers/spree_cm_commissioner/v2/storefront/guest_serializer.rb
@@ -5,7 +5,7 @@ module SpreeCmCommissioner
         set_type :guest
 
         attributes :first_name, :last_name, :dob, :gender, :kyc_fields, :other_occupation, :created_at, :updated_at,
-                   :age, :emergency_contact, :other_organization, :expectation
+                   :age, :emergency_contact, :other_organization, :expectation, :upload_later
 
         attribute :allowed_checkout, &:allowed_checkout?
 

--- a/db/migrate/20240502051314_add_upload_later_to_guest.rb
+++ b/db/migrate/20240502051314_add_upload_later_to_guest.rb
@@ -1,0 +1,5 @@
+class AddUploadLaterToGuest < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cm_guests, :upload_later, :boolean, default: false, if_not_exists: true
+  end
+end


### PR DESCRIPTION
## Changes:
- The purpose of this pull request is to add new field to guests to support upload later experience
- In the UI, when user toggle the uploadLater switch, it will update the column true or false accordingly

## Demo:

https://github.com/bookmebus/cm-market-app/assets/110322558/9f8543e9-6c06-42a2-9329-aa7834d89622