### PR TITLE
close #1643 auto create option value when editing variant

### DIFF
--- a/app/controllers/spree_cm_commissioner/admin/variants_controller_decorator.rb
+++ b/app/controllers/spree_cm_commissioner/admin/variants_controller_decorator.rb
@@ -1,0 +1,47 @@
+module SpreeCmCommissioner
+  module Admin
+    module VariantsControllerDecorator
+      def self.prepended(base)
+        base.before_action :build_option_values_form, only: %i[edit new]
+        base.before_action :build_option_values, only: %i[create update]
+      end
+
+      # build option values that not exist. All option values will display to UI.
+      def build_option_values_form
+        @product.variant_kind_option_types.each do |option_type|
+          @variant.option_values.build(option_type: option_type) if @variant.option_values.find_by(option_type_id: option_type.id).blank?
+        end
+      end
+
+      # construct option values base on name & create new option value when not exist.
+      # then set to variant.
+      def build_option_values
+        option_values = permitted_resource_params.delete(:option_values_attributes).to_h.values
+        return if option_values.blank?
+
+        @object.option_values = option_values.each_with_object([]) do |option_value, new_option_values|
+          option_value_name = validated_option_value_name(option_value[:name], option_value[:option_type_id])
+          next if option_value_name.blank?
+
+          option_type = @product.option_types.find(option_value[:option_type_id])
+          existing_option_value = option_type.option_values.find_or_create_by(name: option_value_name)
+
+          new_option_values << existing_option_value
+        end
+      end
+
+      # some option value name changed after validate.
+      def validated_option_value_name(name, option_type_id)
+        return nil if name.blank?
+
+        option_value = Spree::OptionValue.new(name: name, option_type_id: option_type_id)
+        option_value.validate
+        option_value.name
+      end
+    end
+  end
+end
+
+unless Spree::Admin::VariantsController.ancestors.include?(SpreeCmCommissioner::Admin::VariantsControllerDecorator)
+  Spree::Admin::VariantsController.prepend(SpreeCmCommissioner::Admin::VariantsControllerDecorator)
+end

--- a/app/models/spree_cm_commissioner/variant_decorator.rb
+++ b/app/models/spree_cm_commissioner/variant_decorator.rb
@@ -18,6 +18,8 @@ module SpreeCmCommissioner
       base.has_one :video_on_demand, class_name: 'SpreeCmCommissioner::VideoOnDemand', dependent: :destroy
 
       base.scope :subscribable, -> { active.joins(:product).where(product: { subscribable: true, status: :active }) }
+
+      base.accepts_nested_attributes_for :option_values
     end
 
     def option_value_name_for(option_type_name: nil)

--- a/app/overrides/spree/admin/variants/_form/option_types_replacer.html.erb.deface
+++ b/app/overrides/spree/admin/variants/_form/option_types_replacer.html.erb.deface
@@ -1,14 +1,3 @@
 <!-- insert_top "[data-hook='variants']" -->
 
-<% @product.variant_kind_option_types.each do |option_type| %>
-  <div class="form-group" data-hook="presentation">
-    <%= label :new_variant, option_type.presentation %>
-    <% if option_type.name == 'color' %>
-      <%= f.collection_select 'option_value_ids', option_type.option_values, :id, :name,
-        { include_blank: true }, { name: 'variant[option_value_ids][]', class: 'select2-clear', id: "option_value_ids-#{option_type.id}" } %>
-    <% else %>
-      <%= f.collection_select 'option_value_ids', option_type.option_values, :id, :presentation,
-        { include_blank: true }, { name: 'variant[option_value_ids][]', class: 'select2-clear', id: "option_value_ids-#{option_type.id}"  } %>
-    <% end %>
-  </div>
-<% end %>
+<%= render partial: 'spree/admin/variants/option_values', locals: { f: f } %>

--- a/app/overrides/spree/admin/variants/edit/card-header.html.erb.deface
+++ b/app/overrides/spree/admin/variants/edit/card-header.html.erb.deface
@@ -1,0 +1,10 @@
+<!-- replace ".card-header" -->
+
+<% header = @variant.sku || @variant.options_text %>
+<% if header.present? %>
+  <div class="card-header">
+    <h5 class="mb-0"><%= header %></h5>
+  </div>
+<% else %>
+  <hr class="m-0">
+<% end %>

--- a/app/overrides/spree/admin/variants/edit/variant_status.html.erb.deface
+++ b/app/overrides/spree/admin/variants/edit/variant_status.html.erb.deface
@@ -1,0 +1,22 @@
+<!-- insert_top ".card" -->
+
+<% unless f.object.accommodation? %>
+  <div class="m-3 mb-0">
+    <% valid_duration = f.object.start_date_time.present? && f.object.end_date_time.present? %>
+    <% alert_class = valid_duration ? 'alert-success' : 'alert-warning' %>
+
+    <div class="alert <%= alert_class %> mb-0">
+      <%= svg_icon(name: valid_duration ? "check2-circle.svg" : 'cancel.svg', width: '16', height: '16') %>
+      This variant have start date: <strong><%= pretty_time(f.object.start_date_time).presence || 'N/A' %></strong> and end date: <strong><%= pretty_time(f.object.end_date_time).presence || 'N/A' %></strong>
+    </div>
+
+    <div class="mb-1"></div>
+    <small class="text-muted">
+      <%= svg_icon(name: 'card-checklist', width: '16', height: '16') %>
+      <% option_types = Spree::OptionType.where(name: ["start-date", "end-date", "start-time", "end-time", "reminder-in-hours", "duration-in-hours", "duration-in-minutes", "duration-in-seconds"]) %>
+      <% event_link = f.object.event.present? ? edit_admin_taxonomy_taxon_url(f.object.event.taxonomy.id, f.object.event.id) : edit_admin_product_url(f.object.product) %>
+
+      Duration can be set by either adding <%= link_to 'event section date', event_link, target: '_blank' %> or add option type such as <%= option_types.pluck(:presentation).to_sentence %>
+    </small>
+  </div>
+<% end %>

--- a/app/views/spree/admin/variants/_date_field.html.erb
+++ b/app/views/spree/admin/variants/_date_field.html.erb
@@ -1,0 +1,1 @@
+<%= f.date_field :name, value: f.object.date, class: 'rounded-left form-control bg-transparent' %>

--- a/app/views/spree/admin/variants/_default_field.html.erb
+++ b/app/views/spree/admin/variants/_default_field.html.erb
@@ -1,0 +1,5 @@
+<% option_type = f.object.option_type %>
+
+<%= f.collection_select :name, option_type.option_values, :name, :presentation,
+  { include_blank: true },
+  { class: 'select2-clear', id: "option_value_ids-#{option_type.id}"  } %>

--- a/app/views/spree/admin/variants/_option_values.html.erb
+++ b/app/views/spree/admin/variants/_option_values.html.erb
@@ -1,0 +1,35 @@
+<%= f.fields_for :option_values do |ff| %>
+  <% option_type = ff.object.option_type %>
+
+  <div class="form-group" data-hook="presentation">
+    <%= label :new_variant, option_type.presentation %>
+    <%= link_to_with_icon 'edit.svg', Spree.t(:edit), edit_admin_option_type_url(option_type), no_text: true, target: '_blank' %>
+
+    <% case option_type.attr_type %>
+    <% when "float" %>
+      <%= render partial: 'default_field', locals: { f: ff } %>
+    <% when "integer" %>
+      <%= render partial: 'default_field', locals: { f: ff } %>
+    <% when "string" %>
+      <%= render partial: 'default_field', locals: { f: ff } %>
+    <% when "boolean" %>
+      <%= render partial: 'default_field', locals: { f: ff } %>
+    <% when "date" %>
+      <%= render partial: 'date_field', locals: { f: ff } %>
+    <% when "time" %>
+      <%= render partial: 'time_field', locals: { f: ff } %>
+    <% when "coordinate" %>
+      <%= render partial: 'default_field', locals: { f: ff } %>
+    <% when "state_selection" %>
+      <%= render partial: 'default_field', locals: { f: ff } %>
+    <% when "payment_option" %>
+      <%= render partial: 'default_field', locals: { f: ff } %>
+    <% when "delivery_option" %>
+      <%= render partial: 'default_field', locals: { f: ff } %>
+    <% else %>
+      <%= render partial: 'default_field', locals: { f: ff } %>
+    <% end %>
+
+    <%= ff.hidden_field :option_type_id, value: option_type.id %>
+  </div>
+<% end %>

--- a/app/views/spree/admin/variants/_time_field.html.erb
+++ b/app/views/spree/admin/variants/_time_field.html.erb
@@ -1,0 +1,6 @@
+<div class="input-group">
+  <div class="input-group-prepend">
+    <span class="input-group-text"><%= svg_icon name: "clock.svg", width: '14', height: '14' %></span>
+  </div>
+  <%= time_select f.object_name, "name[time]", { ampm: true, time_separator: "", minute_step: 5, default: { hour: f.object.time&.hour, minute: f.object.time&.min } }, { class: 'form-control' } %>
+</div>


### PR DESCRIPTION
After this, admin doesn't have to go to option type to pre-create option values.

| |
| - |
| ![image](https://github.com/user-attachments/assets/072605f6-5f67-40ca-9d49-e95a6bfe8051) |
| ![image](https://github.com/user-attachments/assets/dfa095e7-f1f9-4eb3-8911-7af489dec2c8) |

