### PR TITLE
Close #1711 Billing report overview bug

### DIFF
--- a/app/controllers/spree/billing/reports_controller.rb
+++ b/app/controllers/spree/billing/reports_controller.rb
@@ -37,13 +37,16 @@ module Spree
       def overdue
         @search = orders_scope.joins(:line_items).where.not(payment_state: %w[paid failed])
                               .where('spree_line_items.due_date < ?', Time.zone.today)
+                              .select('DISTINCT ON (spree_orders.id) spree_orders.*, spree_line_items.*')
                               .ransack(params[:q])
         @orders = @search.result.page(page).per(per_page)
       end
 
       # GET /billing/reports/failed_orders
       def failed_orders
-        @search = orders_scope.joins(:line_items).where(payment_state: 'failed').ransack(params[:q])
+        @search = orders_scope.joins(:line_items).where(payment_state: 'failed')
+                              .select('DISTINCT ON (spree_orders.id) spree_orders.*, spree_line_items.*')
+                              .ransack(params[:q])
         @orders = @search.result.page(page).per(per_page)
       end
 

--- a/spec/controllers/spree/billing/report_controller_spec.rb
+++ b/spec/controllers/spree/billing/report_controller_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Billing::ReportsController, type: :controller do
+  let!(:customer) { create(:cm_customer) }
+  let(:spree_current_user) { create(:user) }
+  let(:admin_role) { create(:role, name: 'admin') }
+
+  before do
+    spree_current_user.spree_roles << admin_role
+  end
+
+  before(:each) do
+    allow_any_instance_of(SpreeCmCommissioner::Subscription).to receive(:date_within_range).and_return(true)
+    create(:cm_subscription, start_date: '2024-05-15'.to_date, customer: customer, price: 13.0, due_date: 5, quantity: 1)
+    create(:cm_subscription, start_date: '2024-05-16'.to_date, customer: customer, price: 25.0, due_date: 5, quantity: 1)
+    create(:cm_subscription, start_date: '2024-05-17'.to_date, customer: customer, price: 32.0, due_date: 5, quantity: 1)
+    SpreeCmCommissioner::SubscriptionsOrderCreator.call(customer: customer)
+  end
+
+  describe 'overdue_report' do
+    before do
+      SpreeCmCommissioner::Subscription.all.each do |subscription|
+        subscription.orders.each {|o| o.payments.last.pend! }
+      end
+    end
+
+    # one order with 3 line items
+    it 'returns only 1 order with overdue payment state' do
+      search = Spree::Order.subscription.joins(:line_items).where.not(payment_state: %w[paid failed])
+                                                           .where('spree_line_items.due_date < ?', Time.zone.today)
+                                                           .select('DISTINCT ON (spree_orders.id) spree_orders.*, spree_line_items.*')
+
+      expect(search.size).to eq 1
+    end
+
+    # 3 orders with 3 line items each (same order number)
+    it 'returns duplicate orders with overdue payment state' do
+      search = Spree::Order.subscription.joins(:line_items).where.not(payment_state: %w[paid failed])
+                                                           .where('spree_line_items.due_date < ?', Time.zone.today)
+
+      expect(search.size).to eq 3
+    end
+  end
+
+  describe 'failed_report' do
+    before do
+      SpreeCmCommissioner::Subscription.all.each do |subscription|
+        subscription.orders.each {|o| o.payments.last.void! }
+      end
+    end
+
+    # one order with 3 line items
+    it 'returns only 1 order with failed payment state' do
+      search = Spree::Order.subscription.joins(:line_items)
+                    .where(payment_state: 'failed')
+                    .select('DISTINCT ON (spree_orders.id) spree_orders.*, spree_line_items.*')
+
+      expect(search.size).to eq 1
+    end
+
+    # 3 orders with 3 line items each (same order number)
+    it 'returns duplicate orders with failed payment state' do
+      search = Spree::Order.subscription.joins(:line_items)
+                    .where(payment_state: 'failed')
+
+      expect(search.size).to eq 3
+    end
+  end
+end
+


### PR DESCRIPTION
- fixed duplication bug in report overview
- fixed duplication bug in overdue page
- fixed duplication bug in failed_order page

How the bug happen:
- When one order has two or more line_items(subscription), the query get the same order multiple times(same number as line_items)

To reproduce bug:
- Subscribe to multiple products in one order

How to fix:
- As the order_id shown multiple times is the same, let the query select unique order_id