### PR TITLE
close #1404 fix id for nil class for shipping method form

### DIFF
--- a/app/overrides/spree/admin/shipping_methods/_form/vendor.html.erb.deface
+++ b/app/overrides/spree/admin/shipping_methods/_form/vendor.html.erb.deface
@@ -3,7 +3,7 @@
 <div data-hook="admin_shipping_method_form_vendor" class="col col-lg-6">
   <%= f.field_container :vendor_id do %>
     <%= f.label :vendor_id, Spree.t('vendor') %>
-    <%= f.collection_select :vendor_id, Spree::Vendor.all, :id, :name, { include_blank: true }, { class: 'form-control select2', disabled: params[:force].present? ? false : @object.vendor.id.present? } %>
+    <%= f.collection_select :vendor_id, Spree::Vendor.all, :id, :name, { include_blank: true }, { class: 'form-control select2', disabled: params[:force].present? ? false : @object.vendor&.id.present? } %>
     <%= f.error_message_on :vendor_id %>
   <% end %>
 </div>


### PR DESCRIPTION
Application spree_starter


⚠️ Error occurred in staging ⚠️
An *ActionView::Template::Error* occurred in *shipping_methods#edit*.


Exception:
undefined method `id' for nil:NilClass


Set by controller:
{:user=>"2"}


Request:
```
* url : https://staging-server.contigo.asia/admin/shipping_methods/3/edit
* http_method : GET
* ip_address : 43.230.192.190
* parameters : {"controller"=>"spree/admin/shipping_methods", "action"=>"edit", "id"=>"3"}
* timestamp : 2024-05-07 19:36:21 +0700
```


Backtrace:
```
* /app/vendor/bundle/ruby/3.2.0/gems/spree_backend-4.5.1/app/views/spree/admin/shipping_methods/_form.html.erb:22:in `block in _vendor_bundle_ruby_______gems_spree_backend_______app_views_spree_admin_shipping_methods__form_html_erb___2689546278487934984_490580'
* /app/vendor/bundle/ruby/3.2.0/gems/actionview-7.0.8/lib/action_view/helpers/capture_helper.rb:45:in `block in capture'
* /app/vendor/bundle/ruby/3.2.0/gems/actionview-7.0.8/lib/action_view/helpers/capture_helper.rb:209:in `with_output_buffer'
* /app/vendor/bundle/ruby/3.2.0/gems/actionview-7.0.8/lib/action_view/helpers/capture_helper.rb:45:in `capture'
* /app/vendor/bundle/ruby/3.2.0/gems/spree_backend-4.5.1/app/helpers/spree