### PR TITLE
close #1565 fix check in bulk creator error

### DIFF
--- a/app/interactors/spree_cm_commissioner/check_in_bulk_creator.rb
+++ b/app/interactors/spree_cm_commissioner/check_in_bulk_creator.rb
@@ -30,7 +30,7 @@ module SpreeCmCommissioner
 
       return guest.check_in if guest.check_in.present?
 
-      event = guest.line_item.product.taxons.where(kind: :event).first.parent
+      event = guest.event
 
       check_in = SpreeCmCommissioner::CheckIn.new(
         guest: guest,


### PR DESCRIPTION
# Error Raised:

Application spree_starter


⚠️ Error occurred in staging ⚠️
A *NoMethodError* occurred in *check_in_bulks#create*.


Exception:
undefined method `parent' for nil:NilClass


Request:
```
* url : https://staging-server.contigo.asia/api/v2/operator/check_in_bulks?locale=en_US
* http_method : POST
* ip_address : 43.230.192.190
* parameters : {"guest_ids"=>[288], "include"=>"guest", "locale"=>"en_US", "format"=>"json", "controller"=>"spree/api/v2/operator/check_in_bulks", "action"=>"create", "check_in_bulk"=>{"guest_ids"=>[288], "include"=>"guest"}}
* timestamp : 2024-06-25 10:34:07 +0700
```

