### PR TITLE
Close #1576 enhance validation for self check-in

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,6 +130,7 @@ en:
 
   self_check_in:
     invalid_distance: "Invalid Check-in distance"
+    invalid_line_item: "Invalid Taxon or Vendor"
 
   telegram_chat_bot:
     vendor_channel_group_info: "This channel/group will be recieve order notifications"


### PR DESCRIPTION
## Functionality:
- The previous version of the self check-in feature didn't validate the taxon and vendor of the lineItem, allowing user to scan any event QR code to check-in.
- This PR is for the enhancement for the problem above.

## Request:
### URL: {{BASE_URL}}/api/v2/storefront/self_check_in
### Body:
``` json
{
  "line_item_id" : 3066,
  "event_id" : 115,
  "operator_id" : 1,
  "qr_data" : "eyJhbGciOiJIUzI1NiJ9.eyJldmVudF9pZCI6MzQ3LCJvcGVyYXRvcl9pZCI6MSwiZXhwIjoxNzI1NTAzNjkwfQ.UWnEbiW_0kRhHZwo0Kry825iBgEbXG5UKUMRnjpdbFM",
  "guest_ids": [440],
  "lat" : 11.562145966834924,
  "lon" : 104.91424119999999
}
```
