### PR TITLE
close #1460 add api for self check-in

### DIFF
--- a/app/controllers/spree/api/v2/operator/event_qrs_controller.rb
+++ b/app/controllers/spree/api/v2/operator/event_qrs_controller.rb
@@ -1,0 +1,35 @@
+module Spree
+  module Api
+    module V2
+      module Operator
+        class EventQrsController < ::Spree::Api::V2::ResourceController
+          include ActionController::MimeResponds
+
+          before_action :require_spree_current_user
+          before_action :load_event, only: [:show]
+
+          def show
+            qr_resource = @event.jwt_token(spree_current_user)
+            render_serialized_payload { serialize_resource(qr_resource) }
+          end
+
+          private
+
+          def load_event
+            @event = Spree::Taxon.find_by(id: params[:id])
+          end
+
+          # override
+          def collection_serializer
+            SpreeCmCommissioner::V2::Operator::EventQrSerializer
+          end
+
+          # override
+          def resource_serializer
+            SpreeCmCommissioner::V2::Operator::EventQrSerializer
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/spree/api/v2/operator/taxons_controller.rb
+++ b/app/controllers/spree/api/v2/operator/taxons_controller.rb
@@ -1,0 +1,30 @@
+module Spree
+  module Api
+    module V2
+      module Operator
+        class TaxonsController < ::Spree::Api::V2::ResourceController
+          before_action :require_spree_current_user
+          before_action :load_event, only: [:show]
+
+          def show
+            render_serialized_payload { serialize_resource(@event) }
+          end
+
+          # override
+          def collection_serializer
+            SpreeCmCommissioner::V2::Operator::TaxonSerializer
+          end
+
+          # override
+          def resource_serializer
+            SpreeCmCommissioner::V2::Operator::TaxonSerializer
+          end
+
+          def load_event
+            @event = Spree::Taxon.find_by(id: params[:id])
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/spree/api/v2/storefront/self_check_in_controller.rb
+++ b/app/controllers/spree/api/v2/storefront/self_check_in_controller.rb
@@ -1,0 +1,79 @@
+module Spree
+  module Api
+    module V2
+      module Storefront
+        class SelfCheckInController < ::Spree::Api::V2::ResourceController
+          before_action :require_spree_current_user
+          before_action :load_operator, only: [:create]
+
+          rescue_from JWT::ExpiredSignature, with: :expired_signature
+          rescue_from JWT::VerificationError, with: :verification
+          rescue_from JWT::DecodeError, with: :decode_error
+
+          # override
+          def create
+            spree_authorize! :create, model_class
+            validate_token!(params[:qr_data])
+
+            context = create_check_in_records(params[:guest_ids])
+
+            if context.success?
+              render_serialized_payload(201) do
+                collection_serializer.new(
+                  context.check_ins, { include: resource_includes }
+                ).serializable_hash
+              end
+            else
+              render_error_payload(context.message)
+            end
+          end
+
+          private
+
+          def create_check_in_records(guest_ids)
+            SpreeCmCommissioner::CheckInBulkCreator.call(
+              guest_ids: guest_ids,
+              check_in_by: spree_current_user
+            )
+          end
+
+          LEEWAY_IN_SECONDS = 60
+          def validate_token!(qr_data)
+            JWT.decode(qr_data, @operator&.secure_token, true, { algorithm: 'HS256', leeway: LEEWAY_IN_SECONDS })
+          end
+
+          def expired_signature(exception)
+            render_error_payload(exception.message, 400)
+          end
+
+          def verification(exception)
+            render_error_payload(exception.message, 400)
+          end
+
+          def decode_error(exception)
+            render_error_payload(exception.message, 400)
+          end
+
+          def load_operator
+            @operator = Spree::User.find_by(id: params[:operator_id])
+          end
+
+          # override
+          def model_class
+            SpreeCmCommissioner::CheckIn
+          end
+
+          # override
+          def resource_serializer
+            SpreeCmCommissioner::V2::Operator::CheckInSerializer
+          end
+
+          # override
+          def collection_serializer
+            SpreeCmCommissioner::V2::Operator::CheckInSerializer
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/line_item_decorator.rb
+++ b/app/models/spree_cm_commissioner/line_item_decorator.rb
@@ -66,6 +66,11 @@ module SpreeCmCommissioner
     # - appointment uses number of hours, etc.
     #
     # override
+
+    def allowed_self_check_in
+      product.product_type != 'ecommerce'
+    end
+
     def amount
       base_price = price * quantity
 

--- a/app/models/spree_cm_commissioner/taxon_decorator.rb
+++ b/app/models/spree_cm_commissioner/taxon_decorator.rb
@@ -43,6 +43,39 @@ module SpreeCmCommissioner
     def set_slug
       self.slug = permalink&.parameterize
     end
+
+    JwtToken = Struct.new(:id, :qr_data, :expired_at)
+
+    def jwt_token(current_user)
+      @current_user = current_user
+      jwt_token = generate_jwt_token(current_user)
+      decoded_token = JWT.decode(jwt_token, nil, false, leeway: jwt_token['leeway'])
+      JwtToken.new(
+        current_user.id,
+        jwt_token,
+        Time.zone.at(decoded_token[0]['exp'])
+      )
+    end
+
+    def generate_jwt_token(current_user)
+      exp = 5.minutes.from_now.to_i
+      payload = { event_id: id.to_s, operator_id: current_user.id.to_s, exp: exp }
+      secret = SecureRandom.hex(16)
+      jwt = generate_jwt(payload, secret)
+      save_secret_key_to_user(current_user, secret)
+      jwt
+    end
+
+    def generate_jwt(payload, secret)
+      JWT.encode(payload, secret, 'HS256')
+    end
+
+    def save_secret_key_to_user(current_user, secret)
+      user = Spree.user_class.find(current_user.id)
+      ActiveRecord::Base.connected_to(role: :writing) do
+        user.update(secure_token: secret)
+      end
+    end
   end
 end
 

--- a/app/serializers/spree/v2/storefront/line_item_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/line_item_serializer_decorator.rb
@@ -5,7 +5,7 @@ module Spree
         def self.prepended(base)
           base.attributes :from_date, :to_date, :need_confirmation, :product_type, :event_status, :amount, :display_amount,
                           :kyc, :kyc_fields, :remaining_total_guests, :number_of_guests,
-                          :completion_steps
+                          :completion_steps, :allowed_self_check_in
 
           base.attribute :delivery_required, &:delivery_required?
 

--- a/app/serializers/spree_cm_commissioner/v2/operator/event_qr_serializer.rb
+++ b/app/serializers/spree_cm_commissioner/v2/operator/event_qr_serializer.rb
@@ -1,0 +1,9 @@
+module SpreeCmCommissioner
+  module V2
+    module Operator
+      class EventQrSerializer < BaseSerializer
+        attributes :qr_data, :expired_at
+      end
+    end
+  end
+end

--- a/app/serializers/spree_cm_commissioner/v2/storefront/self_check_in_serializer.rb
+++ b/app/serializers/spree_cm_commissioner/v2/storefront/self_check_in_serializer.rb
@@ -1,0 +1,21 @@
+module SpreeCmCommissioner
+  module V2
+    module Storefront
+      class SelfCheckInSerializer < BaseSerializer
+        set_type :check_in
+
+        attributes :guest_id,
+                   :verification_state,
+                   :check_in_type,
+                   :entry_type,
+                   :check_in_method,
+                   :confirmed_at,
+                   :token
+
+        belongs_to :check_in_by, serializer: ::Spree::V2::Storefront::UserSerializer
+        belongs_to :guest, serializer: ::SpreeCmCommissioner::V2::Operator::GuestSerializer
+        belongs_to :line_item, serializer: ::SpreeCmCommissioner::V2::Operator::LineItemSerializer
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -363,6 +363,7 @@ Spree::Core::Engine.add_routes do
         resources :homepage_sections, only: [:index]
         resources :order_qrs, only: [:show]
         resources :line_item_qrs, only: [:show]
+        resources :event_qrs, only: [:show]
 
         resources :homepage, only: [] do
           resources :homepage_sections, only: [:index]
@@ -374,6 +375,7 @@ Spree::Core::Engine.add_routes do
           resources :id_cards
         end
         resources :pending_line_items, only: %i[show index]
+        resources :self_check_in, only: %i[index create]
       end
 
       namespace :operator do
@@ -381,7 +383,8 @@ Spree::Core::Engine.add_routes do
         resources :check_ins, only: %i[index create]
         resource :check_in_bulks, only: %i[index create]
         resources :dashboard_crew_events, only: %i[index]
-        resources :taxons do
+        resources :event_qrs, only: [:show]
+        resources :taxons, only: %i[show] do
           resource :event_ticket_aggregators, only: %i[show]
           resource :pie_chart_event_aggregators, only: %i[show]
         end

--- a/db/migrate/20240607061230_add_secure_token_field_to_user.rb
+++ b/db/migrate/20240607061230_add_secure_token_field_to_user.rb
@@ -1,0 +1,5 @@
+class AddSecureTokenFieldToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_users, :secure_token, :string, if_not_exists: true
+  end
+end

--- a/spec/serializers/spree/v2/storefront/line_item_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/line_item_serializer_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe Spree::V2::Storefront::LineItemSerializer, type: :serializer do
         :number_of_guests,
         :completion_steps,
         :delivery_required,
+        :allowed_self_check_in
       )
     end
 
@@ -59,9 +60,9 @@ RSpec.describe Spree::V2::Storefront::LineItemSerializer, type: :serializer do
         :digital_links,
         :vendor,
         :order,
+        :google_wallet,
         :guests,
-        :pending_guests,
-        :google_wallet
+        :pending_guests
       )
     end
   end


### PR DESCRIPTION
## Functionality : 
- This pull request is for the new self check-in feature.
- In this PR, I have added two controllers including event_qrs_controller and self_check_in_controller.

## Description :
### EventQrsController :
- This controller is responsible for generating the necessary data for client side to generate QR code.
- The controller also get qr_resource which is generated by the method called jwt_token in taxon_decorator. The jwt_token is generated by encoding with payload and secret.
- Payload include datas such as  event_id, operator_id, exp, leeway
- secret is a SecureRandom.hex(16), which will be store to the operator that generate the qr for later validation.
- Exp is set to 5 minutes and with a leeway of 120 seconds (2 minutes) to ensure users are still able to check-in 2 minutes after the expired_time.

### Endpoint
- api/v2/operator/event_qrs/:id
- Response:
``` json
{
    "data": {
        "id": "75",
        "type": "event_qr",
        "attributes": {
            "qr_data": "eyJhbGciOiJIUzI1NiJ9.eyJldmVudF9pZCI6IjM0NyIsIm9wZXJhdG9yX2lkIjoiNzUiLCJleHAiOjE3MTg2MDE3MTQsImxlZXdheSI6MzAwfQ.WOn43TNq05Jbfm-j22tfwLJ4ba0kyeQuDbo2Qcc8_8A",
            "expired_at": "2024-06-17T12:21:54.000+07:00"
        }
    }
}
```

### SelfCheckInController :
- This controller is identical to existing check_in_bulk_controller but with additional validation.
- The validation is to validate the jwt_token which is passed through the param when user scanned the qr_code.
- The first decode is to extract the jwt_token to get leeway which allowed user to check-in 2 minutes after the expired_time.
- Finally, it will decode again but this time it is signed with the secure_token of the operator.

## Endpoint
- api/v2/storefront/self_check_in?qr_data=eyJhbGciOiJIUzI1NiJ9.eyJldmVudF9pZCI6IjM0NyIsIm9wZXJhdG9yX2lkIjoiNzUiLCJleHAiOjE3MTg2NjQ5MDMsImxlZXdheSI6MzAwfQ.9DKJXP_Cn9MzSUNGoi04Ct1XO6Se9ge7pfZnISirwrI&operator_id=75
- Response : 
``` json
{
    "data": [
        {
            "id": "363",
            "type": "check_in",
            "attributes": {
                "guest_id": 396,
                "verification_state": "submitted",
                "check_in_type": "pre_check_in",
                "entry_type": "normal",
                "check_in_method": "manual",
                "confirmed_at": "2024-06-14T15:29:25.996+07:00",
                "token": "VWC86n15wEpjkTy78h76epDdp5zrM7W6"
            },
            "relationships": {
                "check_in_by": {
                    "data": {
                        "id": "75",
                        "type": "user"
                    }
                },
                "guest": {
                    "data": {
                        "id": "396",
                        "type": "guest"
                    }
                },
                "line_item": {
                    "data": null
                }
            }
        },
        {
            "id": "364",
            "type": "check_in",
            "attributes": {
                "guest_id": 404,
                "verification_state": "submitted",
                "check_in_type": "pre_check_in",
                "entry_type": "normal",
                "check_in_method": "manual",
                "confirmed_at": "2024-06-14T15:29:25.996+07:00",
                "token": "zNTqPNJUCnB71BSDcgHb9i5LaMkDRQK8"
            },
            "relationships": {
                "check_in_by": {
                    "data": {
                        "id": "75",
                        "type": "user"
                    }
                },
                "guest": {
                    "data": {
                        "id": "404",
                        "type": "guest"
                    }
                },
                "line_item": {
                    "data": null
                }
            }
        }
    ],
```

## Demo

### Check-in within the expired_time


https://github.com/channainfo/commissioner/assets/110322558/580cfe2f-b029-47e4-a2f6-2c599a78dd7d

- If operator is not found, it will not be able to locate a secure token to decode the jwt. Therefore, it will raise error "No verification key available".

### Check-in after the expired_time + after leeway (total time allowed to check-in is 7 minutes)


https://github.com/channainfo/commissioner/assets/110322558/8de32420-0b1c-4f71-b6b0-84fb6c0acc77







