### PR TITLE
close #1730 authenticate with telegram init data

### DIFF
--- a/app/interactors/spree_cm_commissioner/user_telegram_web_app_authenticator.rb
+++ b/app/interactors/spree_cm_commissioner/user_telegram_web_app_authenticator.rb
@@ -1,0 +1,41 @@
+module SpreeCmCommissioner
+  class UserTelegramWebAppAuthenticator < BaseInteractor
+    delegate :telegram_init_data, to: :context
+
+    def call
+      return context.fail!(message: 'invalid_init_data') unless checker_context.success?
+
+      context.telegram_user = ActiveSupport::JSON.decode(checker_context.decoded_telegram_init_data['user'])
+      context.user = find_or_create_telegram_user
+    end
+
+    def find_or_create_telegram_user
+      identity = SpreeCmCommissioner::UserIdentityProvider.telegram.find_or_initialize_by(sub: context.telegram_user['id'])
+
+      if identity.new_record?
+        user = Spree::User.new do |u|
+          identity.name = context.telegram_user['username']
+          u.first_name = context.telegram_user['first_name']
+          u.last_name = context.telegram_user['last_name']
+          u.password = SecureRandom.base64(16)
+          u.user_identity_providers = [identity]
+        end
+        user.save!
+        user
+      else
+        identity.user
+      end
+    end
+
+    def checker_context
+      context.checker_context ||= SpreeCmCommissioner::TelegramWebAppInitDataValidator.call(
+        telegram_init_data: telegram_init_data,
+        bot_token: telegram_bot_token
+      )
+    end
+
+    def telegram_bot_token
+      ENV.fetch('DEFAULT_TELEGRAM_BOT_API_TOKEN', nil)
+    end
+  end
+end

--- a/app/services/spree_cm_commissioner/user_authenticator.rb
+++ b/app/services/spree_cm_commissioner/user_authenticator.rb
@@ -18,12 +18,16 @@ module SpreeCmCommissioner
       when 'social_auth'
         options = { id_token: params[:id_token] }
         SpreeCmCommissioner::UserIdTokenAuthenticator.call(options)
+      when 'telegram_web_app_auth'
+        options = { telegram_init_data: params[:telegram_init_data] }
+        SpreeCmCommissioner::UserTelegramWebAppAuthenticator.call(options)
       end
     end
 
     def self.flow_type(params)
       return 'login_auth' if params.key?(:username) && params.key?(:password)
       return 'social_auth' if params.key?(:id_token)
+      return 'telegram_web_app_auth' if params.key?(:telegram_init_data)
 
       raise exception(I18n.t('authenticator.invalid_or_missing_params'))
     end

--- a/spec/interactors/spree_cm_commissioner/user_telegram_web_app_authenticator_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/user_telegram_web_app_authenticator_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::UserTelegramWebAppAuthenticator do
+  let(:valid_bot_token) { '6453379064:AAF8ISKbrDljptn6r5lMRj2Ben_s_ASmnnE' }
+  let(:invalid_bot_token) { 'invalid-bot-token' }
+  let(:telegram_init_data) { 'user=%7B%22id%22%3A1029000609%2C%22first_name%22%3A%22Spooky%22%2C%22last_name%22%3A%22%22%2C%22username%22%3A%22theacontigo%22%2C%22language_code%22%3A%22en%22%2C%22allows_write_to_pm%22%3Atrue%7D&chat_instance=6719130073186955468&chat_type=private&auth_date=1692617684&hash=9c467fcab396b22e3670698cbb3cc9e7e486ce224c72c993ae295507a29f67bd' }
+
+  describe '.call' do
+    context 'when init data is VALID' do
+      before do
+        allow_any_instance_of(described_class).to receive(:telegram_bot_token).and_return(valid_bot_token)
+      end
+
+      it 'create a new user when user not connect with telegram yet' do
+
+        context = described_class.call(telegram_init_data: telegram_init_data)
+
+        expect(context.success?).to eq true
+
+        # created user
+        expect(context.user.id).to be_present
+        expect(context.user.first_name).to eq 'Spooky'
+        expect(context.user.last_name).to eq ''
+        expect(context.user.user_identity_providers.pluck(:sub)).to eq ['1029000609']
+        expect(context.user.user_identity_providers.pluck(:name)).to eq ['theacontigo']
+
+        # reference data
+        expect(context.telegram_user['first_name']).to eq 'Spooky'
+        expect(context.telegram_user['last_name']).to eq ''
+        expect(context.telegram_user['id']).to eq 1029000609
+        expect(context.telegram_user['username']).to eq 'theacontigo'
+      end
+
+      it 'create return old user when already connected before' do
+        context1 = described_class.call(telegram_init_data: telegram_init_data)
+        context2 = described_class.call(telegram_init_data: telegram_init_data)
+
+        expect(context1.success?).to eq true
+        expect(context2.success?).to eq true
+        expect(context1.user).to eq context2.user
+      end
+    end
+
+    context 'when init data is INVALID' do
+      before do
+        allow_any_instance_of(described_class).to receive(:telegram_bot_token).and_return(invalid_bot_token)
+      end
+
+      it 'raise error' do
+        context = described_class.call(telegram_init_data: telegram_init_data)
+
+        expect(context.success?).to eq false
+        expect(context.message).to eq 'invalid_init_data'
+      end
+    end
+  end
+end

--- a/spec/services/spree_cm_commissioner/user_authenticator_spec.rb
+++ b/spec/services/spree_cm_commissioner/user_authenticator_spec.rb
@@ -28,4 +28,12 @@ RSpec.describe SpreeCmCommissioner::UserAuthenticator do
                                                   )
     end
   end
+
+  describe '.flow_type' do
+    it 'return [telegram_web_app_auth] when params contain telegram_init_data' do
+      flow_type = described_class.flow_type({ telegram_init_data: 'anything-as-long-as-present' })
+
+      expect(flow_type).to eq 'telegram_web_app_auth'
+    end
+  end
 end


### PR DESCRIPTION
Login with Telegram Mini Web App init data.

We pass init data from web app then decode those data and hash with token. If matched, which mean data is validated, we create account for user. If account already connected, return existing account.

- Hash Reference: https://core.telegram.org/bots/webapps#validating-data-received-via-the-mini-app