### PR TITLE
close #1747 save variant options to its public metadata

### DIFF
--- a/app/jobs/spree_cm_commissioner/option_type_variants_public_metadata_updater_job.rb
+++ b/app/jobs/spree_cm_commissioner/option_type_variants_public_metadata_updater_job.rb
@@ -1,0 +1,8 @@
+module SpreeCmCommissioner
+  class OptionTypeVariantsPublicMetadataUpdaterJob < ApplicationJob
+    def perform(option_type_id)
+      optino_type = ::Spree::OptionType.find(option_type_id)
+      optino_type.variants.find_each(&:set_options_to_public_metadata!)
+    end
+  end
+end

--- a/app/jobs/spree_cm_commissioner/option_value_variants_public_metadata_updater_job.rb
+++ b/app/jobs/spree_cm_commissioner/option_value_variants_public_metadata_updater_job.rb
@@ -1,0 +1,8 @@
+module SpreeCmCommissioner
+  class OptionValueVariantsPublicMetadataUpdaterJob < ApplicationJob
+    def perform(option_value_id)
+      option_value = ::Spree::OptionValue.find(option_value_id)
+      option_value.variants.find_each(&:set_options_to_public_metadata!)
+    end
+  end
+end

--- a/app/jobs/spree_cm_commissioner/variants_public_metadata_updater_job.rb
+++ b/app/jobs/spree_cm_commissioner/variants_public_metadata_updater_job.rb
@@ -1,0 +1,13 @@
+# We can use this for migrating old datas.
+module SpreeCmCommissioner
+  class VariantsPublicMetadataUpdaterJob < ApplicationJob
+    def perform
+      Spree::Variant.find_each do |variant|
+        variant.set_options_to_public_metadata
+
+        # can skip even it failed
+        variant.save
+      end
+    end
+  end
+end

--- a/app/models/concerns/spree_cm_commissioner/variant_options_concern.rb
+++ b/app/models/concerns/spree_cm_commissioner/variant_options_concern.rb
@@ -2,29 +2,47 @@ module SpreeCmCommissioner
   module VariantOptionsConcern
     extend ActiveSupport::Concern
 
+    included do
+      before_save :set_options_to_public_metadata
+
+      delegate :location,
+               :reminder_in_hours,
+               :duration_in_hours,
+               :duration_in_minutes,
+               :duration_in_seconds,
+               :payment_option,
+               :delivery_option,
+               :max_quantity_per_order,
+               :due_date,
+               :month,
+               :number_of_adults,
+               :number_of_kids,
+               :kids_age_max,
+               :allowed_extra_adults,
+               :allowed_extra_kids,
+               :number_of_guests,
+               :bib_prefix,
+               :bib_zerofill,
+               to: :options
+    end
+
     def options
       @options ||= VariantOptions.new(self)
     end
 
-    delegate :location,
-             :reminder_in_hours,
-             :duration_in_hours,
-             :duration_in_minutes,
-             :duration_in_seconds,
-             :payment_option,
-             :delivery_option,
-             :max_quantity_per_order,
-             :due_date,
-             :month,
-             :number_of_adults,
-             :number_of_kids,
-             :kids_age_max,
-             :allowed_extra_adults,
-             :allowed_extra_kids,
-             :number_of_guests,
-             :bib_prefix,
-             :bib_zerofill,
-             to: :options
+    def options_in_hash
+      public_metadata[:cm_options]
+    end
+
+    def option_value_name_for(option_type_name: nil)
+      return options_in_hash[option_type_name] if options_in_hash.present? # empty is not considered present?
+
+      find_option_value_name_for(option_type_name: option_type_name)
+    end
+
+    def find_option_value_name_for(option_type_name: nil)
+      option_values.detect { |o| o.option_type.name.downcase.strip == option_type_name.downcase.strip }.try(:name)
+    end
 
     def start_date_time
       return nil if start_date.blank?
@@ -62,6 +80,24 @@ module SpreeCmCommissioner
 
     def post_paid?
       options.payment_option == 'post-paid'
+    end
+
+    # save optins to public_metadata so we don't have to query option types & option values when needed them.
+    # once variant changed, we update metadata.
+    def set_options_to_public_metadata
+      self.public_metadata ||= {}
+
+      latest_options_in_hash = option_values.each_with_object({}) do |option_value, hash|
+        option_type_name = option_value.option_type.name
+        hash[option_type_name] = find_option_value_name_for(option_type_name: option_type_name)
+      end
+
+      self.public_metadata[:cm_options] = latest_options_in_hash
+    end
+
+    def set_options_to_public_metadata!
+      set_options_to_public_metadata
+      save!
     end
   end
 end

--- a/app/models/spree_cm_commissioner/option_type_decorator.rb
+++ b/app/models/spree_cm_commissioner/option_type_decorator.rb
@@ -10,6 +10,8 @@ module SpreeCmCommissioner
 
       base.validate :kind_has_updated, on: :update, if: :kind_changed?
 
+      base.has_many :variants, through: :products
+
       base.scope :promoted, -> { where(promoted: true) }
       base.whitelisted_ransackable_attributes = %w[kind]
     end

--- a/app/models/spree_cm_commissioner/variant_decorator.rb
+++ b/app/models/spree_cm_commissioner/variant_decorator.rb
@@ -22,10 +22,6 @@ module SpreeCmCommissioner
       base.accepts_nested_attributes_for :option_values
     end
 
-    def option_value_name_for(option_type_name: nil)
-      option_values.detect { |o| o.option_type.name.downcase.strip == option_type_name.downcase.strip }.try(:name)
-    end
-
     def delivery_required?
       delivery_option == 'delivery'
     end
@@ -97,8 +93,8 @@ if Spree::Variant.included_modules.exclude?(SpreeCmCommissioner::VariantDecorato
   #
   # problem with those methods is that it store value in memeory,
   # even we call variant.reload, the method value is no being reload.
-  SpreeMultiVendor::Spree::VariantDecorator.remove_method :vendor
-  SpreeMultiVendor::Spree::VariantDecorator.remove_method :vendor_id
+  SpreeMultiVendor::Spree::VariantDecorator.remove_method :vendor if SpreeMultiVendor::Spree::VariantDecorator.method_defined?(:vendor)
+  SpreeMultiVendor::Spree::VariantDecorator.remove_method :vendor_id if SpreeMultiVendor::Spree::VariantDecorator.method_defined?(:vendor_id)
 
   Spree::Variant.prepend(SpreeCmCommissioner::VariantDecorator)
 end

--- a/app/models/spree_cm_commissioner/variant_options.rb
+++ b/app/models/spree_cm_commissioner/variant_options.rb
@@ -9,6 +9,8 @@ module SpreeCmCommissioner
     DEFAULT_KIDS_AGE_MAX = 17
     DEFAULT_NUMBER_OF_ADULTS = 1
 
+    # these method read option value from public metadata first
+    # if no public metadata found, it will find in db.
     def option_value_name_for(option_type_name: nil)
       variant.option_value_name_for(option_type_name: option_type_name)
     end

--- a/lib/tasks/variants_public_metadata_updater.rake
+++ b/lib/tasks/variants_public_metadata_updater.rake
@@ -1,0 +1,7 @@
+# recommend to be used in schedule.yml & manually access in /sidekiq/cron
+namespace :spree_cm_commissioner do
+  desc 'Update variant metadata eg. public_metadata[:options]'
+  task variants_public_metadata_updater: :environment do
+    SpreeCmCommissioner::VariantsPublicMetadataUpdaterJob.perform_now
+  end
+end

--- a/spec/models/concerns/spree_cm_commissioner/option_type_attr_type_spec.rb
+++ b/spec/models/concerns/spree_cm_commissioner/option_type_attr_type_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::OptionTypeAttrType do
+  context 'validation' do
+    describe '#ensure_name_is_not_changed' do
+      context 'when object is being created' do
+        it 'does not call :ensure_name_is_not_changed' do
+          subject = build(:option_type, name: 'abc')
+          subject.validate
+
+          expect(subject).not_to receive(:ensure_name_is_not_changed)
+          expect(subject.validate).to be true
+        end
+      end
+
+      context 'when object is being updated' do
+        it 'valid when name_changed? false' do
+          subject = create(:option_type, name: 'abc')
+          subject.name = 'abc'
+
+          expect(subject.name_changed?).to be false
+          expect(subject).to receive(:ensure_name_is_not_changed).and_call_original
+          expect(subject).to be_valid
+        end
+
+        it 'valid when reserved_option? false' do
+          subject = create(:option_type, name: 'abc')
+          subject.name = 'xyz'
+
+          expect(subject.name_changed?).to be true
+          expect(subject.reserved_option?).to be false
+
+          expect(subject).to receive(:ensure_name_is_not_changed).and_call_original
+          expect(subject).to be_valid
+        end
+
+        it 'invalid when name changed & it is a reserved options' do
+          subject = create(:option_type, name: Spree::OptionType::RESERVED_OPTIONS.keys.first, presentation: 'option')
+          subject.name = 'xyz'
+
+          expect(subject.name_changed?).to be true
+          expect(subject.reserved_option?).to be true
+
+          expect(subject).to receive(:ensure_name_is_not_changed).and_call_original
+          expect(subject).not_to be_valid
+
+          expect(subject.errors[:name]).to eq ['cannot be changed after it has been set']
+        end
+      end
+    end
+  end
+end

--- a/spec/models/concerns/spree_cm_commissioner/option_value_attr_type_spec.rb
+++ b/spec/models/concerns/spree_cm_commissioner/option_value_attr_type_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe SpreeCmCommissioner::OptionValueAttrType do
     context 'for attr_type: time' do
       let(:option_type) { create(:option_type, attr_type: 'time') }
 
-    it 'invalid when input is in wrong format' do
+      it 'invalid when input is in wrong format' do
         subject = build(:option_value, option_type: option_type, name: 'Invalid Presentation')
 
         expect(subject.valid?).to be false
@@ -198,6 +198,55 @@ RSpec.describe SpreeCmCommissioner::OptionValueAttrType do
 
           expect(subject1.valid?).to be false
           expect(subject2.valid?).to be false
+        end
+      end
+    end
+  end
+
+  context 'validation' do
+    describe '#ensure_name_is_not_changed' do
+      context 'when object is being created' do
+        it 'does not call :ensure_name_is_not_changed' do
+          subject = build(:option_type, name: 'abc')
+          subject.validate
+
+          expect(subject).not_to receive(:ensure_name_is_not_changed)
+          expect(subject.validate).to be true
+        end
+      end
+
+      context 'when object is being updated' do
+        it 'valid when name_changed? false' do
+          subject = create(:option_type, name: 'abc')
+          subject.name = 'abc'
+
+          expect(subject.name_changed?).to be false
+          expect(subject).to receive(:ensure_name_is_not_changed).and_call_original
+          expect(subject).to be_valid
+        end
+
+        it 'valid when reserved_option? false' do
+          subject = create(:option_type, name: 'abc')
+          subject.name = 'xyz'
+
+          expect(subject.name_changed?).to be true
+          expect(subject.reserved_option?).to be false
+
+          expect(subject).to receive(:ensure_name_is_not_changed).and_call_original
+          expect(subject).to be_valid
+        end
+
+        it 'invalid when name changed & it is a reserved options' do
+          subject = create(:option_type, name: Spree::OptionType::RESERVED_OPTIONS.keys.first, presentation: 'option')
+          subject.name = 'xyz'
+
+          expect(subject.name_changed?).to be true
+          expect(subject.reserved_option?).to be true
+
+          expect(subject).to receive(:ensure_name_is_not_changed).and_call_original
+          expect(subject).not_to be_valid
+
+          expect(subject.errors[:name]).to eq ['cannot be changed after it has been set']
         end
       end
     end

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe Spree::LineItem, type: :model do
         let(:line_item_b) { create(:line_item, to_date: current + 1.days) }
 
         it 'return line item as upcoming' do
-          expect(Spree::LineItem.filter_by_event('upcoming').pluck(:id)).to eq [line_item_a.id, line_item_b.id]
+          expect(Spree::LineItem.filter_by_event('upcoming').pluck(:id)).to match_array([line_item_a.id, line_item_b.id])
         end
       end
 
@@ -203,7 +203,7 @@ RSpec.describe Spree::LineItem, type: :model do
         let!(:line_item_b) { create(:line_item, to_date: current - 2.days) }
 
         it 'return both line items as complete' do
-          expect(Spree::LineItem.filter_by_event('complete').pluck(:id)).to eq [line_item_a.id, line_item_b.id]
+          expect(Spree::LineItem.filter_by_event('complete').pluck(:id)).to match_array([line_item_a.id, line_item_b.id])
         end
       end
 

--- a/spec/queries/spree_cm_commissioner/dashboard_crew_event_query_spec.rb
+++ b/spec/queries/spree_cm_commissioner/dashboard_crew_event_query_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe SpreeCmCommissioner::DashboardCrewEventQuery do
 
     it 'should return only incoming events that user has access to' do
       query_a = SpreeCmCommissioner::DashboardCrewEventQuery.new(user_id: user_a.id, section: 'incoming')
-      expect(query_a.events.pluck(:taxon_id)).to eq([incoming_event_a.id, incoming_event_b.id])
+      expect(query_a.events.pluck(:taxon_id)).to match_array([incoming_event_a.id, incoming_event_b.id])
     end
 
     it 'should return only previous events that user has access to' do
       query_b = SpreeCmCommissioner::DashboardCrewEventQuery.new(user_id: user_a.id, section: 'previous')
-      expect(query_b.events.pluck(:taxon_id)).to eq([previous_event_a.id, previous_event_b.id])
+      expect(query_b.events.pluck(:taxon_id)).to match_array([previous_event_a.id, previous_event_b.id])
     end
 
     context 'when section is incoming' do
@@ -32,7 +32,7 @@ RSpec.describe SpreeCmCommissioner::DashboardCrewEventQuery do
         expect(incoming_event_a.from_date).to be >= start_from_date
         expect(incoming_event_b.from_date).to be >= start_from_date
         expect(incoming_event_c.from_date).to be >= start_from_date
-        expect(subject.events.pluck(:taxon_id)).to eq([incoming_event_a.id, incoming_event_b.id, incoming_event_c.id])
+        expect(subject.events.pluck(:taxon_id)).to match_array([incoming_event_a.id, incoming_event_b.id, incoming_event_c.id])
       end
 
       context 'when start_from_date not yet pass to_date (can ignore from_date)' do
@@ -45,7 +45,7 @@ RSpec.describe SpreeCmCommissioner::DashboardCrewEventQuery do
 
         it 'return both events' do
           query_a = SpreeCmCommissioner::DashboardCrewEventQuery.new(user_id: user.id, section: 'incoming')
-          expect(query_a.events.pluck(:taxon_id)).to eq([incoming_event_a.id, incoming_event_b.id])
+          expect(query_a.events.pluck(:taxon_id)).to match_array([incoming_event_a.id, incoming_event_b.id])
         end
       end
     end
@@ -59,7 +59,7 @@ RSpec.describe SpreeCmCommissioner::DashboardCrewEventQuery do
         expect(previous_event_a.from_date).to be < start_from_date
         expect(previous_event_b.from_date).to be < start_from_date
 
-        expect(subject.events.pluck(:taxon_id)).to eq([previous_event_a.id, previous_event_b.id])
+        expect(subject.events.pluck(:taxon_id)).to match_array([previous_event_a.id, previous_event_b.id])
       end
     end
 


### PR DESCRIPTION
## Problem
Data inside option values & option types are now used widely in our system including validations, serializers, etc which causes a lot of N+1 queries.

For example:
variant.end_date => trigger query in db to find related option values & option type name 'end-date'. 

## Solution
This PR, save those data into public metadata[:options] on before_save. So to get eg. variant.end_date, it just read variant.public_metadata['cm_options']['end-date'].

### For data sync:
Because public metadata of variant is now depend on option type & option values table, we should sync them when those data are edited.

- For reserved option type & option value: I disabled their name from being edited (those data is important for variant and shouldn't be updated, for eg. no allowed update from 1 -> 2, or 1-1-2022 to 1-2-2022)
- For non-reserved option type & option value: When their name is updated, we trigger to update related variants public_metadata
- Add rake take to update all variants public metadata (Rarely used, but we can use for old data when release this)