### PR TITLE
close #1529 preference fields are missing

### DIFF
--- a/app/helpers/spree/admin/base_helper_decorator.rb
+++ b/app/helpers/spree/admin/base_helper_decorator.rb
@@ -12,26 +12,19 @@ module Spree
       end
 
       def preference_field_for(form, field, options)
-        case options[:type]
-        when :integer
-          form.text_field(field, preference_field_options(options))
-        when :boolean
-          form.check_box(field, preference_field_options(options))
-        when :string
-          if %w[preferred_start_date preferred_end_date].include?(field)
-            date_value = form.object.send(field)
-            form.date_field(field, class: 'form-control js-quick-search-target js-filterable datepicker',
-                                   data: { behavior: 'datepicker' },
-                                   value: Date.parse(date_value)
-            )
-          else
-            form.text_field(field, preference_field_options(options))
-          end
-        when :password
-          form.password_field(field, preference_field_options(options))
-        when :text
-          form.text_area(field, preference_field_options(options))
+        case field
+        when 'preferred_start_date' || 'preferred_end_date'
+          value = parse_date(form.object.send(field))
+          return form.date_field(field, class: 'form-control datepicker bg-transparent', value: value)
         end
+
+        super
+      end
+
+      def parse_date(date)
+        Date.parse(date)
+      rescue StandardError
+        nil
       end
     end
   end


### PR DESCRIPTION
Since we don't call super, most previous field that we override in spree_vpago is gone.

Fixed:

<img width="699" alt="image" src="https://github.com/channainfo/commissioner/assets/29684683/0b63658c-a639-4d19-8087-09d295693bf7">
