### PR TITLE
close #1641 set line item from_date & to_date base on variant option values

### DIFF
--- a/app/models/concerns/spree_cm_commissioner/line_item_durationable.rb
+++ b/app/models/concerns/spree_cm_commissioner/line_item_durationable.rb
@@ -3,7 +3,7 @@ module SpreeCmCommissioner
     extend ActiveSupport::Concern
 
     included do
-      before_validation :set_duration, if: -> { event.present? }
+      before_validation :set_duration
     end
 
     def date_present?
@@ -46,9 +46,11 @@ module SpreeCmCommissioner
       taxons.event.first
     end
 
+    private
+
     def set_duration
-      self.from_date ||= event.from_date
-      self.to_date ||= event.to_date
+      self.from_date ||= variant.start_date_time
+      self.to_date ||= variant.end_date_time
     end
   end
 end

--- a/app/models/concerns/spree_cm_commissioner/option_type_attr_type.rb
+++ b/app/models/concerns/spree_cm_commissioner/option_type_attr_type.rb
@@ -20,7 +20,8 @@ module SpreeCmCommissioner
       'start-date' => 'date',
       'end-date' => 'date',
       'start-time' => 'time',
-      'reminder-in-time' => 'time',
+      'end-time' => 'time',
+      'reminder-in-hours' => 'integer',
       'duration-in-hours' => 'integer',
       'duration-in-minutes' => 'integer',
       'duration-in-seconds' => 'integer',
@@ -44,6 +45,8 @@ module SpreeCmCommissioner
 
       before_validation :set_reverved_options_attributes, if: :reserved_option?
 
+      after_save :sort_date_time_option_values, if: -> { attr_type == 'date' || attr_type == 'time' }
+
       ATTRIBUTE_TYPES.each do |attr_type|
         define_method "attr_type_#{attr_type}?" do
           self.attr_type == attr_type
@@ -58,6 +61,14 @@ module SpreeCmCommissioner
     def set_reverved_options_attributes
       self.attr_type = RESERVED_OPTIONS[name]
       self.kind = :variant
+    end
+
+    def sort_date_time_option_values
+      ordered_option_values = option_values.sort_by { |value| Time.zone.parse(value.name) }.reverse
+      ordered_option_values.each_with_index do |value, index|
+        position = index + 1
+        value.update(position: position)
+      end
     end
   end
 end

--- a/app/models/spree_cm_commissioner/variant_decorator.rb
+++ b/app/models/spree_cm_commissioner/variant_decorator.rb
@@ -10,6 +10,7 @@ module SpreeCmCommissioner
 
       base.belongs_to :vendor, class_name: 'Spree::Vendor'
 
+      base.has_many :taxons, class_name: 'Spree::Taxon', through: :product
       base.has_many :visible_option_values, lambda {
                                               joins(:option_type).where(spree_option_types: { hidden: false })
                                             }, through: :option_value_variants, source: :option_value
@@ -33,6 +34,10 @@ module SpreeCmCommissioner
 
     def permanent_stock?
       accommodation?
+    end
+
+    def event
+      taxons.event.first
     end
 
     # override

--- a/app/models/spree_cm_commissioner/variant_options.rb
+++ b/app/models/spree_cm_commissioner/variant_options.rb
@@ -1,0 +1,119 @@
+module SpreeCmCommissioner
+  class VariantOptions
+    attr_reader :variant
+
+    def initialize(variant)
+      @variant = variant
+    end
+
+    DEFAULT_KIDS_AGE_MAX = 17
+    DEFAULT_NUMBER_OF_ADULTS = 1
+
+    def option_value_name_for(option_type_name: nil)
+      variant.option_value_name_for(option_type_name: option_type_name)
+    end
+
+    def location
+      @location ||= option_value_name_for(option_type_name: 'location')&.to_i
+    end
+
+    def start_date
+      @start_date ||= begin
+        date = option_value_name_for(option_type_name: 'start-date')
+        Time.zone.parse(date) if date.present?
+      end
+    end
+
+    def end_date
+      @end_date ||= begin
+        date = option_value_name_for(option_type_name: 'end-date')
+        Time.zone.parse(date) if date.present?
+      end
+    end
+
+    def start_time
+      @start_time ||= begin
+        time = option_value_name_for(option_type_name: 'start-time')
+        Time.zone.parse(time) if time.present?
+      end
+    end
+
+    def end_time
+      @end_time ||= begin
+        time = option_value_name_for(option_type_name: 'end-time')
+        Time.zone.parse(time) if time.present?
+      end
+    end
+
+    def reminder_in_hours
+      @reminder_in_hours ||= option_value_name_for(option_type_name: 'reminder-in-hours')&.to_i
+    end
+
+    def duration_in_hours
+      @duration_in_hours ||= option_value_name_for(option_type_name: 'duration-in-hours')&.to_i
+    end
+
+    def duration_in_minutes
+      @duration_in_minutes ||= option_value_name_for(option_type_name: 'duration-in-minutes')&.to_i
+    end
+
+    def duration_in_seconds
+      @duration_in_seconds ||= option_value_name_for(option_type_name: 'duration-in-seconds')&.to_i
+    end
+
+    def total_duration_in_seconds
+      total_duration_in_seconds = 0
+
+      total_duration_in_seconds += duration_in_hours * 3600 if duration_in_hours.present?
+      total_duration_in_seconds += duration_in_minutes * 60 if duration_in_minutes.present?
+      total_duration_in_seconds += duration_in_seconds if duration_in_seconds.present?
+
+      total_duration_in_seconds
+    end
+
+    def payment_option
+      @payment_option ||= option_value_name_for(option_type_name: 'payment-option')
+    end
+
+    def delivery_option
+      @delivery_option ||= option_value_name_for(option_type_name: 'delivery-option')
+    end
+
+    def max_quantity_per_order
+      @max_quantity_per_order ||= option_value_name_for(option_type_name: 'max-quantity-per-order')&.to_i
+    end
+
+    def due_date
+      @due_date ||= option_value_name_for(option_type_name: 'due-date')&.to_i
+    end
+
+    def month
+      @month ||= option_value_name_for(option_type_name: 'month')&.to_i
+    end
+
+    def number_of_adults
+      @number_of_adults ||= option_value_name_for(option_type_name: 'number-of-adults')&.to_i || DEFAULT_NUMBER_OF_ADULTS
+    end
+
+    def number_of_kids
+      @number_of_kids ||= option_value_name_for(option_type_name: 'number-of-kids')&.to_i || 0
+    end
+
+    def kids_age_max
+      @kids_age_max ||= option_value_name_for(option_type_name: 'kids-age-max')&.to_i || DEFAULT_KIDS_AGE_MAX
+    end
+
+    def allowed_extra_adults
+      @allowed_extra_adults ||= option_value_name_for(option_type_name: 'allowed-extra-adults')&.to_i || 0
+    end
+
+    def allowed_extra_kids
+      @allowed_extra_kids ||= option_value_name_for(option_type_name: 'allowed-extra-kids')&.to_i || 0
+    end
+
+    # can consider as customers.
+    def number_of_guests
+      number_of_adults + number_of_kids
+    end
+  end
+end

--- a/app/serializers/spree/v2/storefront/variant_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/variant_serializer_decorator.rb
@@ -4,7 +4,7 @@ module Spree
       module VariantSerializerDecorator
         def self.prepended(base)
           base.attributes :need_confirmation, :product_type, :kyc,
-                          :reminder_in_time, :start_time, :delivery_option,
+                          :reminder_in_hours, :start_time, :delivery_option,
                           :number_of_guests, :max_quantity_per_order
 
           base.attribute :delivery_required, &:delivery_required?

--- a/lib/spree_cm_commissioner/test_helper/factories/option_type_factory .rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/option_type_factory .rb
@@ -27,10 +27,16 @@ FactoryBot.define do
       presentation { 'start-time' }
     end
 
-    trait :reminder_in_time do
+    trait :end_time do
       attr_type { :time }
-      name { 'reminder-in-time' }
-      presentation { 'reminder-in-time' }
+      name { 'end-time' }
+      presentation { 'end-time' }
+    end
+
+    trait :reminder_in_hours do
+      attr_type { :integer }
+      name { 'reminder-in-hours' }
+      presentation { 'reminder-in-hours' }
     end
 
     trait :duration_in_hours do

--- a/lib/spree_cm_commissioner/test_helper/factories/taxon_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/taxon_factory.rb
@@ -2,6 +2,10 @@ FactoryBot.define do
   factory :cm_taxon_event_section, parent: :taxon do
     kind { :event }
     sequence(:name) { |n| "Ticket Type #{n}" }
+
+    after(:build) do |taxon, evaluator|
+      taxon.taxonomy.update(kind: taxon.kind)
+    end
   end
 
   factory :cm_taxon_event, parent: :taxon do

--- a/spec/models/concerns/spree_cm_commissioner/variant_options_concern_spec.rb
+++ b/spec/models/concerns/spree_cm_commissioner/variant_options_concern_spec.rb
@@ -4,106 +4,6 @@ RSpec.describe SpreeCmCommissioner::VariantOptionsConcern do
   let(:option_values) { [option_value] }
   let(:variant) { create(:variant, option_values: option_values) }
 
-  describe "#location" do
-    context 'when variant has location option value' do
-      let(:state) { create(:state, name: 'Phnom Penh') }
-      let(:option_type) { create(:cm_option_type, :location) }
-      let(:option_value) { create(:cm_option_value, name: state.id, option_type: option_type) }
-
-      it 'return state id in integer' do
-        expect(variant.location).to eq state.id
-      end
-    end
-  end
-
-  describe "#start_date" do
-    context 'when variant has start_date option value' do
-      let(:option_type) { create(:cm_option_type, :start_date) }
-      let(:option_value) { create(:cm_option_value, name: '2024-05-31', option_type: option_type) }
-
-      it 'return start date in string' do
-        expect(variant.start_date).to eq '2024-05-31'
-      end
-    end
-  end
-
-  describe "#end_date" do
-    context 'when variant has end_date option value' do
-      let(:option_type) { create(:cm_option_type, :end_date) }
-      let(:option_value) { create(:cm_option_value, name: '2024-05-31', option_type: option_type) }
-
-      it 'return end date in string' do
-        expect(variant.end_date).to eq '2024-05-31'
-      end
-    end
-  end
-
-  describe "#start_time" do
-    context 'when variant has start_time option value' do
-      let(:option_type) { create(:cm_option_type, :start_time) }
-      let(:option_value) { create(:cm_option_value, name: '12:53:00', option_type: option_type) }
-
-      it 'return time in string' do
-        expect(variant.start_time).to eq '12:53:00'
-      end
-    end
-  end
-
-  describe "#reminder_in_time" do
-    context 'when variant has reminder_in_time option value' do
-      let(:option_type) { create(:cm_option_type, :reminder_in_time) }
-      let(:option_value) { create(:cm_option_value, name: '12:53:00', option_type: option_type) }
-
-      it 'return time in string' do
-        expect(variant.reminder_in_time).to eq '12:53:00'
-      end
-    end
-  end
-
-  describe "#duration_in_hours" do
-    context 'when variant has duration_in_hours option value' do
-      let(:option_type) { create(:cm_option_type, :duration_in_hours) }
-      let(:option_value) { create(:cm_option_value, name: '2', option_type: option_type) }
-
-      it 'return duration in integer' do
-        expect(variant.duration_in_hours).to eq 2
-      end
-    end
-  end
-
-  describe "#duration_in_minutes" do
-    context 'when variant has duration_in_minutes option value' do
-      let(:option_type) { create(:cm_option_type, :duration_in_minutes) }
-      let(:option_value) { create(:cm_option_value, name: '20', option_type: option_type) }
-
-      it 'return duration in integer' do
-        expect(variant.duration_in_minutes).to eq 20
-      end
-    end
-  end
-
-  describe "#duration_in_seconds" do
-    context 'when variant has duration_in_seconds option value' do
-      let(:option_type) { create(:cm_option_type, :duration_in_seconds) }
-      let(:option_value) { create(:cm_option_value, name: '3200', option_type: option_type) }
-
-      it 'return duration in integer' do
-        expect(variant.duration_in_seconds).to eq 3200
-      end
-    end
-  end
-
-  describe "#payment_option" do
-    context 'when variant has payment_option option value' do
-      let(:option_type) { create(:cm_option_type, :payment_option) }
-      let(:option_value) { create(:cm_option_value, name: 'post-paid', option_type: option_type) }
-
-      it 'return payment_option in string' do
-        expect(variant.payment_option).to eq 'post-paid'
-      end
-    end
-  end
-
   describe "#post_paid?" do
     let(:option_type) { create(:cm_option_type, :payment_option) }
     let(:option_value) { create(:cm_option_value, name: 'post-paid', option_type: option_type) }
@@ -114,161 +14,242 @@ RSpec.describe SpreeCmCommissioner::VariantOptionsConcern do
     end
   end
 
-  describe "#delivery_option" do
-    context 'when variant has delivery_option option value' do
-      let(:option_type) { create(:cm_option_type, :delivery_option) }
+  describe '#start_date_time' do
+    let(:option_type1) { create(:cm_option_type, :start_date) }
+    let(:option_value1) { create(:cm_option_value, name: '2024-01-01', option_type: option_type1) }
 
-      let(:option_value1) { create(:cm_option_value, name: 'delivery', option_type: option_type) }
-      let(:option_value2) { create(:cm_option_value, name: 'pickup', option_type: option_type) }
+    let(:option_type2) { create(:cm_option_type, :start_time) }
+    let(:option_value2) { create(:cm_option_value, name: '03:00:00', option_type: option_type2) }
 
-      it 'return delivery_option in string' do
-        variant1 = create(:variant, option_values: [option_value1])
-        variant2 = create(:variant, option_values: [option_value2])
+    let(:product) { create(:product, option_types: [option_type1, option_type2]) }
+    let(:variant) { create(:variant, product: product, option_values: [option_value1, option_value2]) }
 
-        expect(variant1.delivery_option).to eq 'delivery'
-        expect(variant2.delivery_option).to eq 'pickup'
+    it 'conbine start_date & start_time' do
+      expect(variant.start_date_time).to eq Time.zone.parse('2024-01-01 03:00:00')
+    end
+  end
+
+  describe '#end_date_time' do
+    let(:option_type1) { create(:cm_option_type, :end_date) }
+    let(:option_value1) { create(:cm_option_value, name: '2024-02-02', option_type: option_type1) }
+
+    let(:option_type2) { create(:cm_option_type, :end_time) }
+    let(:option_value2) { create(:cm_option_value, name: '05:00:00', option_type: option_type2) }
+
+    let(:product) { create(:product, option_types: [option_type1, option_type2]) }
+    let(:variant) { create(:variant, product: product, option_values: [option_value1, option_value2]) }
+
+    it 'conbine end_date & end_time' do
+      expect(variant.end_date_time).to eq Time.zone.parse('2024-02-02 05:00:00')
+    end
+  end
+
+  describe '#start_date' do
+    let(:section) { create(:cm_taxon_event_section, from_date: '2024-02-02'.to_date, to_date: '2024-03-03') }
+    let(:option_type) { create(:cm_option_type, :start_date) }
+    let(:option_value) { create(:cm_option_value, name: '2024-01-01', option_type: option_type) }
+
+    context 'when variant has event & [start_date] option value' do
+      let(:product) { create(:product, option_types: [option_type], taxons: [section]) }
+      let(:variant) { create(:variant, product: product, option_values: [option_value]) }
+
+      it 'return start_date of option value' do
+        expect(variant.event.from_date).to eq '2024-02-02'.to_date
+        expect(variant.options.start_date).to eq '2024-01-01'.to_date
+
+        expect(variant.start_date).to eq '2024-01-01'.to_date
       end
     end
 
-    context 'when variant has no delivery_option option value' do
-      let(:option_values) { [ create(:option_value, name: 'just-to-pass-variant-validation') ] }
+    context 'when variant has event & no [start_date] option value' do
+      let(:product) { create(:product, taxons: [section]) }
+      let(:variant) { create(:variant, product: product) }
 
-      it 'return nil' do
-        expect(variant.delivery_option).to eq nil
+      it 'return start_date of event' do
+        expect(variant.event.from_date).to eq '2024-02-02'.to_date
+        expect(variant.options.start_date).to eq nil
+
+        expect(variant.start_date).to eq '2024-02-02'.to_date
+      end
+    end
+
+    context 'when variant has no event & no [start_date] option value' do
+      let(:product) { create(:product) }
+      let(:variant) { create(:variant, product: product) }
+
+      it 'return null' do
+        expect(variant.event&.from_date).to eq nil
+        expect(variant.options.start_date).to eq nil
+
+        expect(variant.start_date).to eq nil
       end
     end
   end
 
-  describe "#max_quantity_per_order" do
-    context 'when variant has max_quantity_per_order option value' do
-      let(:option_type) { create(:cm_option_type, :max_quantity_per_order) }
-      let(:option_value) { create(:cm_option_value, name: '1', option_type: option_type) }
+  describe '#end_date' do
+    context 'when variant has duration option values' do
+      let(:section) { create(:cm_taxon_event_section, from_date: '2024-02-02') }
 
-      it 'return in integer' do
-        expect(variant.max_quantity_per_order).to eq 1
+      let(:duration_in_hours) { create(:cm_option_type, :duration_in_hours) }
+      let(:duration_in_minutes) { create(:cm_option_type, :duration_in_minutes) }
+      let(:duration_in_seconds) { create(:cm_option_type, :duration_in_seconds) }
+
+      let(:two_hours) { create(:cm_option_value, name: '2', option_type: duration_in_hours) }
+      let(:thirdty_minutes) { create(:cm_option_value, name: '30', option_type: duration_in_minutes) }
+      let(:sixty_seconds) { create(:cm_option_value, name: '60', option_type: duration_in_seconds) }
+
+      let(:product) { create(:product, taxons: [section], option_types: [duration_in_hours, duration_in_minutes, duration_in_seconds]) }
+      let(:variant) { create(:variant, product: product, option_values: [two_hours, thirdty_minutes, sixty_seconds]) }
+
+      it 'end date combine of start_date + durations' do
+        expect(variant.end_date).to eq '2024-02-02'.to_date + 2.hours + 30.minutes + 60.seconds
+      end
+    end
+
+    context 'when variant has no duration option values' do
+      let(:section) { create(:cm_taxon_event_section, from_date: '2024-02-02', to_date: '2024-03-03') }
+      let(:option_type) { create(:cm_option_type, :end_date) }
+      let(:option_value) { create(:cm_option_value, name: '2024-01-01', option_type: option_type) }
+
+      context 'when variant has event & [end_date] option value' do
+        let(:product) { create(:product, option_types: [option_type], taxons: [section]) }
+        let(:variant) { create(:variant, product: product, option_values: [option_value]) }
+
+        it 'return end_date of option value' do
+          expect(variant.event.to_date).to eq '2024-03-03'.to_date
+          expect(variant.options.end_date).to eq '2024-01-01'.to_date
+
+          expect(variant.end_date).to eq '2024-01-01'.to_date
+        end
+      end
+
+      context 'when variant has event & no [end_date] option value' do
+        let(:product) { create(:product, taxons: [section]) }
+        let(:variant) { create(:variant, product: product) }
+
+        it 'return end_date of event' do
+          expect(variant.event.to_date).to eq '2024-03-03'.to_date
+          expect(variant.options.end_date).to eq nil
+
+          expect(variant.end_date).to eq '2024-03-03'.to_date
+        end
+      end
+
+      context 'when variant has no event & no [end_date] option value' do
+        let(:product) { create(:product) }
+        let(:variant) { create(:variant, product: product) }
+
+        it 'return null' do
+          expect(variant.event&.from_date).to eq nil
+          expect(variant.options.end_date).to eq nil
+
+          expect(variant.end_date).to eq nil
+        end
       end
     end
   end
 
-  describe "#due_date" do
-    context 'when variant has due_date option value' do
-      let(:option_type) { create(:cm_option_type, :due_date) }
-      let(:option_value) { create(:cm_option_value, name: '10', option_type: option_type) }
+  describe '#start_time' do
+    let(:section) { create(:cm_taxon_event_section, from_date: '2024-02-02 13:00:00', to_date: '2024-03-03 17:00:00') }
+    let(:option_type) { create(:cm_option_type, :start_time) }
+    let(:option_value) { create(:cm_option_value, name: '03:00:00', option_type: option_type) }
 
-      it 'return due_date in days integer' do
-        expect(variant.due_date).to eq 10
+    context 'when variant has event & [start_time] option value' do
+      let(:product) { create(:product, option_types: [option_type], taxons: [section]) }
+      let(:variant) { create(:variant, product: product, option_values: [option_value]) }
+
+      it 'return start_time of option value' do
+        expect(variant.event.from_date).to eq Time.zone.parse('2024-02-02 13:00:00')
+        expect(variant.options.start_time).to eq Time.zone.parse('03:00:00')
+
+        expect(variant.start_time.strftime('%H:%M:%S')).to eq '03:00:00'
+      end
+    end
+
+    context 'when variant has event & no [start_time] option value' do
+      let(:product) { create(:product, taxons: [section]) }
+      let(:variant) { create(:variant, product: product) }
+
+      it 'return start_time of event instead' do
+        expect(variant.event.from_date).to eq Time.zone.parse('2024-02-02 13:00:00')
+        expect(variant.options.start_time).to eq nil
+
+        expect(variant.start_time.strftime('%H:%M:%S')).to eq '13:00:00'
+      end
+    end
+
+    context 'when variant has no event & no [start_time] option value' do
+      let(:product) { create(:product) }
+      let(:variant) { create(:variant, product: product) }
+
+      it 'return null' do
+        expect(variant.event&.from_date).to eq nil
+        expect(variant.options.start_time).to eq nil
+
+        expect(variant.start_time).to eq nil
       end
     end
   end
 
-  describe "#month" do
-    context 'when variant has month option value' do
-      let(:option_type) { create(:cm_option_type, :month) }
-      let(:option_value) { create(:cm_option_value, name: '10', option_type: option_type) }
+  describe '#end_time' do
+    context 'when variant has duration option values' do
+      let(:section) { create(:cm_taxon_event_section, from_date: '2024-02-02 03:00:00') }
 
-      it 'return month in integer' do
-        expect(variant.month).to eq 10
-      end
-    end
-  end
+      let(:duration_in_hours) { create(:cm_option_type, :duration_in_hours) }
+      let(:duration_in_minutes) { create(:cm_option_type, :duration_in_minutes) }
+      let(:duration_in_seconds) { create(:cm_option_type, :duration_in_seconds) }
 
-  describe "#number_of_adults" do
-    context 'when variant has number_of_adults option value' do
-      let(:option_type) { create(:cm_option_type, :number_of_adults) }
-      let(:option_value) { create(:cm_option_value, name: '10', option_type: option_type) }
+      let(:two_hours) { create(:cm_option_value, name: '2', option_type: duration_in_hours) }
+      let(:thirdty_minutes) { create(:cm_option_value, name: '30', option_type: duration_in_minutes) }
+      let(:sixty_seconds) { create(:cm_option_value, name: '60', option_type: duration_in_seconds) }
 
-      it 'return number_of_adults in integer' do
-        expect(variant.number_of_adults).to eq 10
-      end
-    end
+      let(:product) { create(:product, taxons: [section], option_types: [duration_in_hours, duration_in_minutes, duration_in_seconds]) }
+      let(:variant) { create(:variant, product: product, option_values: [two_hours, thirdty_minutes, sixty_seconds]) }
 
-    context 'when variant has no option value' do
-      let(:option_values) { [ create(:option_value) ] }
-
-      it 'return DEFAULT_NUMBER_OF_ADULTS by default' do
-        expect(variant.number_of_adults).to eq described_class::DEFAULT_NUMBER_OF_ADULTS
-      end
-    end
-  end
-
-  describe "#number_of_kids" do
-    context 'when variant has number_of_kids option value' do
-      let(:option_type) { create(:cm_option_type, :number_of_kids) }
-      let(:option_value) { create(:cm_option_value, name: '10', option_type: option_type) }
-
-      it 'return number_of_kids in integer' do
-        expect(variant.number_of_kids).to eq 10
+      it 'end date combine of from_date + durations' do
+        expect(variant.end_time.strftime('%H:%M:%S')).to eq('05:31:00')
       end
     end
 
-    context 'when variant has no option value' do
-      let(:option_values) { [ create(:option_value) ] }
+    context 'when variant has no duration option values' do
+      let(:section) { create(:cm_taxon_event_section, from_date: '2024-02-02 13:00:00', to_date: '2024-03-03 17:00:00') }
+      let(:option_type) { create(:cm_option_type, :end_time) }
+      let(:option_value) { create(:cm_option_value, name: '03:00:00', option_type: option_type) }
 
-      it 'return 0 by default' do
-        expect(variant.number_of_kids).to eq 0
+      context 'when variant has event & [end_time] option value' do
+        let(:product) { create(:product, option_types: [option_type], taxons: [section]) }
+        let(:variant) { create(:variant, product: product, option_values: [option_value]) }
+
+        it 'return end_time of option value' do
+          expect(variant.event.to_date).to eq Time.zone.parse('2024-03-03 17:00:00')
+          expect(variant.options.end_time).to eq Time.zone.parse('03:00:00')
+
+          expect(variant.end_time.strftime('%H:%M:%S')).to eq '03:00:00'
+        end
       end
-    end
-  end
 
-  describe "#number_of_guests" do
-    let(:option_type1) { create(:cm_option_type, :number_of_adults) }
-    let(:option_type2) { create(:cm_option_type, :number_of_kids) }
+      context 'when variant has event & no [end_time] option value' do
+        let(:product) { create(:product, taxons: [section]) }
+        let(:variant) { create(:variant, product: product) }
 
-    let(:option_value1) { create(:cm_option_value, name: '2', option_type: option_type1) }
-    let(:option_value2) { create(:cm_option_value, name: '3', option_type: option_type2) }
+        it 'return end_time of event instead' do
+          expect(variant.event.to_date).to eq Time.zone.parse('2024-03-03 17:00:00')
+          expect(variant.options.end_time).to eq nil
 
-    let(:option_values) { [option_value1, option_value2] }
-
-    it 'return sum of kids + adults' do
-      expect(variant.number_of_guests).to eq 2 + 3
-    end
-  end
-
-  describe "#kids_age_max" do
-    context 'when variant has kids_age_max option value' do
-      let(:option_type) { create(:cm_option_type, :kids_age_max) }
-      let(:option_value) { create(:cm_option_value, name: '10', option_type: option_type) }
-
-      it 'return kids_age_max in integer' do
-        expect(variant.kids_age_max).to eq 10
+          expect(variant.end_time.strftime('%H:%M:%S')).to eq '17:00:00'
+        end
       end
-    end
 
-    context 'when variant has no kids_age_max option value' do
-      let(:option_values) { [ create(:option_value, name: 'just-to-skip-variant-validation') ] }
+      context 'when variant has no event & no [end_time] option value' do
+        let(:product) { create(:product) }
+        let(:variant) { create(:variant, product: product) }
 
-      it 'return default age max' do
-        expect(variant.kids_age_max).to eq described_class::DEFAULT_KIDS_AGE_MAX
-      end
-    end
-  end
+        it 'return null' do
+          expect(variant.event&.from_date).to eq nil
+          expect(variant.options.end_time).to eq nil
 
-  describe "#allowed_extra_adults" do
-    context 'when variant has allowed_extra_adults option value' do
-      let(:option_type) { create(:cm_option_type, :allowed_extra_adults) }
-      let(:option_value) { create(:cm_option_value, name: '10', option_type: option_type) }
-
-      it 'return allowed_extra_adults in integer' do
-        expect(variant.allowed_extra_adults).to eq 10
-      end
-    end
-  end
-
-  describe "#allowed_extra_kids" do
-    context 'when variant has allowed_extra_kids option value' do
-      let(:option_type) { create(:cm_option_type, :allowed_extra_kids) }
-      let(:option_value) { create(:cm_option_value, name: '10', option_type: option_type) }
-
-      it 'return allowed_extra_kids in integer' do
-        expect(variant.allowed_extra_kids).to eq 10
-      end
-    end
-
-    context 'when variant has no allowed_extra_kids option value' do
-      let(:option_values) { [ create(:option_value) ] }
-
-      it 'return 0 by default' do
-        expect(variant.allowed_extra_kids).to eq 0
+          expect(variant.end_time).to eq nil
+        end
       end
     end
   end

--- a/spec/models/spree/option_type_spec.rb
+++ b/spec/models/spree/option_type_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Spree::OptionType, type: :model do
       it 'return only promoted option types' do
         option_type1 = create(:option_type, promoted: true)
         option_type2 = create(:option_type, promoted: false)
-  
+
         expect(described_class.promoted.size).to eq 1
         expect(described_class.promoted.first).to eq option_type1
       end
@@ -42,6 +42,26 @@ RSpec.describe Spree::OptionType, type: :model do
       expect(option_type.vendor?).to eq true
       expect(option_type.kind_changed?).to eq true
       expect{option_type.save!}.to raise_error ActiveRecord::RecordInvalid
+    end
+  end
+
+  describe 'callback after_save' do
+    describe '#sort_date_time_option_values' do
+      let(:date_option_type1) { create(:option_value, name: '2024-01-01') }
+      let(:date_option_type2) { create(:option_value, name: '2025-01-01') }
+      let(:date_option_type3) { create(:option_value, name: '2022-01-01') }
+
+      let(:time_option_type1) { create(:option_value, name: '03:00:00') }
+      let(:time_option_type2) { create(:option_value, name: '05:00:00') }
+      let(:time_option_type3) { create(:option_value, name: '01:00:00') }
+
+      let(:date_option_type) { create(:option_type, attr_type: 'date', option_values: [date_option_type1, date_option_type2, date_option_type3]) }
+      let(:time_option_type) { create(:option_type, attr_type: 'time', option_values: [time_option_type1, time_option_type2, time_option_type3]) }
+
+      it 'sort date & time option values' do
+        expect(date_option_type.option_values.reload.pluck(:name)).to eq(['2025-01-01', '2024-01-01', '2022-01-01'])
+        expect(time_option_type.option_values.reload.pluck(:name)).to eq(['05:00:00', '03:00:00', '01:00:00'])
+      end
     end
   end
 end

--- a/spec/models/spree_cm_commissioner/variant_options_spec.rb
+++ b/spec/models/spree_cm_commissioner/variant_options_spec.rb
@@ -1,0 +1,270 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::VariantOptions do
+  let(:option_values) { [option_value] }
+  let(:variant) { create(:variant, option_values: option_values) }
+
+  subject { described_class.new(variant) }
+
+  describe "#location" do
+    context 'when variant has location option value' do
+      let(:state) { create(:state, name: 'Phnom Penh') }
+      let(:option_type) { create(:cm_option_type, :location) }
+      let(:option_value) { create(:cm_option_value, name: state.id, option_type: option_type) }
+
+      it 'return state id in integer' do
+        expect(subject.location).to eq state.id
+      end
+    end
+  end
+
+  describe "#start_date" do
+    context 'when variant has start_date option value' do
+      let(:option_type) { create(:cm_option_type, :start_date) }
+      let(:option_value) { create(:cm_option_value, name: '2024-05-31', option_type: option_type) }
+
+      it 'return start date in string' do
+        expect(subject.start_date).to eq Time.zone.parse('2024-05-31')
+      end
+    end
+  end
+
+  describe "#end_date" do
+    context 'when variant has end_date option value' do
+      let(:option_type) { create(:cm_option_type, :end_date) }
+      let(:option_value) { create(:cm_option_value, name: '2024-05-31', option_type: option_type) }
+
+      it 'return end date in string' do
+        expect(subject.end_date).to eq Time.zone.parse('2024-05-31')
+      end
+    end
+  end
+
+  describe "#start_time" do
+    context 'when variant has start_time option value' do
+      let(:option_type) { create(:cm_option_type, :start_time) }
+      let(:option_value) { create(:cm_option_value, name: '12:53:00', option_type: option_type) }
+
+      it 'return time in string' do
+        expect(subject.start_time).to eq Time.zone.parse('12:53:00')
+      end
+    end
+  end
+
+  describe "#reminder_in_hours" do
+    context 'when variant has reminder_in_hours option value' do
+      let(:option_type) { create(:cm_option_type, :reminder_in_hours) }
+      let(:option_value) { create(:cm_option_value, name: '4', option_type: option_type) }
+
+      it 'return reminder in hours in integer' do
+        expect(subject.reminder_in_hours).to eq 4
+      end
+    end
+  end
+
+  describe "#duration_in_hours" do
+    context 'when variant has duration_in_hours option value' do
+      let(:option_type) { create(:cm_option_type, :duration_in_hours) }
+      let(:option_value) { create(:cm_option_value, name: '2', option_type: option_type) }
+
+      it 'return duration in integer' do
+        expect(subject.duration_in_hours).to eq 2
+      end
+    end
+  end
+
+  describe "#duration_in_minutes" do
+    context 'when variant has duration_in_minutes option value' do
+      let(:option_type) { create(:cm_option_type, :duration_in_minutes) }
+      let(:option_value) { create(:cm_option_value, name: '20', option_type: option_type) }
+
+      it 'return duration in integer' do
+        expect(subject.duration_in_minutes).to eq 20
+      end
+    end
+  end
+
+  describe "#duration_in_seconds" do
+    context 'when variant has duration_in_seconds option value' do
+      let(:option_type) { create(:cm_option_type, :duration_in_seconds) }
+      let(:option_value) { create(:cm_option_value, name: '3200', option_type: option_type) }
+
+      it 'return duration in integer' do
+        expect(subject.duration_in_seconds).to eq 3200
+      end
+    end
+  end
+
+  describe "#payment_option" do
+    context 'when variant has payment_option option value' do
+      let(:option_type) { create(:cm_option_type, :payment_option) }
+      let(:option_value) { create(:cm_option_value, name: 'post-paid', option_type: option_type) }
+
+      it 'return payment_option in string' do
+        expect(subject.payment_option).to eq 'post-paid'
+      end
+    end
+  end
+
+  describe "#delivery_option" do
+    context 'when variant has delivery_option option value' do
+      let(:option_type) { create(:cm_option_type, :delivery_option) }
+
+      let(:option_value1) { create(:cm_option_value, name: 'delivery', option_type: option_type) }
+      let(:option_value2) { create(:cm_option_value, name: 'pickup', option_type: option_type) }
+
+      it 'return delivery_option in string' do
+        variant1 = create(:variant, option_values: [option_value1])
+        variant2 = create(:variant, option_values: [option_value2])
+
+        subject1 = described_class.new(variant1)
+        subject2 = described_class.new(variant2)
+
+        expect(subject1.delivery_option).to eq 'delivery'
+        expect(subject2.delivery_option).to eq 'pickup'
+      end
+    end
+
+    context 'when variant has no delivery_option option value' do
+      let(:option_values) { [ create(:option_value, name: 'just-to-pass-variant-validation') ] }
+
+      it 'return nil' do
+        expect(subject.delivery_option).to eq nil
+      end
+    end
+  end
+
+  describe "#max_quantity_per_order" do
+    context 'when variant has max_quantity_per_order option value' do
+      let(:option_type) { create(:cm_option_type, :max_quantity_per_order) }
+      let(:option_value) { create(:cm_option_value, name: '1', option_type: option_type) }
+
+      it 'return in integer' do
+        expect(subject.max_quantity_per_order).to eq 1
+      end
+    end
+  end
+
+  describe "#due_date" do
+    context 'when variant has due_date option value' do
+      let(:option_type) { create(:cm_option_type, :due_date) }
+      let(:option_value) { create(:cm_option_value, name: '10', option_type: option_type) }
+
+      it 'return due_date in days integer' do
+        expect(subject.due_date).to eq 10
+      end
+    end
+  end
+
+  describe "#month" do
+    context 'when variant has month option value' do
+      let(:option_type) { create(:cm_option_type, :month) }
+      let(:option_value) { create(:cm_option_value, name: '10', option_type: option_type) }
+
+      it 'return month in integer' do
+        expect(subject.month).to eq 10
+      end
+    end
+  end
+
+  describe "#number_of_adults" do
+    context 'when variant has number_of_adults option value' do
+      let(:option_type) { create(:cm_option_type, :number_of_adults) }
+      let(:option_value) { create(:cm_option_value, name: '10', option_type: option_type) }
+
+      it 'return number_of_adults in integer' do
+        expect(subject.number_of_adults).to eq 10
+      end
+    end
+
+    context 'when variant has no option value' do
+      let(:option_values) { [ create(:option_value) ] }
+
+      it 'return DEFAULT_NUMBER_OF_ADULTS by default' do
+        expect(subject.number_of_adults).to eq described_class::DEFAULT_NUMBER_OF_ADULTS
+      end
+    end
+  end
+
+  describe "#number_of_kids" do
+    context 'when variant has number_of_kids option value' do
+      let(:option_type) { create(:cm_option_type, :number_of_kids) }
+      let(:option_value) { create(:cm_option_value, name: '10', option_type: option_type) }
+
+      it 'return number_of_kids in integer' do
+        expect(subject.number_of_kids).to eq 10
+      end
+    end
+
+    context 'when variant has no option value' do
+      let(:option_values) { [ create(:option_value) ] }
+
+      it 'return 0 by default' do
+        expect(subject.number_of_kids).to eq 0
+      end
+    end
+  end
+
+  describe "#number_of_guests" do
+    let(:option_type1) { create(:cm_option_type, :number_of_adults) }
+    let(:option_type2) { create(:cm_option_type, :number_of_kids) }
+
+    let(:option_value1) { create(:cm_option_value, name: '2', option_type: option_type1) }
+    let(:option_value2) { create(:cm_option_value, name: '3', option_type: option_type2) }
+
+    let(:option_values) { [option_value1, option_value2] }
+
+    it 'return sum of kids + adults' do
+      expect(subject.number_of_guests).to eq 2 + 3
+    end
+  end
+
+  describe "#kids_age_max" do
+    context 'when variant has kids_age_max option value' do
+      let(:option_type) { create(:cm_option_type, :kids_age_max) }
+      let(:option_value) { create(:cm_option_value, name: '10', option_type: option_type) }
+
+      it 'return kids_age_max in integer' do
+        expect(subject.kids_age_max).to eq 10
+      end
+    end
+
+    context 'when variant has no kids_age_max option value' do
+      let(:option_values) { [ create(:option_value, name: 'just-to-skip-variant-validation') ] }
+
+      it 'return default age max' do
+        expect(subject.kids_age_max).to eq described_class::DEFAULT_KIDS_AGE_MAX
+      end
+    end
+  end
+
+  describe "#allowed_extra_adults" do
+    context 'when variant has allowed_extra_adults option value' do
+      let(:option_type) { create(:cm_option_type, :allowed_extra_adults) }
+      let(:option_value) { create(:cm_option_value, name: '10', option_type: option_type) }
+
+      it 'return allowed_extra_adults in integer' do
+        expect(subject.allowed_extra_adults).to eq 10
+      end
+    end
+  end
+
+  describe "#allowed_extra_kids" do
+    context 'when variant has allowed_extra_kids option value' do
+      let(:option_type) { create(:cm_option_type, :allowed_extra_kids) }
+      let(:option_value) { create(:cm_option_value, name: '10', option_type: option_type) }
+
+      it 'return allowed_extra_kids in integer' do
+        expect(subject.allowed_extra_kids).to eq 10
+      end
+    end
+
+    context 'when variant has no allowed_extra_kids option value' do
+      let(:option_values) { [ create(:option_value) ] }
+
+      it 'return 0 by default' do
+        expect(subject.allowed_extra_kids).to eq 0
+      end
+    end
+  end
+end

--- a/spec/serializers/spree/v2/storefront/variant_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/variant_serializer_spec.rb
@@ -37,7 +37,7 @@ describe Spree::V2::Storefront::VariantSerializer, type: :serializer do
         :kyc,
         :need_confirmation,
         :product_type,
-        :reminder_in_time,
+        :reminder_in_hours,
         :start_time,
         :max_quantity_per_order,
         :number_of_guests,


### PR DESCRIPTION
Some products required specific date instead of just date from event. 

### Test on staging:
<img width="250" alt="image" src="https://github.com/channainfo/commissioner/assets/29684683/9024ee9d-8080-4b76-8055-6292f25860ca">

-----

For above case, admin just need to set these 3 option types to variant:

| |
| - |
| ![](https://github.com/channainfo/commissioner/assets/29684683/bacb7245-0634-4479-89e5-95f24bf35720) |
| ![](https://github.com/channainfo/commissioner/assets/29684683/f8dbecb2-08a4-4145-9a9b-ae4ace97e94e) |
