### PR TITLE
close #1732 set order channel API

### DIFF
--- a/app/models/spree_cm_commissioner/order_decorator.rb
+++ b/app/models/spree_cm_commissioner/order_decorator.rb
@@ -1,6 +1,6 @@
 module SpreeCmCommissioner
   module OrderDecorator
-    def self.prepended(base)
+    def self.prepended(base) # rubocop:disable Metrics/MethodLength
       base.include SpreeCmCommissioner::PhoneNumberSanitizer
       base.include SpreeCmCommissioner::OrderRequestable
 
@@ -19,6 +19,7 @@ module SpreeCmCommissioner
       base.before_create :associate_customer
 
       base.validates :promo_total, base::MONEY_VALIDATION
+      base.validates :channel, inclusion: { in: %w[spree google_form telegram] }, if: :channel_changed?
 
       base.validates :phone_number, presence: true, if: :require_phone_number
       base.has_one :invoice, dependent: :destroy, class_name: 'SpreeCmCommissioner::Invoice'

--- a/app/serializers/spree/v2/storefront/cart_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/cart_serializer_decorator.rb
@@ -3,7 +3,8 @@ module Spree
     module Storefront
       module CartSerializerDecorator
         def self.prepended(base)
-          base.attributes :phone_number, :intel_phone_number, :country_code, :request_state, :qr_data
+          base.attributes :phone_number, :intel_phone_number, :country_code, :request_state, :qr_data,
+                          :channel
         end
       end
     end

--- a/config/initializers/spree_permitted_attributes.rb
+++ b/config/initializers/spree_permitted_attributes.rb
@@ -33,6 +33,7 @@ module Spree
     ]
 
     @@checkout_attributes += %i[
+      channel
       phone_number
       country_code
     ]

--- a/spec/serializers/spree/v2/storefront/cart_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/cart_serializer_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe Spree::V2::Storefront::CartSerializer, type: :serializer do
         :country_code,
         :request_state,
         :qr_data,
+        :channel,
       )
     end
 

--- a/spec/services/spree_cm_commissioner/imports/import_order_service_spec.rb
+++ b/spec/services/spree_cm_commissioner/imports/import_order_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SpreeCmCommissioner::Imports::ImportOrderService do
   let(:orders) {
     [
       {
-        order_channel: 'web',
+        order_channel: 'google_form',
         order_email: 'abc@gmail.com',
         order_phone_number: '1234567890',
         variant_sku: variant1.sku,
@@ -16,7 +16,7 @@ RSpec.describe SpreeCmCommissioner::Imports::ImportOrderService do
         age: 10,
       },
       {
-        order_channel: 'app',
+        order_channel: 'spree',
         order_email: 'valo@gmail.com',
         order_phone_number: '1234567890',
         variant_sku: variant2.sku,
@@ -25,7 +25,7 @@ RSpec.describe SpreeCmCommissioner::Imports::ImportOrderService do
         age: 10,
       },
       {
-        order_channel: 'mobile',
+        order_channel: 'telegram',
         order_email: 'zerko@gmail.com',
         order_phone_number: '1234567890',
         variant_sku: variant3.sku,


### PR DESCRIPTION
This is required for Telegram web bot to work smoothly. Its use case is when constructing continue_success_URL for payment, we include order_channel in URL params.
- `v2_continue?order_number=R12345&order_channel=telegram`

We need it because telegram will open external browser which lose all session, So params `order_channel` is only source that we can use. With params above, client app can decide whether to pop current web tab or deeplink back to Telegram.