### PR TITLE
close #1552 generate number for line item

### DIFF
--- a/lib/tasks/ensure_number_for_line_items.rake
+++ b/lib/tasks/ensure_number_for_line_items.rake
@@ -1,0 +1,13 @@
+# recommend to be used in schedule.yml & manually access in /sidekiq/cron
+namespace :spree_cm_commissioner do
+  desc 'Ensure line item number is present.'
+  task ensure_number_for_line_items: :environment do
+    Spree::LineItem
+      .where(number: nil)
+      .find_each do |line_item|
+      host = Spree::LineItem
+      number = host.number_generator.generate_permalink(host)
+      line_item.update_columns(number: number) # rubocop:disable Rails/SkipsModelValidations
+    end
+  end
+end

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -16,6 +16,20 @@ RSpec.describe Spree::LineItem, type: :model do
     end
   end
 
+  describe 'callback before_validation' do
+    let(:line_item) { build(:line_item) }
+
+    describe 'Spree::Core::NumberGenerator#generate_permalink' do
+      it 'generate number for line item with base length 10' do
+        expect(line_item.number).to eq nil
+
+        line_item.save
+
+        expect(line_item.number.size).to eq 10
+      end
+    end
+  end
+
   describe 'validations' do
     context 'make sure quantity not exceed max-quantity-per-order' do
       let(:line_item) { create(:line_item) }


### PR DESCRIPTION
Current example of line item number is L123-59103902 = L{id}-{order_number}. This is currently generate before save, meaning that `id` is not present and causes line item number to not have id. Example L-59103902 which is a bug.

While fixing this, I see number using line item id may not a preferred way for display to user, so this PR to generate number for line item with same logic as generating order number.

New number will be: L39103905

This is just a proposal, its cons is that it generates another number may cause some confusion between line item number & order number.

![telegram-cloud-photo-size-5-6319037077840313460-y](https://github.com/channainfo/commissioner/assets/29684683/c83423c4-137c-4a75-a55f-2b91162857e1)
