### PR TITLE
close #1547 fix option values can't be reorder

### DIFF
--- a/app/overrides/spree/admin/option_types/edit/option_header_replacer.html.erb.deface
+++ b/app/overrides/spree/admin/option_types/edit/option_header_replacer.html.erb.deface
@@ -1,7 +1,0 @@
-<!-- replace "[data-hook='option_header']" -->
-
-<tr>
-  <th colspan="2"><%= Spree.t(:name) %> <span class="required">*</span></th>
-  <th><%= Spree.t(:display) %> <span class="required">*</span></th>
-  <th class="actions"></th>
-</tr>


### PR DESCRIPTION
Just remove the deface, it affects the UI & also is not needed.

https://github.com/channainfo/commissioner/assets/29684683/9333627c-aaa6-4c9f-9d13-9fc4e1ca169d

