### PR TITLE
close #1614 allow on or off self check-in

### DIFF
--- a/app/models/concerns/spree_cm_commissioner/product_delegation.rb
+++ b/app/models/concerns/spree_cm_commissioner/product_delegation.rb
@@ -8,6 +8,7 @@ module SpreeCmCommissioner
                :need_confirmation?, :need_confirmation, :kyc,
                :accommodation?, :service?, :ecommerce?,
                :associated_event,
+               :allow_self_check_in,
                to: :product
     end
   end

--- a/app/models/spree_cm_commissioner/line_item_decorator.rb
+++ b/app/models/spree_cm_commissioner/line_item_decorator.rb
@@ -77,7 +77,7 @@ module SpreeCmCommissioner
     end
 
     def allowed_self_check_in?
-      ecommerce? && guests.any?
+      ecommerce? && guests.any? && product.allow_self_check_in?
     end
 
     def amount_per_guest

--- a/app/overrides/spree/admin/products/_form/allow_self_check_in.html.erb.deface
+++ b/app/overrides/spree/admin/products/_form/allow_self_check_in.html.erb.deface
@@ -1,0 +1,9 @@
+<!-- insert_after "[data-hook='admin_product_form_subscribable']" -->
+
+<div data-hook="admin_product_form_allow_self_check_in">
+  <%= f.field_container :allow_self_check_in do %>
+    <%= f.check_box :allow_self_check_in %>
+    <%= f.label :allow_self_check_in, Spree.t(:allow_self_check_in) %>
+    <%= f.error_message_on :allow_self_check_in %>
+  <% end %>
+</div>

--- a/db/migrate/20240705075515_add_allow_self_check_in_to_spree_product.rb
+++ b/db/migrate/20240705075515_add_allow_self_check_in_to_spree_product.rb
@@ -1,0 +1,5 @@
+class AddAllowSelfCheckInToSpreeProduct < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_products , :allow_self_check_in, :boolean, default: false, if_not_exists: true
+  end
+end


### PR DESCRIPTION
## Functionality :

- Currently, our product will be able to perform self check-in when it has a product type other than e-commerce.
- However, some product might not need self check-in and they want to check-in using the operator feature.
- To handle this issue, we decided to add a toggle checkbox that can be updated from the admin dashboard.

## Changes : 

- Add allow self check-in checkbox in the product form under subscribable
- Modify the allowed_self_check_in condition in lineitem_decorator
- Add new field in spree_product table to store the allow_self_check_in (boolean)

## Demo : 

https://github.com/channainfo/commissioner/assets/110322558/c5198429-3550-4621-a397-8019b9496c9b

