### PR TITLE
close #1516 added invoice and order recurring

### DIFF
--- a/app/interactors/spree_cm_commissioner/subscriptions_order_creator.rb
+++ b/app/interactors/spree_cm_commissioner/subscriptions_order_creator.rb
@@ -1,52 +1,76 @@
 module SpreeCmCommissioner
   class SubscriptionsOrderCreator < BaseInteractor
     delegate :customer, to: :context
-
     def call
-      return if context.customer.orders.blank?
+      today = Time.zone.today.beginning_of_month
+      last_invoice_date = context.customer.last_invoice_date || (today - 1.month)
+      active_subscriptions = active_subscriptions_query(today)
 
-      if last_invoice_date.month == Date.current.month
-        context.fail!(error: 'Invoice for this month is already existed')
-      else
-        create_order
-        create_invoice
+      return context.fail!(error: 'Invoice for this month is already existed') if last_invoice_date.beginning_of_month == today
 
-        context.new_order.create_default_payment_if_eligble
-        context.new_order.reload
-        context.customer.reload
+      return context.fail!(error: 'There are no active subscriptions') if active_subscriptions.blank?
+
+      return unless last_invoice_date.beginning_of_month < today
+
+      missed_months = missed_months(last_invoice_date.beginning_of_month, today)
+      missed_months.times do |i|
+        month = i + 1
+        generate_invoice(last_invoice_date, month, active_subscriptions)
       end
+      context.customer.update(last_invoice_date: Time.zone.now)
     end
 
-    def create_order
-      active_subscriptions = context.customer.active_subscriptions
-      return if active_subscriptions.blank?
+    private
 
-      today = Time.zone.today
+    def missed_months(date, today)
+      ((today.year * 12) + today.month) - ((date.year * 12) + date.month)
+    end
+
+    def create_order(active_subscriptions)
       context.new_order = customer.user.orders.create!(
         subscription_id: active_subscriptions.first.id,
         phone_number: context.customer.phone_number,
         user_id: context.customer.user_id
       )
+    end
 
+    def generate_invoice(last_invoice_date, month, active_subscriptions)
+      create_order(active_subscriptions)
+      add_subscription_variant_to_line_item(last_invoice_date, active_subscriptions, month)
+      create_invoice
+
+      context.new_order.create_default_payment_if_eligble
+      context.new_order.reload
+      context.customer.reload
+    end
+
+    def add_subscription_variant_to_line_item(last_invoice_date, active_subscriptions, month)
+      from_date = last_invoice_date + month.month
+      to_date = from_date + 1.month
       active_subscriptions.each do |subscription|
+        next if subscription.start_date.beginning_of_month > from_date.beginning_of_month
+
         Spree::Cart::AddItem.call(
           order: context.new_order,
           variant: subscription.variant,
           quantity: subscription.quantity,
           options: {
-            from_date: today,
-            to_date: today + 1.month
+            from_date: from_date,
+            to_date: to_date
           }
         )
       end
     end
 
-    def create_invoice
-      SpreeCmCommissioner::InvoiceCreator.call(order: context.new_order)
+    def active_subscriptions_query(today)
+      context.customer.active_subscriptions.where(
+        'EXTRACT(YEAR FROM start_date) < ? OR (EXTRACT(YEAR FROM start_date) = ? AND EXTRACT(MONTH FROM start_date) <= ?)',
+        today.year, today.year, today.month
+      )
     end
 
-    def last_invoice_date
-      context.customer.orders.last.invoice.date
+    def create_invoice
+      SpreeCmCommissioner::InvoiceCreator.call(order: context.new_order)
     end
   end
 end

--- a/app/interactors/spree_cm_commissioner/subscriptions_order_cron_executor.rb
+++ b/app/interactors/spree_cm_commissioner/subscriptions_order_cron_executor.rb
@@ -1,33 +1,10 @@
 module SpreeCmCommissioner
   class SubscriptionsOrderCronExecutor < BaseInteractor
     def call
-      remaining_subscriptions.find_each do |subscription|
-        SpreeCmCommissioner::SubscribedOrderCreator.call(subscription: subscription)
+      customers = SpreeCmCommissioner::Customer.where('active_subscriptions_count > ?', 0)
+      customers.each do |customer|
+        SpreeCmCommissioner::SubscriptionsOrderCreator.call(customer: customer)
       end
-    end
-
-    def partition_orders
-      Spree::Order.select('id,number, subscription_id, rank() OVER (PARTITION BY subscription_id ORDER BY id DESC)')
-                  .where.not(subscription_id: nil)
-                  .order(:subscription_id)
-    end
-
-    def last_orders
-      Spree::Order
-        .select('po.id, po.number, po.subscription_id,po.rank')
-        .joins("INNER JOIN (#{partition_orders.to_sql}) AS po ON po.id = spree_orders.id")
-        .where('rank = 1')
-    end
-
-    def remaining_subscriptions
-      SpreeCmCommissioner::Subscription
-        .joins("INNER JOIN(#{last_orders.to_sql}) AS lo ON lo.subscription_id = cm_subscriptions.id")
-        .joins('INNER JOIN spree_line_items as li on li.order_id = lo.id')
-        .where('li.to_date <= ?', current)
-    end
-
-    def current
-      context.current ||= Date.current
     end
   end
 end

--- a/db/migrate/20240605104235_add_last_invoice_date_to_cm_customers.rb
+++ b/db/migrate/20240605104235_add_last_invoice_date_to_cm_customers.rb
@@ -1,0 +1,5 @@
+class AddLastInvoiceDateToCmCustomers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cm_customers, :last_invoice_date, :date, null: true, if_not_exists: true
+  end
+end

--- a/spec/interactors/spree_cm_commissioner/subscribed_order_creator_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/subscribed_order_creator_spec.rb
@@ -28,6 +28,21 @@ RSpec.describe SpreeCmCommissioner::SubscribedOrderCreator do
         expect(context.order.line_items.size).to eq 1
         expect(context.order.line_items[0].variant).to eq subscription.variant
         expect(context.order.line_items[0].quantity).to eq 2
+        expect(customer.last_invoice_date).to eq Time.zone.now.to_date
+      end
+    end
+
+    context "when subscriptions is later than this month" do
+      it "do not create any order"do
+        subscription1 = create(:cm_subscription, customer: customer, quantity: 2, start_date: '2024-07-02'.to_date)
+        subscription2 = create(:cm_subscription, customer: customer, quantity: 2, start_date: '2025-01-02'.to_date)
+        expect(customer.orders.count).to eq 0
+        expect(customer.subscriptions.count).to eq 2
+        expect(customer.subscriptions).to include(subscription1)
+        expect(customer.subscriptions).to include(subscription2)
+      end
+      it "doesn't set last_invoice_date" do
+        expect(customer.last_invoice_date).to eq nil
       end
     end
 

--- a/spec/interactors/spree_cm_commissioner/subscriptions_order_cron_executor_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/subscriptions_order_cron_executor_spec.rb
@@ -10,54 +10,36 @@ RSpec.describe SpreeCmCommissioner::SubscriptionsOrderCronExecutor do
   let(:option_type_payment) {create(:option_type, name: "payment-option", attr_type: :string)}
   let(:option_value_payment){create(:option_value, name: "post-paid", presentation: "post-paid", option_type: option_type_payment)}
 
+  let(:vendor) { create(:vendor) }
 
-  let(:vendor) {create(:vendor)}
+  let(:product) { create(:base_product, option_types: [option_type_month, option_type_day, option_type_payment], subscribable: true, vendor: vendor) }
+  let(:variant) { create(:base_variant, option_values: [option_value_month, option_value_day, option_value_payment], price: 30, product: product) }
 
-  let(:product) { create(:base_product, option_types: [option_type_month,option_type_day,option_type_payment], subscribable: true, vendor: vendor)}
-  let(:variant) { create(:base_variant, option_values: [option_value_month,option_value_day,option_value_payment], price: 30, product: product)}
+  let(:customer1) { create(:cm_customer, vendor: vendor, phone_number: "0962200288") }
+  let(:customer2) { create(:cm_customer, vendor: vendor, phone_number: "0972200288") }
+  let(:customer3) { create(:cm_customer, vendor: vendor, phone_number: "0982200288") }
 
-  before(:each) do
-    variant.stock_items.first.adjust_count_on_hand(10)
+  let!(:subscription1) { SpreeCmCommissioner::Subscription.create!(variant: variant, start_date: 4.months.ago, customer: customer1) }
+  let!(:subscription2) { SpreeCmCommissioner::Subscription.create!(variant: variant, start_date: 1.months.ago, customer: customer2) }
+  let!(:subscription3) { SpreeCmCommissioner::Subscription.create!(variant: variant, start_date: Time.zone.now, customer: customer3) }
 
-    customer = create(:cm_customer, vendor: vendor, phone_number: "0962200288")
-    vendor.reload
-    customer2 = create(:cm_customer, vendor: vendor, phone_number: "0972200288")
-    vendor.reload
-    customer3 = create(:cm_customer, vendor: vendor, phone_number: "0982200288")
-    vendor.reload
-
-    subscription1 = SpreeCmCommissioner::Subscription.create!(variant: variant, start_date: '2021-01-01', customer: customer)
-    subscription2 = SpreeCmCommissioner::Subscription.create!(variant: variant, start_date: '2021-02-01', customer: customer2)
-    subscription3 = SpreeCmCommissioner::Subscription.create!(variant: variant, start_date: '2021-03-01', customer: customer3)
+  before do
+    customer1.update(last_invoice_date: 4.months.ago)
+    customer2.update(last_invoice_date: 1.months.ago)
   end
 
   describe ".call" do
-    it "renews all expired subscription by 1 month" do
-      instance = described_class.new(current: Date.parse('2021-03-01'))
-      instance.call
-      # renew orders should be 2 as 2 subscriptions are expired
-      expect(instance.remaining_subscriptions.size).to eq 2
-    end
-  end
+    it "creates invoices for all the missing months" do
+      described_class.call()
 
-  describe "#partition_orders" do
-    it "return all subscription orders" do
-      instance = described_class.new(current: Date.parse('2021-03-01'))
-      expect(instance.partition_orders.size).to eq 3
-    end
-  end
+      [customer1, customer2, customer3].each(&:reload)
 
-  describe "#last_orders" do
-    it "return all subscription last order" do
-      instance = described_class.new(current: Date.parse('2021-03-01'))
-      expect(instance.last_orders.size).to eq 3
-    end
-  end
-
-  describe "#remaining_subscriptions" do
-    it "return all the expired subscriptions" do
-      instance = described_class.new(current: Date.parse('2021-03-01'))
-      expect(instance.remaining_subscriptions.first.customer.phone_number).to eq "0962200288"
+      expect(customer1.orders.count).to eq 5
+      expect(customer2.orders.count).to eq 2
+      expect(customer3.orders.count).to eq 1
+      expect(customer1.last_invoice_date).to eq (4.months.ago + 4.months).to_date
+      expect(customer2.last_invoice_date).to eq (1.months.ago + 1.months).to_date
+      expect(customer3.last_invoice_date).to eq Time.zone.now.to_date
     end
   end
 end


### PR DESCRIPTION
***Future Subscription***
- When a subscription is scheduled to start in the future (i.e., next month or beyond), an invoice will not be generated immediately.
- The invoice for the subscription will be generated automatically when the current month matches the subscription's start month.

***Missing Invoices***
- To address potential invoice creation failures, a new field, last_invoice_date, has been added to the cm_customers table.
- This field will be used to track the date of the last successful invoice creation.
- If there are gaps in the invoicing period (i.e., months where invoices were not generated), the system will calculate the number of missing invoices based on the last_invoice_date and create the necessary invoices accordingly.
