### PR TITLE
Close #1756 Billing report use_custom_date_range bug

### DIFF
--- a/app/assets/javascripts/spree_cm_commissioner/report_hide_filter.js
+++ b/app/assets/javascripts/spree_cm_commissioner/report_hide_filter.js
@@ -3,28 +3,32 @@ document.addEventListener("spree:load", function () {
     "#spree_cm_commissioner_report_use_custom_date_range"
   );
 
-  if (useCustomDateRange.length <= 0) return;
+  const dateRangeFilter = $(".date-range-filter");
+  const periodRangeFilter = $(".period-range-filter");
 
-  $("#spree_cm_commissioner_report_use_custom_date_range").removeAttr(
-    "checked"
+  const params = new URLSearchParams(window.location.search);
+  const useCustomDateRangeParam = params.get(
+    "spree_cm_commissioner_report[use_custom_date_range]"
   );
 
-  // Hide the date range filter by default
-  $(".date-range-filter").hide();
-
-  // Show the date range filter if the checkbox is checked
-  if (useCustomDateRange.is(":checked")) {
-    $(".date-range-filter").show();
+  // Check if the use_custom_date_range param is set to 1
+  if (useCustomDateRangeParam === "1") {
+    useCustomDateRange.prop("checked", true);
+    dateRangeFilter.show();
+    periodRangeFilter.hide();
+  } else {
+    dateRangeFilter.hide();
+    periodRangeFilter.show();
   }
 
   // Toggle the date range filter on checkbox change
   useCustomDateRange.change(function () {
     if (this.checked) {
-      $(".date-range-filter").show();
-      $(".period-range-filter").hide();
+      dateRangeFilter.show();
+      periodRangeFilter.hide();
     } else {
-      $(".date-range-filter").hide();
-      $(".period-range-filter").show();
+      dateRangeFilter.hide();
+      periodRangeFilter.show();
     }
   });
 });

--- a/app/controllers/spree/billing/reports_controller.rb
+++ b/app/controllers/spree/billing/reports_controller.rb
@@ -97,18 +97,18 @@ module Spree
       end
 
       def date_range_for_month
-        if params[:period].present?
+        if params.dig(:spree_cm_commissioner_report, :use_custom_date_range) == '1'
+          from_date = params[:from_date]
+          to_date = params[:to_date]
+          raise SpreeCmCommissioner::ExceedingRangeError if (to_date.to_date - from_date.to_date).to_i > 180
+        elsif params[:period].present?
           today = Time.zone.today
           month = params[:period]
           year = (params[:year].presence || today.year)
           from_date = Time.zone.local(year, month.to_i, 1).beginning_of_day
           to_date = Time.zone.local(year, month.to_i, 31).end_of_day
-          [from_date, to_date]
-        else
-          from_date = params[:from_date]
-          to_date = params[:to_date]
-          raise SpreeCmCommissioner::ExceedingRangeError if (to_date.to_date - from_date.to_date).to_i > 180
         end
+        [from_date, to_date]
       end
 
       def revenue_report_query(from_date, to_date)

--- a/app/views/spree/billing/reports/_date_range_picker.html.erb
+++ b/app/views/spree/billing/reports/_date_range_picker.html.erb
@@ -8,7 +8,7 @@
             data-wrap="true"
             data-alt-format="<%= Spree.t(:fpr_human_friendly_date_format, scope: 'date_picker', default: 'M j, Y') %>">
 
-        <%= f.text_field :from_date,
+        <%= f.date_field :from_date,
                           class: 'form-control',
                           placeholder: Spree.t(:starting_from),
                           value: params[:from_date].to_date,
@@ -22,7 +22,7 @@
             data-alt-format="<%= Spree.t(:fpr_human_friendly_date_format, scope: 'date_picker', default: 'M j, Y') %>"
             data-min-date="<%= params[:from_date] %>">
 
-        <%= f.text_field :to_date,
+        <%= f.date_field :to_date,
                           class: 'form-control',
                           placeholder: Spree.t(:ending_at),
                           value: params[:to_date].to_date,
@@ -48,13 +48,13 @@
                                       ['September', 9],
                                       ['October', 10],
                                       ['November', 11],
-                                      ['December', 12]], selected: params[:period].present? ? params[:period] : Time.zone.today.month), { include_blank: true }, for: 'period-select', class: 'period-select form-control select2-clear js-filterable', id: 'period-select' %>
+                                      ['December', 12]], selected: params[:period].presence || Time.zone.today.month), { include_blank: false }, for: 'period-select', class: 'period-select form-control select2-clear js-filterable', id: 'period-select' %>
     </div>
 
     <div class="form-group">
       <%= f.label :year, Spree.t(:select_year), class: 'form-check-label' %>
       <%= f.select :year,
-                  options_for_select((Time.zone.today.year - 5..Time.zone.today.year + 5).to_a, selected: params[:year].present? ? params[:year] : Time.zone.today.year), { include_blank: true }, for: 'year-select', class: 'year-select form-control select2-clear js-filterable', id: 'year-select' %>
+                  options_for_select((Time.zone.today.year.downto(Time.zone.today.year - 5)).to_a), { include_blank: false }, for: 'year-select', class: 'year-select form-control select2-clear js-filterable', id: 'year-select' %>
     </div>
   </div>
 


### PR DESCRIPTION
How the bug happen:
- Because the period field has a preselected option(current month), it will always return a value which makes the controller to ignore the custom date range condition

How to fix:
- make the controller to check for the checkbox condition first, if its value == 1, the custom_date_range will be used
- if the checkbox is not checked, the date_range will set to the month selected
- if both custom_date_range and month is not selected, the date_range will default to last month


https://github.com/user-attachments/assets/05ff2405-145d-4b0d-ac8b-451fa7ac8971

