### PR TITLE
close #1638 make delivery required base entirely on variant option type

### DIFF
--- a/app/models/spree_cm_commissioner/order_decorator.rb
+++ b/app/models/spree_cm_commissioner/order_decorator.rb
@@ -86,14 +86,8 @@ module SpreeCmCommissioner
       saved_change_to_state? && state == 'canceled'
     end
 
-    # required only in one case,
-    # some of line_items are ecommerce & not digital.
     def delivery_required?
-      contain_non_digital_ecommerce?
-    end
-
-    def contain_non_digital_ecommerce?
-      line_items.select { |item| item.ecommerce? && !item.digital? }.size.positive?
+      line_items.any?(&:delivery_required?)
     end
 
     # overrided not to send email yet to user if order needs confirmation

--- a/app/models/spree_cm_commissioner/variant_decorator.rb
+++ b/app/models/spree_cm_commissioner/variant_decorator.rb
@@ -24,8 +24,6 @@ module SpreeCmCommissioner
     end
 
     def delivery_required?
-      return true if non_digital_ecommerce?
-
       delivery_option == 'delivery'
     end
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Spree::Order, type: :model do
         order = build(:order, promo_total: -1)
 
         expect(order.save).to be true
-        expect(order.promo_total).to eq -1
+        expect(order.promo_total).to eq(-1)
       end
     end
   end
@@ -148,44 +148,30 @@ RSpec.describe Spree::Order, type: :model do
 
     let(:order) { create(:order, line_items: [line_item1, line_item2]) }
 
-    context 'required delivery' do
-      it 'required delivery when all products are :ecommerce & not digital' do
-        order.line_items[0].product.update_columns(product_type: :ecommerce)
-        order.line_items[1].product.update_columns(product_type: :ecommerce)
+    context 'when some line items required delivery' do
+      it 'return true' do
+        allow(order.line_items[0]).to receive(:delivery_required?).and_return(true)
+        allow(order.line_items[1]).to receive(:delivery_required?).and_return(false)
 
-        allow(order.line_items[0]).to receive(:digital?).and_return(false)
-        allow(order.line_items[1]).to receive(:digital?).and_return(false)
-
-        expect(order.delivery_required?).to eq true
-      end
-
-      it 'required delivery when some of products are :ecommerce & not digital' do
-        order.line_items[0].product.update_columns(product_type: :ecommerce)
-        order.line_items[1].product.update_columns(product_type: :service)
-
-        allow(order.line_items[0]).to receive(:digital?).and_return(false)
-        allow(order.line_items[1]).to receive(:digital?).and_return(false)
-
-        expect(order.delivery_required?).to eq true
+        expect(order.delivery_required?).to be true
       end
     end
 
-    context 'not required delivery' do
-      it 'not required delivery when products are not :ecommerce (digital? are ignored this case)' do
-        order.line_items[0].product.update_columns(product_type: :accommodation)
-        order.line_items[1].product.update_columns(product_type: :service)
+    context 'when all line items required delivery' do
+      it 'return true' do
+        allow(order.line_items[0]).to receive(:delivery_required?).and_return(true)
+        allow(order.line_items[1]).to receive(:delivery_required?).and_return(true)
 
-        expect(order.delivery_required?).to eq false
+        expect(order.delivery_required?).to be true
       end
+    end
 
-      it 'not required delivery when some of products are :ecommerce & it is digital' do
-        order.line_items[0].product.update_columns(product_type: :ecommerce)
-        order.line_items[1].product.update_columns(product_type: :service)
+    context 'when none of line items required delivery' do
+      it 'return false' do
+        allow(order.line_items[0]).to receive(:delivery_required?).and_return(false)
+        allow(order.line_items[1]).to receive(:delivery_required?).and_return(false)
 
-        allow(order.line_items[0]).to receive(:digital?).and_return(true)
-        allow(order.line_items[1]).to receive(:digital?).and_return(false)
-
-        expect(order.delivery_required?).to eq false
+        expect(order.delivery_required?).to be false
       end
     end
   end

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -110,39 +110,28 @@ RSpec.describe Spree::Variant, type: :model do
     end
   end
 
+  # delivery required will be base entirely on option type
   describe '#delivery_required?' do
-    context 'when non_digital ecommerce? is true' do
-      let(:product) { create(:product, product_type: :ecommerce) }
-      subject { create(:variant, product: product) }
+    let(:product) { create(:product, product_type: :ecommerce, option_types: [option_type]) }
+    let(:option_type) { create(:cm_option_type, :delivery_option) }
+
+    subject { build(:variant, product: product, digitals: [create(:digital)], option_values: [option_value]) }
+
+    context 'when deliver option is "delivery"' do
+      let(:option_value) { create(:option_value, name: 'delivery', presentation: 'Delivery', option_type: option_type) }
 
       it 'returns true' do
-        expect(subject.non_digital_ecommerce?).to be true
+        expect(subject.non_digital_ecommerce?).to be false
         expect(subject.delivery_required?).to be true
       end
     end
 
-    context 'when non_digital_ecommerce? is false' do
-      let(:product) { create(:product, product_type: :ecommerce, option_types: [option_type]) }
-      let(:option_type) { create(:cm_option_type, :delivery_option) }
+    context 'when deliver option is "pickup"' do
+      let(:option_value) { create(:option_value, name: 'pickup', presentation: 'Pickup', option_type: option_type) }
 
-      subject { build(:variant, product: product, digitals: [create(:digital)], option_values: [option_value]) }
-
-      context 'when deliver option is "delivery"' do
-        let(:option_value) { create(:option_value, name: 'delivery', presentation: 'Delivery', option_type: option_type) }
-
-        it 'returns true' do
-          expect(subject.non_digital_ecommerce?).to be false
-          expect(subject.delivery_required?).to be true
-        end
-      end
-
-      context 'when deliver option is "pickup"' do
-        let(:option_value) { create(:option_value, name: 'pickup', presentation: 'Pickup', option_type: option_type) }
-
-        it 'returns false' do
-          expect(subject.non_digital_ecommerce?).to be false
-          expect(subject.delivery_required?).to be false
-        end
+      it 'returns false' do
+        expect(subject.non_digital_ecommerce?).to be false
+        expect(subject.delivery_required?).to be false
       end
     end
   end

--- a/spec/models/spree_cm_commissioner/stock/availability_checker_spec.rb
+++ b/spec/models/spree_cm_commissioner/stock/availability_checker_spec.rb
@@ -67,14 +67,16 @@ RSpec.describe SpreeCmCommissioner::Stock::AvailabilityChecker do
 
         context 'stock items is available' do
           it 'return can_supply? true' do
-            expect(variant.delivery_required?).to be true
+            allow(variant).to receive(:delivery_required?).and_return(true)
+
             expect(subject.can_supply?(3)).to be true
           end
         end
 
         context 'stock items is not available' do
           it 'return can_supply? false' do
-            expect(variant.delivery_required?).to be true
+            allow(variant).to receive(:delivery_required?).and_return(true)
+
             expect(subject.can_supply?(4)).to be false
           end
         end


### PR DESCRIPTION
## Problem
`delivery_required?` is true unless variant is e-commerce & does not have digital assets. So to make order skip the delivery step, admin have to make sure variant is e-commerce & has digital assets. To do so, admin have to upload digital assets, which confusing.

To fix it, we can override method `digital?` but it could break some digital assets logic of Spree.

## Solution
Solution is to check `delivery_required?` with option type.  So admin doesn't have to upload digital assets.