### PR TITLE
close #1409 only build shipments & inventory units for line item that required delivery

### DIFF
--- a/app/models/spree_cm_commissioner/line_item_decorator.rb
+++ b/app/models/spree_cm_commissioner/line_item_decorator.rb
@@ -23,7 +23,7 @@ module SpreeCmCommissioner
       base.whitelisted_ransackable_associations |= %w[guests]
       base.whitelisted_ransackable_attributes |= %w[to_date from_date]
 
-      delegate :kyc?, to: :product
+      base.delegate :delivery_required?, to: :variant
 
       base.accepts_nested_attributes_for :guests, allow_destroy: true
 

--- a/app/models/spree_cm_commissioner/stock/inventory_unit_builder_decorator.rb
+++ b/app/models/spree_cm_commissioner/stock/inventory_unit_builder_decorator.rb
@@ -1,0 +1,26 @@
+module SpreeCmCommissioner
+  module Stock
+    module InventoryUnitBuilderDecorator
+      # override
+      def units
+        @order.line_items.filter_map do |line_item|
+          next unless line_item.delivery_required?
+
+          # They go through multiple splits, avoid loading the
+          # association to order until needed.
+          Spree::InventoryUnit.new(
+            pending: true,
+            line_item_id: line_item.id,
+            variant_id: line_item.variant_id,
+            quantity: line_item.quantity,
+            order_id: @order.id
+          )
+        end
+      end
+    end
+  end
+end
+
+unless Spree::Stock::InventoryUnitBuilder.included_modules.include?(SpreeCmCommissioner::Stock::InventoryUnitBuilderDecorator)
+  Spree::Stock::InventoryUnitBuilder.prepend(SpreeCmCommissioner::Stock::InventoryUnitBuilderDecorator)
+end

--- a/app/models/spree_cm_commissioner/variant_decorator.rb
+++ b/app/models/spree_cm_commissioner/variant_decorator.rb
@@ -16,6 +16,16 @@ module SpreeCmCommissioner
       base.scope :subscribable, -> { active.joins(:product).where(product: { subscribable: true, status: :active }) }
     end
 
+    def delivery_required?
+      return true if non_digital_ecommerce?
+
+      delivery_option == 'delivery'
+    end
+
+    def non_digital_ecommerce?
+      !digital? && ecommerce?
+    end
+
     # override
     def options_text
       @options_text ||= Spree::Variants::VisableOptionsPresenter.new(self).to_sentence

--- a/app/serializers/spree/v2/storefront/line_item_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/line_item_serializer_decorator.rb
@@ -7,6 +7,8 @@ module Spree
                           :kyc, :kyc_fields, :remaining_total_guests, :number_of_guests,
                           :completion_steps
 
+          base.attribute :delivery_required, &:delivery_required?
+
           base.has_one :vendor
 
           base.belongs_to :order, serializer: Spree::V2::Storefront::LineItemOrderSerializer

--- a/app/serializers/spree/v2/storefront/variant_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/variant_serializer_decorator.rb
@@ -7,6 +7,8 @@ module Spree
                           :reminder, :started_at, :delivery_option,
                           :number_of_guests, :max_quantity_per_order
 
+          base.attribute :delivery_required, &:delivery_required?
+
           base.has_many :stock_locations
         end
       end

--- a/lib/spree_cm_commissioner/test_helper/factories/option_type_factory .rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/option_type_factory .rb
@@ -18,6 +18,12 @@ FactoryBot.define do
       presentation { 'payment-option' }
     end
 
+    trait :delivery_option do
+      attr_type { 'delivery_type' }
+      name { 'delivery-option' }
+      presentation { 'Delivery option' }
+    end
+
     trait :adults do
       attr_type { 'integer' }
       name { 'adults' }

--- a/spec/models/spree/stock/inventory_unit_builder_spec.rb
+++ b/spec/models/spree/stock/inventory_unit_builder_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Stock::InventoryUnitBuilder do
+  describe '#units' do
+    let(:line_item_a) { create(:line_item) }
+    let(:line_item_b) { create(:line_item) }
+    let(:order) { create(:order, line_items: [line_item_a, line_item_b]) }
+
+    it 'only build unit that required delivery' do
+      allow(line_item_a.variant).to receive(:delivery_required?).and_return true
+      allow(line_item_b.variant).to receive(:delivery_required?).and_return false
+
+      units = described_class.new(order).units
+
+      expect(units.size).to eq 1
+      expect(units[0].line_item_id).to eq line_item_a.id
+    end
+  end
+end

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -202,4 +202,76 @@ RSpec.describe Spree::Variant, type: :model do
       end
     end
   end
+
+  describe '#delivery_required?' do
+    context 'when non_digital ecommerce? is true' do
+      let(:product) { create(:product, product_type: :ecommerce) }
+      subject { create(:variant, product: product) }
+
+      it 'returns true' do
+        expect(subject.non_digital_ecommerce?).to be true
+        expect(subject.delivery_required?).to be true
+      end
+    end
+
+    context 'when non_digital_ecommerce? is false' do
+      let(:product) { create(:product, product_type: :ecommerce, option_types: [option_type]) }
+      let(:option_type) { create(:cm_option_type, :delivery_option) }
+
+      subject { build(:variant, product: product, digitals: [create(:digital)], option_values: [option_value]) }
+
+      context 'when deliver option is "delivery"' do
+        let(:option_value) { create(:option_value, name: 'delivery', presentation: 'delivery', option_type: option_type) }
+
+        it 'returns true' do
+          expect(subject.non_digital_ecommerce?).to be false
+          expect(subject.delivery_required?).to be true
+        end
+      end
+
+      context 'when deliver option is "pickup"' do
+        let(:option_value) { create(:option_value, name: 'pickup', presentation: 'pickup', option_type: option_type) }
+
+        it 'returns false' do
+          expect(subject.non_digital_ecommerce?).to be false
+          expect(subject.delivery_required?).to be false
+        end
+      end
+    end
+  end
+
+  describe '#non_digital_ecommerce?' do
+    context 'when digital? is false and ecommerce? is true' do
+      let(:product) { create(:product, product_type: :ecommerce) }
+      subject { build(:variant, product: product, digitals: []) }
+
+      it 'returns true' do
+        expect(subject.digital?).to be false
+        expect(subject.ecommerce?).to be true
+        expect(subject.non_digital_ecommerce?).to be true
+      end
+    end
+
+    context 'when digital? is true' do
+      let(:product) { create(:product, product_type: :ecommerce) }
+      subject { build(:variant, product: product, digitals: [create(:digital)]) }
+
+      it 'returns false even variant is ecommerce' do
+        expect(subject.ecommerce?).to be true
+        expect(subject.digital?).to be true
+        expect(subject.non_digital_ecommerce?).to be false
+      end
+    end
+
+    context 'when ecommerce? is false' do
+      let(:product) { create(:product, product_type: :service) }
+      subject { build(:variant, product: product, digitals: []) }
+
+      it 'returns false event variant is not digital' do
+        expect(subject.ecommerce?).to be false
+        expect(subject.digital?).to be false
+        expect(subject.non_digital_ecommerce?).to be false
+      end
+    end
+  end
 end

--- a/spec/serializers/spree/v2/storefront/line_item_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/line_item_serializer_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe Spree::V2::Storefront::LineItemSerializer, type: :serializer do
         :kyc_fields,
         :remaining_total_guests,
         :number_of_guests,
-        :completion_steps
+        :completion_steps,
+        :delivery_required,
       )
     end
 

--- a/spec/serializers/spree/v2/storefront/variant_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/variant_serializer_spec.rb
@@ -41,7 +41,8 @@ describe Spree::V2::Storefront::VariantSerializer, type: :serializer do
         :started_at,
         :max_quantity_per_order,
         :number_of_guests,
-        :delivery_option
+        :delivery_option,
+        :delivery_required,
       )
     end
 


### PR DESCRIPTION
When cart has both required delivery & not required, our current system still create inventory units & shipments for all line items.

This PR fixed that.