### PR TITLE
Close #1656 validate longitude and latitude for self check-in

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -128,6 +128,9 @@ en:
     created_successfully: "Place was successfully added to product."
     place_required: "Please select a place before creating the product place."
 
+  self_check_in:
+    invalid_distance: "Invalid Check-in distance"
+
   telegram_chat_bot:
     vendor_channel_group_info: "This channel/group will be recieve order notifications"
     only_for_authorized_user_info: "Only authorized users can approve/reject line items, make sure to input their telegram username"


### PR DESCRIPTION
## Functionality:
- This is an enhancement of our self check-in feature.
- Now, we improve it by validate the between the user's location and the venue location.

## Demo:

https://github.com/user-attachments/assets/982556c4-6fcb-409f-9964-7d0554e2dc1e

