### PR TITLE
close #1393 making sure shipping flow from backend work

### DIFF
--- a/app/controllers/spree_cm_commissioner/admin/orders_controller_decorator.rb
+++ b/app/controllers/spree_cm_commissioner/admin/orders_controller_decorator.rb
@@ -3,7 +3,7 @@ module SpreeCmCommissioner
     module OrdersControllerDecorator
       def self.prepended(base)
         # spree try to create an empty order in the #new action
-        base.around_action :set_writing_role, only: %i[new]
+        base.around_action :set_writing_role, only: %i[new edit]
 
         base.before_action :load_order, only: %i[
           edit update cancel resume approve resend open_adjustments

--- a/app/overrides/spree/admin/shipping_methods/_form/vendor.html.erb.deface
+++ b/app/overrides/spree/admin/shipping_methods/_form/vendor.html.erb.deface
@@ -1,0 +1,9 @@
+<!-- insert_after "[data-hook='admin_shipping_method_form_display_field']" -->
+
+<div data-hook="admin_shipping_method_form_vendor" class="col col-lg-6">
+  <%= f.field_container :vendor_id do %>
+    <%= f.label :vendor_id, Spree.t('vendor') %>
+    <%= f.collection_select :vendor_id, Spree::Vendor.all, :id, :name, { include_blank: true }, { class: 'form-control select2', disabled: params[:force].present? ? false : @object.vendor.id.present? } %>
+    <%= f.error_message_on :vendor_id %>
+  <% end %>
+</div>


### PR DESCRIPTION
<img width="1052" alt="image" src="https://github.com/channainfo/commissioner/assets/29684683/d88b35af-0ff3-4b1c-a10d-edc5fb245c22">

## In this PR
- Add missing vendor field to shipping method
- Allow write mode in edit action (edit action did call refresh shipping rate which may update database)

## How does shipping work here?
- In current logic from spree_multi_vendor
  - each vendor has multiple shipping_methods.
  - product are allowed to ship with shipping methods of their vendor.

To setup:
- Create vendor
- Create stock location for that vendor
- Create shipping methods for that vendor
  - Assign zone to it
    - zone mean shipment can deliver to there
    - zone can be base on countries or states
- Create product, add variant, then add stock to variant (stock is required for shipping)
- Finally, try add an order to test it:
  - Add order
  - Add variant that setup above
  - Go to customer page to fill shipping address. 
    - Once set, it will take either state_id or country_id to find zone & shipping method for that zone.
    - Then, calculate the shipping price.
  - After this, go to order shipment, then click "Ship" when item is shipped.