### PR TITLE
close #1563 add confirm pin code checker

### DIFF
--- a/app/controllers/spree/api/v2/storefront/confirm_pin_code_checkers_controller.rb
+++ b/app/controllers/spree/api/v2/storefront/confirm_pin_code_checkers_controller.rb
@@ -1,0 +1,24 @@
+module Spree
+  module Api
+    module V2
+      module Storefront
+        class ConfirmPinCodeCheckersController < ::Spree::Api::V2::ResourceController
+          before_action :require_spree_current_user
+
+          def update
+            context = SpreeCmCommissioner::ConfirmPinCodeChecker.call(
+              input_pin_code: params[:pin_code],
+              user_pin_code: spree_current_user.confirm_pin_code_digest
+            )
+
+            if context.success?
+              render_serialized_payload { { status: 'ok' } }
+            else
+              render_error_payload(context.message, 400)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/interactors/spree_cm_commissioner/confirm_pin_code_checker.rb
+++ b/app/interactors/spree_cm_commissioner/confirm_pin_code_checker.rb
@@ -1,0 +1,17 @@
+module SpreeCmCommissioner
+  class ConfirmPinCodeChecker < BaseInteractor
+    delegate :input_pin_code, :user_pin_code, to: :context
+
+    def call
+      context.fail!(message: :pin_code_must_not_blank) if input_pin_code.blank?
+
+      validate_pin_code!
+    end
+
+    private
+
+    def validate_pin_code!
+      context.fail!(message: :invalid_pin_code) unless BCrypt::Password.new(user_pin_code) == input_pin_code
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/user_decorator.rb
+++ b/app/models/spree_cm_commissioner/user_decorator.rb
@@ -7,8 +7,6 @@ module SpreeCmCommissioner
 
       base.enum gender: %i[male female other]
 
-      base.encrypts :encrypted_confirm_pin_code
-
       base.has_many :subscriptions, through: :customer, class_name: 'SpreeCmCommissioner::Subscription'
       base.has_many :payments, as: :payable, class_name: 'Spree::Payment', dependent: :nullify
       base.has_many :role_permissions, through: :spree_roles, class_name: 'SpreeCmCommissioner::RolePermission'
@@ -22,6 +20,8 @@ module SpreeCmCommissioner
 
       base.has_one :profile, as: :viewable, dependent: :destroy, class_name: 'SpreeCmCommissioner::UserProfile'
       base.has_one :customer, class_name: 'SpreeCmCommissioner::Customer'
+
+      base.has_secure_password :confirm_pin_code, validations: false
 
       base.whitelisted_ransackable_attributes = %w[email first_name last_name gender phone_number]
 

--- a/app/serializers/spree/v2/storefront/user_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/user_serializer_decorator.rb
@@ -3,9 +3,9 @@ module Spree
     module Storefront
       module UserSerializerDecorator
         def self.prepended(base)
-          base.attributes :first_name, :last_name, :gender, :phone_number,
-                          :intel_phone_number, :country_code, :otp_enabled,
-                          :otp_email, :otp_phone_number, :encrypted_confirm_pin_code
+          base.attributes :first_name, :last_name, :gender, :phone_number, :intel_phone_number,
+                          :country_code, :otp_enabled, :otp_email, :otp_phone_number,
+                          :confirm_pin_code_enabled
           base.has_one :profile, serializer: ::Spree::V2::Storefront::UserProfileSerializer
           base.has_many :device_tokens, serializer: Spree::V2::Storefront::UserDeviceTokenSerializer
           base.has_many :spree_roles, serializer: Spree::V2::Storefront::RoleSerializer

--- a/config/initializers/spree_permitted_attributes.rb
+++ b/config/initializers/spree_permitted_attributes.rb
@@ -14,7 +14,7 @@ module Spree
       otp_enabled
       otp_email
       otp_phone_number
-      encrypted_confirm_pin_code
+      confirm_pin_code_enabled
     ]
     @@taxon_attributes += %i[
       category_icon

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -353,6 +353,8 @@ Spree::Core::Engine.add_routes do
         resources :pin_code_generators, only: [:create]
         resource :pin_code_checkers, only: [:update]
 
+        resource :confirm_pin_code_checkers, only: [:update]
+
         resources :order_products_taxons, only: [:index]
 
         resource :change_passwords, only: [:update]

--- a/db/migrate/20240619103418_rename_encrypted_confirm_pin_code_to_confirm_pin_code_digest_to_spree_users.rb
+++ b/db/migrate/20240619103418_rename_encrypted_confirm_pin_code_to_confirm_pin_code_digest_to_spree_users.rb
@@ -1,0 +1,6 @@
+class RenameEncryptedConfirmPinCodeToConfirmPinCodeDigestToSpreeUsers < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :spree_users, :encrypted_confirm_pin_code, :confirm_pin_code_digest
+    change_column :spree_users, :confirm_pin_code_digest, :string, limit: 128
+  end
+end

--- a/db/migrate/20240619104325_add_confirm_pin_code_enabled_to_spree_users.rb
+++ b/db/migrate/20240619104325_add_confirm_pin_code_enabled_to_spree_users.rb
@@ -1,0 +1,5 @@
+class AddConfirmPinCodeEnabledToSpreeUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_users, :confirm_pin_code_enabled, :boolean, default: false
+  end
+end

--- a/spec/interactors/spree_cm_commissioner/confirm_pin_code_checker_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/confirm_pin_code_checker_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require 'bcrypt'
+
+RSpec.describe SpreeCmCommissioner::ConfirmPinCodeChecker do
+  let(:user_confirm_pin_code) { BCrypt::Password.create('987654') }
+
+  describe '#call' do
+    context 'when input pin code is blank' do
+      let(:input_pin_code) { '' }
+
+      it 'fails with a pin_code_must_not_blank message' do
+        interactor = SpreeCmCommissioner::ConfirmPinCodeChecker.call(user_pin_code: user_confirm_pin_code, input_pin_code: input_pin_code)
+        expect(interactor.failure?).to be true
+        expect(interactor.message).to eq(:pin_code_must_not_blank)
+      end
+    end
+
+    context 'when input pin code is not blank' do
+      let(:input_pin_code) { '987654' }
+
+      context 'and pin codes match' do
+        it 'succeeds' do
+          interactor = SpreeCmCommissioner::ConfirmPinCodeChecker.call(user_pin_code: user_confirm_pin_code, input_pin_code: input_pin_code)
+          expect(interactor.success?).to be true
+        end
+      end
+
+      context 'and pin codes do not match' do
+        let(:input_pin_code) { '123456' }
+
+        it 'fails with an invalid_pin_code message' do
+          interactor = SpreeCmCommissioner::ConfirmPinCodeChecker.call(user_pin_code: user_confirm_pin_code, input_pin_code: input_pin_code)
+          expect(interactor.failure?).to be true
+          expect(interactor.message).to eq(:invalid_pin_code)
+        end
+      end
+    end
+  end
+end

--- a/spec/serializers/spree/v2/storefront/user_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/user_serializer_spec.rb
@@ -27,7 +27,7 @@ describe Spree::V2::Storefront::UserSerializer, type: :serializer do
         :otp_enabled,
         :otp_email,
         :otp_phone_number,
-        :encrypted_confirm_pin_code
+        :confirm_pin_code_enabled
       )
     end
 


### PR DESCRIPTION
## App Demo: https://github.com/bookmebus/cm-market-app/pull/1449

```ruby
def has_secure_password(attribute = :password, validations: true)
        # Load bcrypt gem only when has_secure_password is used.
        # This is to avoid ActiveModel (and by extension the entire framework)
        # being dependent on a binary library.
        begin
          require "bcrypt"
        rescue LoadError
          $stderr.puts "You don't have bcrypt installed in your application. Please add it to your Gemfile and run bundle install"
          raise
        end

        include InstanceMethodsOnActivation.new(attribute)

        if validations
          include ActiveModel::Validations

          # This ensures the model has a password by checking whether the password_digest
          # is present, so that this works with both new and existing records. However,
          # when there is an error, the message is added to the password attribute instead
          # so that the error message will make sense to the end-user.
          validate do |record|
            record.errors.add(attribute, :blank) unless record.public_send("#{attribute}_digest").present?
          end

          validates_length_of attribute, maximum: ActiveModel::SecurePassword::MAX_PASSWORD_LENGTH_ALLOWED
          validates_confirmation_of attribute, allow_blank: true
        end
      end
```

```ruby
 class InstanceMethodsOnActivation < Module
      def initialize(attribute)
        attr_reader attribute

        define_method("#{attribute}=") do |unencrypted_password|
          if unencrypted_password.nil?
            instance_variable_set("@#{attribute}", nil)
            self.public_send("#{attribute}_digest=", nil)
          elsif !unencrypted_password.empty?
            instance_variable_set("@#{attribute}", unencrypted_password)
            cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost
            self.public_send("#{attribute}_digest=", BCrypt::Password.create(unencrypted_password, cost: cost))
          end
        end

        define_method("#{attribute}_confirmation=") do |unencrypted_password|
          instance_variable_set("@#{attribute}_confirmation", unencrypted_password)
        end

        # Returns +self+ if the password is correct, otherwise +false+.
        #
        #   class User < ActiveRecord::Base
        #     has_secure_password validations: false
        #   end
        #
        #   user = User.new(name: 'david', password: 'mUc3m00RsqyRe')
        #   user.save
        #   user.authenticate_password('notright')      # => false
        #   user.authenticate_password('mUc3m00RsqyRe') # => user
        define_method("authenticate_#{attribute}") do |unencrypted_password|
          attribute_digest = public_send("#{attribute}_digest")
          attribute_digest.present? && BCrypt::Password.new(attribute_digest).is_password?(unencrypted_password) && self
        end

        alias_method :authenticate, :authenticate_password if attribute == :password
      end
    end
```