### PR TITLE
close #1678 implement video required on product

### DIFF
--- a/app/controllers/spree/admin/video_on_demands_controller.rb
+++ b/app/controllers/spree/admin/video_on_demands_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Admin
     class VideoOnDemandsController < Spree::Admin::ResourceController
-      before_action :load_parent
+      before_action :product
       before_action :load_video_on_demands, only: %i[index new edit create]
 
       def new
@@ -35,6 +35,13 @@ module Spree
         end
       end
 
+      def update_positions
+        params[:positions].each do |id, index|
+          video_on_demand = SpreeCmCommissioner::VideoOnDemand.find(id)
+          video_on_demand.update(position: index)
+        end
+      end
+
       private
 
       def model_class
@@ -49,13 +56,25 @@ module Spree
         admin_product_video_on_demands_url(options)
       end
 
-      def load_parent
+      def product
         @product ||= Spree::Product.find_by(slug: params[:product_id])
       end
 
       def load_video_on_demands
-        @variants = @product.variants.includes(:video_on_demand)
-        @video_on_demands = @product.variants.includes(:video_on_demand).map(&:video_on_demand).compact
+        @video_on_demands = []
+        @product.variants.each do |variant|
+          @video_on_demands.concat(variant.video_on_demands.to_a)
+        end
+
+        @variants = @product.variants.map do |variant|
+          [variant.options_text, variant.id]
+        end
+
+        return unless @product.use_video_as_default?
+
+        video_on_demand = SpreeCmCommissioner::VideoOnDemand.where(variant_id: @product.master_id).to_a
+        @variants.insert(0, [Spree.t(:default), @product.master_id])
+        @video_on_demands.concat(video_on_demand)
       end
     end
   end

--- a/app/models/spree_cm_commissioner/variant_decorator.rb
+++ b/app/models/spree_cm_commissioner/variant_decorator.rb
@@ -15,7 +15,7 @@ module SpreeCmCommissioner
                                               joins(:option_type).where(spree_option_types: { hidden: false })
                                             }, through: :option_value_variants, source: :option_value
 
-      base.has_one :video_on_demand, class_name: 'SpreeCmCommissioner::VideoOnDemand', dependent: :destroy
+      base.has_many :video_on_demands, class_name: 'SpreeCmCommissioner::VideoOnDemand', dependent: :destroy
 
       base.scope :subscribable, -> { active.joins(:product).where(product: { subscribable: true, status: :active }) }
 

--- a/app/overrides/spree/admin/products/_form/use_video_as_default.html.erb.deface
+++ b/app/overrides/spree/admin/products/_form/use_video_as_default.html.erb.deface
@@ -1,0 +1,9 @@
+<!-- insert_after "[data-hook='admin_product_form_promotionable']" -->
+
+<div data-hook="admin_product_form_use_video_as_default">
+  <%= f.field_container :use_video_as_default do %>
+    <%= f.check_box :use_video_as_default %>
+    <%= f.label :use_video_as_default, Spree.t(:use_video_as_default) %>
+    <%= f.error_message_on :use_video_as_default %>
+  <% end %>
+</div>

--- a/app/overrides/spree/admin/shared/_product_tabs/video_on_demand.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/video_on_demand.html.erb.deface
@@ -1,7 +1,18 @@
-<!-- insert_after "erb[silent]:contains('Spree::Digital')" -->
-<%= content_tag :li, class: 'nav-item' do %>
-    <%= link_to_with_icon 'collection-play.svg', Spree.t(:video),
+<!-- insert_after "erb[silent]:contains('Spree::Image')" -->
+
+  <% if @product.use_video_as_default %>
+    <% if (SpreeCmCommissioner::VideoOnDemand.where(variant_id: @product.master_id).to_a).any? %>
+      <%= link_to_with_icon 'collection-play.svg', Spree.t(:videos),
       admin_product_video_on_demands_url(@product),
       class: "nav-link #{'active' if current == :video_on_demand}" %>
-<% end %>
+    <% else %>
+      <%= link_to_with_icon 'collection-play.svg', Spree.t(:videos),
+        admin_product_video_on_demands_url(@product),
+        class: "nav-link #{'active text-white' if current == :video_on_demand} #{'text-danger' unless current == :video_on_demand}" %>
+      <% end %>
+  <% else %>
+      <%= link_to_with_icon 'collection-play.svg', Spree.t(:videos),
+      admin_product_video_on_demands_url(@product),
+      class: "nav-link #{'active' if current == :video_on_demand}" %>
+  <% end %>
 

--- a/app/serializers/spree/v2/storefront/product_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/product_serializer_decorator.rb
@@ -9,7 +9,7 @@ module Spree
           base.has_many :possible_promotions, serializer: ::SpreeCmCommissioner::V2::Storefront::PromotionSerializer
 
           base.has_one :default_state, serializer: :state
-          base.attributes :need_confirmation, :product_type, :kyc, :allowed_upload_later, :allow_anonymous_booking
+          base.attributes :need_confirmation, :product_type, :kyc, :allowed_upload_later, :allow_anonymous_booking, :use_video_as_default
           base.attributes :reveal_description, :discontinue_on
         end
       end

--- a/app/views/spree/admin/video_on_demands/_form.html.erb
+++ b/app/views/spree/admin/video_on_demands/_form.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-12">
-
+    
     <%= f.hidden_field :uuid, id: "uuid" %>
     <%= f.hidden_field :config, id: "config"%>
 
@@ -21,9 +21,9 @@
     <% end %>
 
     <div class="form-group">
-      <%= f.label :variant_id, raw(Spree::Variant.model_name.human + required_span_tag) %>
+     <%= f.label :variant_id, raw(Spree::Variant.model_name.human + required_span_tag) %>
       <% if @variants.present? %>
-        <%= f.select :variant_id, options_for_select(@variants.map { |v| [v.options_text, v.id, { disabled: v.id != f.object.variant_id && @video_on_demands.map(&:variant_id).include?(v.id) }] }, f.object.variant_id), {}, { class: 'select2 form-control' } %>
+        <%= f.select :variant_id, @variants, {}, {class: 'select2'} %>
       <% else %>
         <p>No variants available</p>
       <% end %>

--- a/app/views/spree/admin/video_on_demands/index.html.erb
+++ b/app/views/spree/admin/video_on_demands/index.html.erb
@@ -8,13 +8,14 @@
 <% if !@video_on_demands.any? %>
   <div class="text-center no-objects-found m-5">
     <%= Spree.t(:no_resource_found, resource: plural_resource_name(SpreeCmCommissioner::VideoOnDemand)) %>,
-    <%= link_to(Spree.t(:add_one), admin_product_video_on_demands_url(@product)) if can? :create, SpreeCmCommissioner::VideoOnDemand %>!
+    <%= link_to(Spree.t(:add_one), new_admin_product_video_on_demand_url(@product)) if can? :create, SpreeCmCommissioner::VideoOnDemand %>!
   </div>
 <% else %>
   <div class="table-responsive border rounded bg-white">
-    <table class="table table-striped">
-      <thead class="text-muted">
+    <table class="table sortable" data-sortable-link="<%= update_positions_admin_product_video_on_demands_path(@product) %>">
+      <thead data-hook= "video_on_demands_header" class="text-muted">
         <tr>
+          <th></th>
           <th class="text-center"><%= Spree.t(:uuid) %></th>
           <th class="text-center"><%= Spree.t(:title) %></th>
           <th class="text-center"><%= Spree.t(:variant) %></th>
@@ -24,12 +25,23 @@
           <th class="action"></th>
         </tr>
       </thead>
-      <tbody>
+      <tbody id="sortVert">
         <% @video_on_demands.each do |video_on_demand| %>
-          <tr id="<%= dom_id(video_on_demand) %>">
+          <tr id="<%= spree_dom_id video_on_demand %>" data-hook="video_on_demand_row">
+            <td class="move-handle">
+              <% if can? :edit, video_on_demand %>
+                <%= svg_icon name: "grip-vertical.svg", width: '18', height: '18' %>
+              <% end %>
+            </td>
             <td class="text-center"><%= video_on_demand.uuid %></td>
             <td class="text-center"><%= video_on_demand.title %></td>
-            <td class="text-center"><%= video_on_demand.variant.options_text %></td>
+            <td class="text-center">
+              <% if video_on_demand.variant.id == @product.master_id %>
+                <%= 'Default' %>
+              <% else %>
+                <%= video_on_demand.variant.options_text %>
+              <% end %>
+            </td>
             <td class="image text-center">
               <div class="admin-product-image-container small-img">
                 <%= image_tag (main_app.rails_blob_url(video_on_demand.thumbnail)) if video_on_demand&.thumbnail&.attached? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,7 +84,12 @@ Spree::Core::Engine.add_routes do
         get 'edit_kyc', to: 'kyc#edit'
         put 'update_kyc', to: 'kyc#update'
       end
-      resources :video_on_demands
+
+      resources :video_on_demands do
+        collection do
+          post :update_positions
+        end
+      end
 
       resources :google_wallets do
         member do

--- a/db/migrate/20240724025704_add_position_to_cm_video_on_demands.rb
+++ b/db/migrate/20240724025704_add_position_to_cm_video_on_demands.rb
@@ -1,0 +1,5 @@
+class AddPositionToCmVideoOnDemands < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cm_video_on_demands, :position, :integer, default: 0, if_not_exists: true
+  end
+end

--- a/db/migrate/20240725034550_add_use_video_as_default_to_spree_products.rb
+++ b/db/migrate/20240725034550_add_use_video_as_default_to_spree_products.rb
@@ -1,0 +1,5 @@
+class AddUseVideoAsDefaultToSpreeProducts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_products, :use_video_as_default, :boolean, default: false, if_not_exists: true
+  end
+end

--- a/spec/serializers/spree/v2/storefront/product_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/product_serializer_spec.rb
@@ -6,20 +6,20 @@ RSpec.describe Spree::V2::Storefront::ProductSerializer, type: :serializer do
 
     subject {
       described_class.new(product, params: { 'store': product.stores.first }, include: [
-        :variants,
-        :option_types,
-        :product_properties,
-        :taxons,
-        :images,
-        :default_variant,
-        :primary_variant,
-        :vendor,
-        :variant_kind_option_types,
-        :product_kind_option_types,
-        :promoted_option_types,
-        :possible_promotions,
-        :default_state,
-      ]).serializable_hash
+                                     :variants,
+                                     :option_types,
+                                     :product_properties,
+                                     :taxons,
+                                     :images,
+                                     :default_variant,
+                                     :primary_variant,
+                                     :vendor,
+                                     :variant_kind_option_types,
+                                     :product_kind_option_types,
+                                     :promoted_option_types,
+                                     :possible_promotions,
+                                     :default_state,
+                                   ]).serializable_hash
     }
 
     it 'returns exact attributes' do
@@ -49,7 +49,8 @@ RSpec.describe Spree::V2::Storefront::ProductSerializer, type: :serializer do
         :reveal_description,
         :allowed_upload_later,
         :allow_anonymous_booking,
-        :discontinue_on
+        :discontinue_on,
+        :use_video_as_default
       )
     end
 

--- a/spec/serializers/spree/v2/storefront/product_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/product_serializer_spec.rb
@@ -6,20 +6,20 @@ RSpec.describe Spree::V2::Storefront::ProductSerializer, type: :serializer do
 
     subject {
       described_class.new(product, params: { 'store': product.stores.first }, include: [
-                                     :variants,
-                                     :option_types,
-                                     :product_properties,
-                                     :taxons,
-                                     :images,
-                                     :default_variant,
-                                     :primary_variant,
-                                     :vendor,
-                                     :variant_kind_option_types,
-                                     :product_kind_option_types,
-                                     :promoted_option_types,
-                                     :possible_promotions,
-                                     :default_state,
-                                   ]).serializable_hash
+        :variants,
+        :option_types,
+        :product_properties,
+        :taxons,
+        :images,
+        :default_variant,
+        :primary_variant,
+        :vendor,
+        :variant_kind_option_types,
+        :product_kind_option_types,
+        :promoted_option_types,
+        :possible_promotions,
+        :default_state,
+      ]).serializable_hash
     }
 
     it 'returns exact attributes' do


### PR DESCRIPTION
- Add check box on product ( if check user need to upload video default )

![image](https://github.com/user-attachments/assets/7213f9ce-3356-4dd4-b0bb-fa37f8dab66f)


- when require video is checked and default not uploaded yet 

![image](https://github.com/user-attachments/assets/2509fa63-3124-477e-8b99-ac0970c2af3c)


 - Video list with position is movable 
 
![image](https://github.com/user-attachments/assets/11c88e79-4870-4cdc-b16e-8afc388e0767)



- Update some relationship at from one variant have only one video ==> one variant can has many video
- Create default variant for default video in case require_default_video is checked on product (which use product master_id instead of variant_id inside video_on_demand_table)

![image](https://github.com/user-attachments/assets/1ab88b1d-3c8d-442a-841c-bba24fa71374)
