### PR TITLE
close #1585 add vendor stop

### DIFF
--- a/app/models/spree_cm_commissioner/service_calendar.rb
+++ b/app/models/spree_cm_commissioner/service_calendar.rb
@@ -10,7 +10,7 @@ module SpreeCmCommissioner
     include SpreeCmCommissioner::ServiceCalendarType
     EXCEPTION_RULE_JSON_SCHEMA = Pathname.new("#{COMMISSIONER_ROOT}/config/schemas/service_calendar_exception_rule.json")
 
-    belongs_to :calendarable, polymorphic: true
+    belongs_to :calendarable, polymorphic: true, optional: false
     validates :exception_rules, json: { schema: EXCEPTION_RULE_JSON_SCHEMA }
     self.whitelisted_ransackable_attributes = %w[name]
 

--- a/app/models/spree_cm_commissioner/trip.rb
+++ b/app/models/spree_cm_commissioner/trip.rb
@@ -15,7 +15,7 @@ module SpreeCmCommissioner
 
     has_many :trip_stops, class_name: 'SpreeCmCommissioner::TripStop', dependent: :destroy
 
-    after_create :create_trip_stops
+    after_commit :create_trip_stops
 
     accepts_nested_attributes_for :trip_stops, allow_destroy: true
 

--- a/app/models/spree_cm_commissioner/trip_stop.rb
+++ b/app/models/spree_cm_commissioner/trip_stop.rb
@@ -8,11 +8,22 @@ module SpreeCmCommissioner
     belongs_to :stop, class_name: 'Spree::Taxon'
 
     before_validation :set_stop_name
+    after_create :create_vendor_stop
 
     validates :stop_id, uniqueness: { scope: :trip_id }
 
     def set_stop_name
       self.stop_name = stop.name
+    end
+
+    def create_vendor_stop
+      vendor.vendor_stops.where(stop_id: stop_id, stop_type: stop_type).first_or_create
+    end
+
+    private
+
+    def vendor
+      Spree::Product.find(trip.product_id).vendor
     end
   end
 end

--- a/app/models/spree_cm_commissioner/vendor_decorator.rb
+++ b/app/models/spree_cm_commissioner/vendor_decorator.rb
@@ -33,6 +33,12 @@ module SpreeCmCommissioner
       base.has_many :places,
                     through: :nearby_places, source: :place, class_name: 'SpreeCmCommissioner::Place'
 
+      base.has_many :vendor_stops, class_name: 'SpreeCmCommissioner::VendorStop', dependent: :destroy
+      base.has_many :boarding_points, -> { where(cm_vendor_stops: { stop_type: 0 }) },
+                    through: :vendor_stops, source: :stop, class_name: 'Spree::Taxon'
+      base.has_many :drop_off_points, -> { where(cm_vendor_stops: { stop_type: 1 }) },
+                    through: :vendor_stops, source: :stop, class_name: 'Spree::Taxon'
+
       base.has_one  :logo, as: :viewable, dependent: :destroy, class_name: 'SpreeCmCommissioner::VendorLogo'
       base.has_one  :payment_qrcode, as: :viewable, dependent: :destroy, class_name: 'SpreeCmCommissioner::VendorPaymentQrcode'
       base.has_one  :web_promotion_banner, as: :viewable, dependent: :destroy, class_name: 'SpreeCmCommissioner::VendorWebPromotionBanner'

--- a/app/models/spree_cm_commissioner/vendor_stop.rb
+++ b/app/models/spree_cm_commissioner/vendor_stop.rb
@@ -1,0 +1,9 @@
+require_dependency 'spree_cm_commissioner'
+module SpreeCmCommissioner
+  class VendorStop < ApplicationRecord
+    belongs_to :vendor, class_name: 'Spree::Vendor'
+    belongs_to :stop, class_name: 'Spree::Taxon'
+
+    enum stop_type: { boarding: 0, drop_off: 1 }
+  end
+end

--- a/db/migrate/20240626073702_create_cm_vendor_stops.rb
+++ b/db/migrate/20240626073702_create_cm_vendor_stops.rb
@@ -1,0 +1,10 @@
+class CreateCmVendorStops < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cm_vendor_stops do |t|
+      t.integer :vendor_id
+      t.integer :stop_id
+      t.integer :stop_type
+      t.timestamps
+    end
+  end
+end

--- a/lib/spree_cm_commissioner/test_helper/factories/product_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/product_factory.rb
@@ -36,15 +36,8 @@ FactoryBot.define do
     factory :route do
       route_type {:automobile}
       product_type { :transit }
-      trip_attributes do
-        departure_time { '13:00' }
-        duration { 5 }
-        vehicle_id {1}
-        origin_id {1}
-        destination_id {2}
-      end
       before(:create) do |route, evaluator|
-        stock_location = create(:stock_location) unless Spree::StockLocation.any?
+        create(:stock_location) unless Spree::StockLocation.any?
         if route.stores.empty?
           default_store = Spree::Store.default.persisted? ? Spree::Store.default : nil
           store = default_store || create(:store)

--- a/spec/models/spree_cm_commissioner/trip_stop_spec.rb
+++ b/spec/models/spree_cm_commissioner/trip_stop_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::TripStop, type: :model do
+  let!(:vet_airbus) {create(:vendor, name: 'Vet Airbus', code:"VET")}
+  let!(:larryta) {create(:vendor, name: 'Larryta', code: 'LTA')}
+
+  #location
+  let!(:phnom_penh) { create(:transit_place, name: 'Phnom Penh', data_type:8) }
+  let!(:siem_reap) { create(:transit_place, name: 'Siem Reap', data_type:8) }
+  let!(:sihanoukville) { create(:transit_place, name: 'Sihanoukville', data_type:8) }
+  let!(:aeon1) {create(:transit_place, name: 'Aeon Mall 1', data_type:1)}
+  let!(:angkor_wat) {create(:transit_place, name: 'Angkor Wat', data_type:1)}
+
+  #Vehicle
+  let!(:airbus) {create(:vehicle_type,
+  :with_seats,
+  code: "AIRBUS",
+  vendor: vet_airbus,
+  row: 4,
+  column: 4)}
+  let!(:bus1) {create(:vehicle, vehicle_type: airbus, vendor: vet_airbus)}
+
+  let!(:vet_phnom_penh_siem_reap) { create(:route, name: 'VET Airbus Phnom Penh Siem Reap 10:00', short_name:"PP-SR-10:00-6", vendor: vet_airbus ) }
+  let!(:vet_phnom_penh_sihanoukville) { create(:route,name: 'VET Airbus Phnom Penh Sihanoukville 10:00', short_name:"PP-SV-10:00-6", vendor: vet_airbus) }
+  describe '#create_vendor_stop' do
+    context "Trip isn't existed" do
+      it "should create vendor stop with trip's origin and destination for vet_airbus" do
+        SpreeCmCommissioner::Trip.create(origin_id: phnom_penh.id, destination_id: siem_reap.id, departure_time: '10:00', duration: 3600, vehicle_id: bus1.id, product_id: vet_phnom_penh_siem_reap.id)
+        vendor = vet_airbus
+        expect(vendor.boarding_points.count).to eq(1)
+        expect(vendor.drop_off_points.count).to eq(1)
+        expect(vendor.boarding_points.first.name).to eq 'Phnom Penh'
+        expect(vendor.drop_off_points.first.name).to eq 'Siem Reap'
+        expect(larryta.boarding_points.count).to eq(0)
+        expect(larryta.drop_off_points.count).to eq(0)
+      end
+      it "should not create duplicate vendor stop for PhnomPenh for vet_airbus" do
+        SpreeCmCommissioner::Trip.create(origin_id: phnom_penh.id, destination_id: siem_reap.id, departure_time: '10:00', duration: 3600, vehicle_id: bus1.id, product_id: vet_phnom_penh_siem_reap.id)
+        SpreeCmCommissioner::Trip.create(origin_id: phnom_penh.id, destination_id: sihanoukville.id, departure_time: '10:00', duration: 3600, vehicle_id: bus1.id, product_id: vet_phnom_penh_siem_reap.id)
+        vendor = vet_airbus
+        expect(vendor.boarding_points.count).to eq(1)
+        expect(vendor.drop_off_points.count).to eq(2)
+        expect(vendor.boarding_points).to contain_exactly(phnom_penh)
+        expect(vendor.drop_off_points).to contain_exactly(siem_reap, sihanoukville)
+        expect(larryta.boarding_points.count).to eq(0)
+        expect(larryta.drop_off_points.count).to eq(0)
+      end
+    end
+    context "add more stops on existing trip" do
+      before do
+        trip = SpreeCmCommissioner::Trip.create(origin_id: phnom_penh.id, destination_id: siem_reap.id, departure_time: '10:00', duration: 3600, vehicle_id: bus1.id, product_id: vet_phnom_penh_siem_reap.id)
+        SpreeCmCommissioner::TripStop.create(trip_id: trip.id, stop_id: aeon1.id, stop_type: 'boarding')
+        SpreeCmCommissioner::TripStop.create(trip_id: trip.id, stop_id: angkor_wat.id, stop_type: 'drop_off')
+      end
+      it "should create vendor stop with the new added stops for vet_airbus" do
+        vendor = vet_airbus
+        expect(vendor.boarding_points.count).to eq(2)
+        expect(vendor.drop_off_points.count).to eq(2)
+        expect(vendor.boarding_points).to contain_exactly(phnom_penh, aeon1)
+        expect(vendor.drop_off_points).to contain_exactly(siem_reap, angkor_wat)
+        expect(larryta.boarding_points.count).to eq(0)
+        expect(larryta.drop_off_points.count).to eq(0)
+      end
+      it "should not create duplicate vendor stop for aeon1 for vet_airbus" do
+        trip2 = SpreeCmCommissioner::Trip.create(origin_id: phnom_penh.id, destination_id: sihanoukville.id, departure_time: '10:00', duration: 3600, vehicle_id: bus1.id, product_id: vet_phnom_penh_siem_reap.id)
+        SpreeCmCommissioner::TripStop.create(trip_id: trip2.id, stop_id: aeon1.id, stop_type: 'boarding')
+        vendor = vet_airbus
+        expect(vendor.boarding_points.count).to eq(2)
+        expect(vendor.drop_off_points.count).to eq(3)
+        expect(vendor.boarding_points).to contain_exactly(phnom_penh, aeon1)
+        expect(vendor.drop_off_points).to contain_exactly(siem_reap, angkor_wat, sihanoukville)
+        expect(larryta.boarding_points.count).to eq(0)
+        expect(larryta.drop_off_points.count).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/queries/spree_cm_commissioner/trip_search_query_spec.rb
+++ b/spec/queries/spree_cm_commissioner/trip_search_query_spec.rb
@@ -188,7 +188,7 @@ let!(:tomorrow) {today + 1.day}
 
         result.each do |r|
           table.add_row [r["trip_id"], r["route_name"], r["vendor_name"], r['short_name'],
-                        r["origin"] + " - " + r['origin_id'].to_s, r["destination"] +" - " +r['destination_id'].to_s, r["total_seats"], r['total_sold'],
+                        r["origin"] + " - " + r['origin_id'].to_s, r["destination"] + " - " + r['destination_id'].to_s, r["total_seats"], r['total_sold'],
                         r['total_seats'] - r['total_sold'], r['departure_time'].strftime("%H:%M"), r['duration'], r['vehicle_id']]
           table.add_separator unless r.equal?(result.last) # Avoid adding separator after the last row
         end

--- a/spec/serializers/spree/v2/storefront/line_item_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/line_item_serializer_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 RSpec.describe Spree::V2::Storefront::LineItemSerializer, type: :serializer do
   describe '#serializable_hash' do
-    let(:line_item) { create(:cm_line_item) }
+  product = Spree::Product.create(name: 'Test Product', price: 10.00, product_type: :accommodation)
+  line_item = Spree::LineItem.new(quantity: 1, price: 10.00, currency: 'USD', product: product)
 
     subject {
       described_class.new(line_item, include: [


### PR DESCRIPTION
- A new middle table cm_vendor_stops to store stops of a vendor
- When a stop is assigned to a trip, it checks if the stop is existed, if not, it creates a new record to store the stop and the the vendor.
<img width="1186" alt="image" src="https://github.com/channainfo/commissioner/assets/87005466/d0da7fdd-def4-4a1d-885a-5a3ab042fd8a">

