### PR TITLE
close #1413 add pending guests api for kyc upload later experience

### DIFF
--- a/app/controllers/spree/api/v2/storefront/guests_controller.rb
+++ b/app/controllers/spree/api/v2/storefront/guests_controller.rb
@@ -3,10 +3,6 @@ module Spree
     module V2
       module Storefront
         class GuestsController < ::Spree::Api::V2::ResourceController
-          include Spree::Api::V2::Storefront::OrderConcern
-
-          before_action :ensure_order
-
           # override
           def model_class
             SpreeCmCommissioner::Guest
@@ -55,7 +51,7 @@ module Spree
           end
 
           def line_item
-            @line_item ||= spree_current_order.line_items.find(params[:line_item_id])
+            @line_item ||= spree_current_user.line_items.find(params[:line_item_id])
           end
 
           def guest_params

--- a/app/controllers/spree/api/v2/storefront/pending_line_items_controller.rb
+++ b/app/controllers/spree/api/v2/storefront/pending_line_items_controller.rb
@@ -1,0 +1,39 @@
+module Spree
+  module Api
+    module V2
+      module Storefront
+        class PendingLineItemsController < ::Spree::Api::V2::ResourceController
+          before_action :require_spree_current_user
+
+          # override
+          def collection_serializer
+            Spree::V2::Storefront::LineItemSerializer
+          end
+
+          # override
+          def resource_serializer
+            Spree::V2::Storefront::LineItemSerializer
+          end
+
+          def collection
+            Spree::LineItem.joins(:guests)
+                           .where(order: spree_current_user.orders.complete, guests: { upload_later: true })
+                           .distinct
+                           .page(params[:page]).per(params[:per_page])
+          end
+
+          def index
+            render_serialized_payload do
+              serialize_collection(paginated_collection)
+            end
+          end
+
+          def allowed_sort_attributes
+            super << :to_date
+            super << :from_date
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/guest.rb
+++ b/app/models/spree_cm_commissioner/guest.rb
@@ -47,7 +47,7 @@ module SpreeCmCommissioner
       return emergency_contact.present? if field == :guest_emergency_contact
       return other_organization.present? if field == :guest_organization
       return expectation.present? if field == :guest_expectation
-      return id_card.present? && id_card.allowed_checkout? if field == :guest_id_card
+      return upload_later? || (id_card.present? && id_card.allowed_checkout?) if field == :guest_id_card
 
       false
     end

--- a/app/serializers/spree/v2/storefront/line_item_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/line_item_serializer_decorator.rb
@@ -15,6 +15,8 @@ module Spree
 
           base.has_many :guests, serializer: SpreeCmCommissioner::V2::Storefront::GuestSerializer
 
+          base.has_many :pending_guests, serializer: SpreeCmCommissioner::V2::Storefront::GuestSerializer
+
           # completion_steps updates frequently
           base.cache_options store: nil
         end

--- a/app/serializers/spree_cm_commissioner/v2/storefront/guest_serializer.rb
+++ b/app/serializers/spree_cm_commissioner/v2/storefront/guest_serializer.rb
@@ -15,6 +15,8 @@ module SpreeCmCommissioner
         has_one :id_card, serializer: Spree::V2::Storefront::IdCardSerializer
         has_one :check_in
 
+        belongs_to :line_item, serializer: Spree::V2::Storefront::LineItemSerializer
+
         # allowed_checkout updates frequently
         cache_options store: nil
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -338,6 +338,7 @@ Spree::Core::Engine.add_routes do
         resources :guests, only: %i[create update show] do
           resources :id_cards
         end
+        resources :pending_line_items, only: %i[show index]
       end
 
       namespace :operator do

--- a/spec/serializers/spree/v2/storefront/guest_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/guest_serializer_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe SpreeCmCommissioner::V2::Storefront::GuestSerializer, type: :seri
         :occupation,
         :nationality,
         :id_card,
-        :check_in
+        :check_in,
+        :line_item
       )
     end
   end

--- a/spec/serializers/spree/v2/storefront/line_item_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/line_item_serializer_spec.rb
@@ -59,7 +59,8 @@ RSpec.describe Spree::V2::Storefront::LineItemSerializer, type: :serializer do
         :digital_links,
         :vendor,
         :order,
-        :guests
+        :guests,
+        :pending_guests
       )
     end
   end


### PR DESCRIPTION
## Functionality
- This is the api for KYC upload later experience (https://github.com/bookmebus/cm-market-app/issues/1325)
- API endpoint: "/api/v2/storefront/pending_guests?per_page=1&include=vendor,pending_guests,order" 
- This api list the lineItem from user's orders that are completed and it only query guests with upload_later true and id_card nil.
- Response
```json
"data": [
        {
            "id": "2802",
            "type": "line_item",
            "attributes": {
                "name": "Internship 1 - 22th April 2024 - Normal",
                "quantity": 3,
                "price": "0.0",
                "slug": "internship-1-22th-april-2024-normal",
                "options_text": "Ticket Type: Normal Ticket",
                "currency": "USD",
                "display_price": "$0.00",
                "total": "0.0",
                "display_total": "$0.00",
                "adjustment_total": "0.0",
                "display_adjustment_total": "$0.00",
                "additional_tax_total": "0.0",
                "discounted_amount": "0.0",
                "display_discounted_amount": "$0.00",
                "display_additional_tax_total": "$0.00",
                "promo_total": "0.0",
                "display_promo_total": "$0.00",
                "included_tax_total": "0.0",
                "display_included_tax_total": "$0.00",
                "pre_tax_amount": "0.0",
                "display_pre_tax_amount": "$0.00",
                "public_metadata": {},
                "from_date": "2024-04-18T00:00:00.000+07:00",
                "to_date": "2024-04-30T00:00:00.000+07:00",
                "need_confirmation": false,
                "product_type": "ecommerce",
                "event_status": "complete",
                "amount": "0.0",
                "display_amount": "$0.00",
                "kyc": 23,
                "kyc_fields": [
                    "guest_name",
                    "guest_gender",
                    "guest_dob",
                    "guest_id_card"
                ],
                "remaining_total_guests": 0,
                "number_of_guests": 3,
                "completion_steps": [],
                "delivery_required": false
            },
            "relationships": {
                "variant": {
                    "data": {
                        "id": "366",
                        "type": "variant"
                    }
                },
                "digital_links": {
                    "data": [
                        {
                            "id": "407",
                            "type": "digital_link"
                        }
                    ]
                },
                "vendor": {
                    "data": {
                        "id": "109",
                        "type": "vendor"
                    }
                },
                "order": {
                    "data": {
                        "id": "2565",
                        "type": "order"
                    }
                },
                "guests": {
                    "data": [
                        {
                            "id": "425",
                            "type": "guest"
                        },
                        {
                            "id": "427",
                            "type": "guest"
                        },
                        {
                            "id": "426",
                            "type": "guest"
                        }
                    ]
                },
                "pending_guests": {
                    "data": [
                        {
                            "id": "427",
                            "type": "guest"
                        },
                        {
                            "id": "425",
                            "type": "guest"
                        }
                    ]
                }
            }
        }
    ],
```