### PR TITLE
Close: #1556 add meta-data to file video upload

### DIFF
--- a/app/controllers/spree/admin/video_on_demands_controller.rb
+++ b/app/controllers/spree/admin/video_on_demands_controller.rb
@@ -8,6 +8,30 @@ module Spree
         @video_on_demand = SpreeCmCommissioner::VideoOnDemand.find(params[:id])
       end
 
+      def create
+        video_on_demand_params = params.require(:spree_cm_commissioner_video_on_demand)
+        result = SpreeCmCommissioner::VideoOnDemandCreator.call(video_on_demand_params: video_on_demand_params)
+
+        if result.success?
+          redirect_to collection_url
+        else
+          flash[:error] = result.error
+          render :new
+        end
+      end
+
+      def update
+        @video_on_demand = SpreeCmCommissioner::VideoOnDemand.find(params[:id])
+        result = SpreeCmCommissioner::VideoOnDemandUpdater.call(video_on_demand: @video_on_demand, params: params)
+
+        if result.success?
+          redirect_to collection_url
+        else
+          flash[:error] = result.error
+          render :edit
+        end
+      end
+
       private
 
       def model_class

--- a/app/helpers/spree_cm_commissioner/admin/video_on_demand_helper.rb
+++ b/app/helpers/spree_cm_commissioner/admin/video_on_demand_helper.rb
@@ -1,0 +1,23 @@
+module SpreeCmCommissioner
+  module Admin
+    module VideoOnDemandHelper
+      def calculate_quality_value(params)
+        quality_params = params.slice(*SpreeCmCommissioner::VideoOnDemandBitwise::QUALITY_BIT_FIELDS.keys)
+        return nil unless quality_params.values.any?(&:present?)
+
+        quality_params.values.each_with_index.sum do |value, index|
+          value.to_i * (2**index)
+        end
+      end
+
+      def calculate_protocol_value(params)
+        protocol_params = params.slice(*SpreeCmCommissioner::VideoOnDemandBitwise::PROTOCOL_BIT_FIELDS.keys)
+        return nil unless protocol_params.values.any?(&:present?)
+
+        protocol_params.values.each_with_index.sum do |value, index|
+          value.to_i * (2**index)
+        end
+      end
+    end
+  end
+end

--- a/app/interactors/spree_cm_commissioner/video_on_demand_creator.rb
+++ b/app/interactors/spree_cm_commissioner/video_on_demand_creator.rb
@@ -1,0 +1,45 @@
+module SpreeCmCommissioner
+  class VideoOnDemandCreator < BaseInteractor
+    def call
+      video_on_demand_params = context.video_on_demand_params
+
+      instance = SpreeCmCommissioner::VideoOnDemand.new
+      quality_result = instance.calculate_quality_value(video_on_demand_params)
+      protocol_result = instance.calculate_protocol_value(video_on_demand_params)
+      frame_rate = SpreeCmCommissioner::VideoOnDemand.frame_rates[video_on_demand_params[:frame_rate]]
+
+      uuid = SecureRandom.uuid.gsub('-', '')
+      new_file_name = generate_new_file_name(video_on_demand_params[:file], quality_result, protocol_result, frame_rate, uuid)
+      video_on_demand_params[:file].original_filename = new_file_name
+      permitted_params = permit_params(video_on_demand_params, quality_result, protocol_result, frame_rate, uuid)
+
+      create_video_on_demand(permitted_params)
+    end
+
+    private
+
+    def generate_new_file_name(file, quality_result, protocol_result, frame_rate, uuid)
+      file_name = File.basename(file.original_filename, File.extname(file.original_filename))
+      "#{file_name}-#{uuid}-f#{frame_rate}-p#{protocol_result}-q#{quality_result}.mp4"
+    end
+
+    def permit_params(params, quality_result, protocol_result, frame_rate, uuid)
+      params.merge(
+        uuid: uuid,
+        video_quality: quality_result,
+        video_protocol: protocol_result,
+        frame_rate: frame_rate
+      ).permit(:title, :description, :uuid, :file, :thumbnail, :variant_id, :video_quality, :video_protocol, :frame_rate)
+    end
+
+    def create_video_on_demand(permitted_params)
+      video_on_demand = SpreeCmCommissioner::VideoOnDemand.new(permitted_params)
+
+      if video_on_demand.save
+        context.video_on_demand = video_on_demand
+      else
+        context.fail!(error: 'Failed to create VideoOnDemand')
+      end
+    end
+  end
+end

--- a/app/interactors/spree_cm_commissioner/video_on_demand_updater.rb
+++ b/app/interactors/spree_cm_commissioner/video_on_demand_updater.rb
@@ -1,0 +1,46 @@
+module SpreeCmCommissioner
+  class VideoOnDemandUpdater < BaseInteractor
+    def call
+      video_on_demand = context.video_on_demand
+      params = context.params
+      instance = SpreeCmCommissioner::VideoOnDemand.new
+
+      quality_result = instance.calculate_quality_value(params[:spree_cm_commissioner_video_on_demand])
+      protocol_result = instance.calculate_protocol_value(params[:spree_cm_commissioner_video_on_demand])
+      frame_rate = SpreeCmCommissioner::VideoOnDemand.frame_rates[params[:spree_cm_commissioner_video_on_demand][:frame_rate].to_sym]
+      uuid = SecureRandom.uuid.gsub('-', '')
+      new_file_name = generate_new_file_name(video_on_demand, quality_result, protocol_result, frame_rate, uuid)
+
+      update_file_name(video_on_demand, new_file_name) if video_on_demand.file.attached?
+      update_thumbnail(video_on_demand, params) if params[:spree_cm_commissioner_video_on_demand][:thumbnail].present?
+
+      return if video_on_demand.update(
+        title: params[:spree_cm_commissioner_video_on_demand][:title],
+        description: params[:spree_cm_commissioner_video_on_demand][:description],
+        variant_id: params[:spree_cm_commissioner_video_on_demand][:variant_id],
+        video_quality: quality_result,
+        video_protocol: protocol_result,
+        frame_rate: frame_rate,
+        uuid: uuid
+      )
+
+      context.fail!(error: 'Failed to update VideoOnDemand')
+    end
+
+    private
+
+    def generate_new_file_name(video_on_demand, quality_result, protocol_result, frame_rate, uuid)
+      file_name = File.basename(video_on_demand.file.filename.to_s, File.extname(video_on_demand.file.filename.to_s))
+      base_file_name = file_name.split('-')[0...-4].join('-')
+      "#{base_file_name}-#{uuid}-f#{frame_rate}-p#{protocol_result}-q#{quality_result}.mp4"
+    end
+
+    def update_file_name(video_on_demand, new_file_name)
+      video_on_demand.file.blob.update(filename: new_file_name)
+    end
+
+    def update_thumbnail(video_on_demand, params)
+      video_on_demand.thumbnail = params[:spree_cm_commissioner_video_on_demand][:thumbnail]
+    end
+  end
+end

--- a/app/models/concerns/spree_cm_commissioner/video_on_demand_bitwise.rb
+++ b/app/models/concerns/spree_cm_commissioner/video_on_demand_bitwise.rb
@@ -1,0 +1,52 @@
+module SpreeCmCommissioner
+  module VideoOnDemandBitwise
+    extend ActiveSupport::Concern
+
+    # must add migration to cm_guests when adding new field.
+    QUALITY_BIT_FIELDS = {
+      low: 0b1,           # quality_320p
+      standard: 0b10,     # quality_480p
+      medium: 0b100,      # quality_720p
+      high: 0b1000        # quality_1080p
+    }.freeze
+
+    PROTOCOL_BIT_FIELDS = {
+      p_hls: 0b1,
+      p_dash: 0b10,
+      p_file: 0b100
+    }.freeze
+
+    def quality? = quality != 0
+    def protocol? = protocol != 0
+
+    # Quality
+    QUALITY_BIT_FIELDS.each do |field, bit_value|
+      define_method "#{field}?" do
+        quality_value_enabled?(bit_value)
+      end
+    end
+
+    def quality_fields
+      QUALITY_BIT_FIELDS.filter_map do |field, bit_value|
+        field if video_quality & bit_value != 0
+      end
+    end
+
+    def quality_value_enabled?(bit_value)
+      video_quality & bit_value != 0
+    end
+
+    # Protocol
+    PROTOCOL_BIT_FIELDS.each do |field, bit_value|
+      define_method "#{field}?" do
+        video_protocol & bit_value != 0
+      end
+    end
+
+    def protocol_fields
+      PROTOCOL_BIT_FIELDS.filter_map do |field, bit_value|
+        field if video_protocol & bit_value != 0
+      end
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/video_on_demand.rb
+++ b/app/models/spree_cm_commissioner/video_on_demand.rb
@@ -1,10 +1,17 @@
 module SpreeCmCommissioner
   class VideoOnDemand < SpreeCmCommissioner::Base
+    include SpreeCmCommissioner::VideoOnDemandBitwise
+    include SpreeCmCommissioner::Admin::VideoOnDemandHelper
+
+    enum frame_rate: { FPS_TWEENTY_FOUR: 24, FPS_THIRTY: 30, FPS_SIXTY: 60 }
+
     belongs_to :variant, class_name: 'Spree::Variant'
+
     has_one_attached :file
     has_one_attached :thumbnail
 
-    validates :title, :description, :file, :thumbnail, presence: true
-    validates :variant_id, uniqueness: true
+    validates :video_quality, :video_protocol, :frame_rate, presence: true
+    validates :file, presence: true, if: :new_record?
+    validates :thumbnail, presence: true, if: :new_record?
   end
 end

--- a/app/views/spree/admin/video_on_demands/_form.html.erb
+++ b/app/views/spree/admin/video_on_demands/_form.html.erb
@@ -1,29 +1,70 @@
 <div class="row">
   <div class="col-12">
+    <%= f.hidden_field :uuid %>
     <%= f.field_container :title do %>
-      <%= f.label :title, raw(Spree.t(:title) + required_span_tag) %>
-      <%= f.text_field :title, class: 'form-control', placeholder: 'eg. Video Title', required: true %>
-      <%= f.error_message_on :title %>
+      <div class="form-group">
+        <%= f.label :title, raw(Spree.t(:title) + required_span_tag) %>
+        <%= f.text_field :title, class: 'form-control', placeholder: 'eg. Video Title', required: true %>
+        <%= f.error_message_on :title %>
+      </div>
     <% end %>
     <%= f.field_container :description do %>
-      <%= f.label :description, raw(Spree.t(:description) + required_span_tag) %>
-      <%= f.text_area :description, cols: 60, rows: 6, class: 'form-control', placeholder: 'eg. This product required to complete following step.' , required: true %>
-      <%= f.error_message_on :description %>
+      <div class="form-group">
+        <%= f.label :description, raw(Spree.t(:description) + required_span_tag) %>
+        <%= f.text_area :description, cols: 60, rows: 6, class: 'form-control', placeholder: 'eg. This product required to complete following step.', required: true %>
+        <%= f.error_message_on :description %>
+      </div>
     <% end %>
     <div class="form-group">
       <%= f.label :variant_id, raw(Spree::Variant.model_name.human + required_span_tag) %>
-      <%= f.select :variant_id, options_for_select(@variants.map { |v| [v.options_text, v.id, { disabled: v.id != f.object.variant_id && @video_on_demands.map(&:variant_id).include?(v.id) }] }, f.object.variant_id), {}, { class: 'select2' } %>
+      <%= f.select :variant_id, options_for_select(@variants.map { |v| [v.options_text, v.id, { disabled: v.id != f.object.variant_id && @video_on_demands.map(&:variant_id).include?(v.id) }] }, f.object.variant_id), {}, { class: 'select2 form-control' } %>
       <%= f.error_message_on :variant_id %>
     </div>
-    <div class="field mb-4">
+    <div class="form-group">
       <%= f.label :thumbnail, raw(Spree.t(:thumbnail) + required_span_tag) %>
-      <%= f.file_field :thumbnail, required: true, accept: 'image/*' %>
+      <%= f.file_field :thumbnail, required: f.object.new_record?, accept: 'image/*', class: 'form-control-file' %>
       <%= f.error_message_on :thumbnail %>
     </div>
-    <div class="field">
-      <%= f.label :file, raw(Spree.t(:video) + required_span_tag)%>
-      <%= f.file_field :file, accept: 'video/*'  %>
-      <%= f.error_message_on :file, required: true %>
+    <div class="form-group">
+      <%= f.label :file, raw(Spree.t(:video) + required_span_tag) %>
+      <%= f.file_field :file, required: f.object.new_record?, accept: 'video/*', class: 'form-control-file' %>
+      <%= f.error_message_on :file %>
+    </div>
+    <div class="form-group">
+      <%= f.label :video_quality, raw(Spree.t(:video_quality)) %>
+      <div class="form-check form-check-inline">
+        <% SpreeCmCommissioner::VideoOnDemandBitwise::QUALITY_BIT_FIELDS.each do |field, bit_value| %>
+          <div class="form-check form-check-inline ml-3">
+            <%= f.check_box field, class: 'form-check-input', checked: f.object.quality_value_enabled?(bit_value) %>
+            <%= f.label field, t("video_on_demand.quality.#{field}"), class: 'form-check-label' %>
+          </div>
+        <% end %>
+        <%= f.error_message_on :video_quality, class: 'text-danger' %>
+      </div>
+    </div>
+    <div class="form-group">
+      <%= f.label :video_protocol, raw(Spree.t(:video_protocol)) %>
+      <div class="form-check form-check-inline">
+        <% SpreeCmCommissioner::VideoOnDemandBitwise::PROTOCOL_BIT_FIELDS.each do |protocol, bit_value| %>
+          <div class="form-check form-check-inline ml-3">
+            <%= f.check_box protocol, class: 'form-check-input', checked: f.object.protocol_fields.include?(protocol) %>
+            <%= f.label protocol, t("video_on_demand.protocol.#{protocol}"), class: 'form-check-label' %>
+          </div>
+        <% end %>
+        <%= f.error_message_on :video_protocol, class: 'text-danger' %>
+      </div>
+    </div>
+    <div class="form-group">
+      <%= f.label :frame_rate, raw(Spree.t(:frame_rate) + required_span_tag) %>
+      <div class="form-check form-check-inline">
+        <% SpreeCmCommissioner::VideoOnDemand.frame_rates.keys.each do |frame_rate| %>
+          <div class="form-check form-check-inline ml-3">
+            <%= f.radio_button :frame_rate, frame_rate, class: 'form-check-input frame_rates_radios', required: true %>
+            <%= f.label :frame_rate, t("video_on_demand.frame_rates.#{frame_rate}"), class: 'form-check-label' %>
+          </div>
+        <% end %>
+        <%= f.error_message_on :frame_rate, class: 'text-danger' %>
+      </div>
     </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -418,3 +418,17 @@ en:
     cannot_delete_account: "You cannot delete this account because you own a special role"
   kyc:
     note: "<b>Note:</b> Select Required KYC Field For this Product"
+  video_on_demand:
+    quality:
+      low: 'Low (320p)'
+      standard: 'Standard (480p)'
+      medium: 'Medium (720p)'
+      high: 'High (1080p)'
+    protocol:
+      p_hls: 'HLS'
+      p_dash: 'DASH'
+      p_file: 'File'
+    frame_rates:
+      FPS_TWEENTY_FOUR: "24 (Cinematic Mode)"
+      FPS_THIRTY: "30 (TV Show or Online Video)"
+      FPS_SIXTY: "60 (Sport and Gaming)"

--- a/db/migrate/20240624082727_add_video_quality_to_cm_video_on_demands.rb
+++ b/db/migrate/20240624082727_add_video_quality_to_cm_video_on_demands.rb
@@ -1,0 +1,5 @@
+class AddVideoQualityToCmVideoOnDemands < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cm_video_on_demands, :video_quality, :integer, default: 0, if_not_exists: true
+  end
+end

--- a/db/migrate/20240624092531_add_video_protocol_to_cm_video_on_demands.rb
+++ b/db/migrate/20240624092531_add_video_protocol_to_cm_video_on_demands.rb
@@ -1,0 +1,5 @@
+class AddVideoProtocolToCmVideoOnDemands < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cm_video_on_demands, :video_protocol, :integer, default: 0, if_not_exists: true
+  end
+end

--- a/db/migrate/20240627022903_add_frame_rate_to_cm_video_on_demands.rb
+++ b/db/migrate/20240627022903_add_frame_rate_to_cm_video_on_demands.rb
@@ -1,0 +1,5 @@
+class AddFrameRateToCmVideoOnDemands < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cm_video_on_demands, :frame_rate, :integer, null: false
+  end
+end

--- a/db/migrate/20240704021831_add_uuid_to_cm_video_on_demand.rb
+++ b/db/migrate/20240704021831_add_uuid_to_cm_video_on_demand.rb
@@ -1,0 +1,5 @@
+class AddUuidToCmVideoOnDemand < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cm_video_on_demands, :uuid, :uuid, index: true, null: false
+  end
+end


### PR DESCRIPTION
### What done on this PR:
- add video quality and protocol to Table Video on-demand as bit-wise
- add Frame-rate to Table Video on-demand as integer ( frame-rate 24 => add 24 to table)
- add meta-data to file video 
  + File = cohesion-4rftyuuiohjk8jk2hu2892992992020-f24-p3-q7.mp4

![image](https://github.com/channainfo/commissioner/assets/95096862/0fb36f06-67b5-487c-b646-6dca696bdae9)
![image](https://github.com/channainfo/commissioner/assets/95096862/1f292a77-bf57-4400-93f9-9c4662f78eb8)
