### PR TITLE
close #1559 make sure events query more accurate

### DIFF
--- a/app/models/concerns/spree_cm_commissioner/kyc_bitwise.rb
+++ b/app/models/concerns/spree_cm_commissioner/kyc_bitwise.rb
@@ -16,6 +16,19 @@ module SpreeCmCommissioner
       guest_expectation: 0b1000000000
     }.freeze
 
+    ORDERED_BIT_FIELDS = %i[
+      guest_name
+      guest_gender
+      guest_dob
+      guest_occupation
+      guest_nationality
+      guest_age
+      guest_emergency_contact
+      guest_organization
+      guest_expectation
+      guest_id_card
+    ].freeze
+
     def kyc? = kyc != 0
 
     BIT_FIELDS.each do |field, bit_value|
@@ -24,10 +37,14 @@ module SpreeCmCommissioner
       end
     end
 
-    def kyc_fields
+    def unordered_kyc_fields
       BIT_FIELDS.filter_map do |field, bit_value|
         field if kyc & bit_value != 0
       end
+    end
+
+    def kyc_fields
+      unordered_kyc_fields.sort_by { |item| ORDERED_BIT_FIELDS.index(item) }
     end
 
     def kyc_value_enabled?(bit_value)

--- a/app/models/concerns/spree_cm_commissioner/line_items_filter_scope.rb
+++ b/app/models/concerns/spree_cm_commissioner/line_items_filter_scope.rb
@@ -10,10 +10,10 @@ module SpreeCmCommissioner
       scope :filter_by_event, lambda { |event|
         case event
         when 'upcoming'
-          where.not(to_date: nil).where('to_date >= ?', Date.current)
+          where.not(to_date: nil).where('to_date >= ?', Time.zone.now)
 
         when 'complete'
-          where.not(to_date: nil).where('to_date < ?', Date.current)
+          where.not(to_date: nil).where('to_date < ?', Time.zone.now)
 
         else
           none
@@ -21,9 +21,9 @@ module SpreeCmCommissioner
       }
 
       def event_status
-        return 'upcoming' if to_date.present? && to_date >= Date.current
+        return 'upcoming' if to_date.present? && to_date >= Time.zone.now
 
-        'complete' if to_date.present? && to_date < Date.current
+        'complete' if to_date.present? && to_date < Time.zone.now
       end
     end
   end

--- a/app/queries/spree_cm_commissioner/dashboard_crew_event_query.rb
+++ b/app/queries/spree_cm_commissioner/dashboard_crew_event_query.rb
@@ -6,17 +6,17 @@ module SpreeCmCommissioner
     def initialize(user_id:, section:, start_from_date: nil)
       @user_id = user_id
       @section = section
-      @start_from_date = start_from_date || Time.zone.today
+      @start_from_date = start_from_date || Time.zone.now
     end
 
     def events
       taxons = Spree::Taxon.joins(:user_events).where(user_events: { user_id: user_id })
 
       if section == 'incoming'
-        taxons.where('from_date >= ?', start_from_date)
+        taxons.where('to_date >= ?', start_from_date)
               .order(from_date: :asc)
       else
-        taxons.where('from_date < ?', start_from_date)
+        taxons.where('to_date < ?', start_from_date)
               .order(to_date: :desc)
       end
     end

--- a/app/serializers/spree/v2/storefront/cart_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/cart_serializer_decorator.rb
@@ -3,7 +3,7 @@ module Spree
     module Storefront
       module CartSerializerDecorator
         def self.prepended(base)
-          base.attributes :phone_number, :intel_phone_number, :country_code, :request_state
+          base.attributes :phone_number, :intel_phone_number, :country_code, :request_state, :qr_data
         end
       end
     end

--- a/app/views/spree/admin/line_items/_form.html.erb
+++ b/app/views/spree/admin/line_items/_form.html.erb
@@ -12,7 +12,7 @@
       <div data-hook="admin_line_item_form_date">
         <%= f.field_container :from_date do %>
           <%= f.label :from_date, raw(Spree.t(:from_date) + required_span_tag) %>
-          <%= f.text_field :from_date, class: 'form-control datePickerFrom mb-2', 'data-input': '', value: (@line_item.from_date ? @line_item.from_date.to_date : nil) %>
+          <%= f.text_field :from_date, class: 'form-control datePickerFrom mb-2', 'data-alt-input': true, 'data-enable-time': true, value: (@line_item.from_date ? @line_item.from_date.to_date : nil) %>
           <%= f.error_message_on :from_date %>
         <% end %>
       </div>
@@ -20,7 +20,7 @@
       <div data-hook="admin_line_item_to_date">
         <%= f.field_container :to_date do %>
           <%= f.label :to_date, raw(Spree.t(:to_date) + required_span_tag) %>
-          <%= f.text_field :to_date, class: 'form-control datePickerTo', 'data-input': '', value: (@line_item.to_date ? @line_item.to_date.to_date : nil), 'data-min-date': (@line_item.from_date ? @line_item.from_date.to_date : nil) %>
+          <%= f.text_field :to_date, class: 'form-control datePickerTo', 'data-alt-input': true, 'data-enable-time': true, value: @line_item.to_date, 'data-min-date': @line_item.from_date %>
           <%= f.error_message_on :to_date %>
         <% end %>
       </div>

--- a/spec/queries/spree_cm_commissioner/dashboard_crew_event_query_spec.rb
+++ b/spec/queries/spree_cm_commissioner/dashboard_crew_event_query_spec.rb
@@ -34,6 +34,20 @@ RSpec.describe SpreeCmCommissioner::DashboardCrewEventQuery do
         expect(incoming_event_c.from_date).to be >= start_from_date
         expect(subject.events.pluck(:taxon_id)).to eq([incoming_event_a.id, incoming_event_b.id, incoming_event_c.id])
       end
+
+      context 'when start_from_date not yet pass to_date (can ignore from_date)' do
+        let!(:start_from_date) { Time.zone.now }
+
+        let(:incoming_event_a) { create(:cm_taxon_event, name: 'LongTedX', to_date: start_from_date + 10.second) }
+        let(:incoming_event_b) { create(:cm_taxon_event, name: 'LongTedX', to_date: start_from_date + 1.days) }
+
+        let!(:user) { create(:cm_operator_user, events: [incoming_event_a, incoming_event_b]) }
+
+        it 'return both events' do
+          query_a = SpreeCmCommissioner::DashboardCrewEventQuery.new(user_id: user.id, section: 'incoming')
+          expect(query_a.events.pluck(:taxon_id)).to eq([incoming_event_a.id, incoming_event_b.id])
+        end
+      end
     end
 
     context 'when section is previous' do

--- a/spec/serializers/spree/v2/storefront/cart_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/cart_serializer_spec.rb
@@ -57,7 +57,8 @@ RSpec.describe Spree::V2::Storefront::CartSerializer, type: :serializer do
         :phone_number,
         :intel_phone_number,
         :country_code,
-        :request_state
+        :request_state,
+        :qr_data,
       )
     end
 


### PR DESCRIPTION
Tested on both client app & operator app, switch different just 1 minute will also make it go from upcoming to past:

https://github.com/channainfo/commissioner/assets/29684683/ec4d5d39-b8b4-4579-b75b-aff2899f6677

https://github.com/channainfo/commissioner/assets/29684683/46ccf7d7-7022-436b-9855-20295f5e051f

I also reorder kyc fields & add qr_data within this PR.
