### PR TITLE
Close #1769 Billing report overview bug

### DIFF
--- a/app/controllers/spree/billing/reports_controller.rb
+++ b/app/controllers/spree/billing/reports_controller.rb
@@ -37,17 +37,15 @@ module Spree
       def overdue
         @search = orders_scope.joins(:line_items).where.not(payment_state: %w[paid failed])
                               .where('spree_line_items.due_date < ?', Time.zone.today)
-                              .select('DISTINCT ON (spree_orders.id) spree_orders.*, spree_line_items.*')
                               .ransack(params[:q])
-        @orders = @search.result.page(page).per(per_page)
+        @orders = @search.result.includes(:line_items).page(page).per(per_page)
       end
 
       # GET /billing/reports/failed_orders
       def failed_orders
         @search = orders_scope.joins(:line_items).where(payment_state: 'failed')
-                              .select('DISTINCT ON (spree_orders.id) spree_orders.*, spree_line_items.*')
                               .ransack(params[:q])
-        @orders = @search.result.page(page).per(per_page)
+        @orders = @search.result.includes(:line_items).page(page).per(per_page)
       end
 
       # GET /billing/reports/active_subscribers

--- a/app/interactors/spree_cm_commissioner/invoice_creator.rb
+++ b/app/interactors/spree_cm_commissioner/invoice_creator.rb
@@ -17,12 +17,12 @@ module SpreeCmCommissioner
 
     # 04-12-2023 -> 0412
     def load_prefix
-      context.prefix = order.line_items.first.from_date.strftime('%m%y')
+      context.prefix = order.line_items.first.to_date.strftime('%m%y')
     end
 
     def load_invoices_count
-      from = order.line_items.first.from_date.beginning_of_month
-      to = order.line_items.first.from_date.end_of_month
+      from = order.line_items.first.to_date.beginning_of_month
+      to = order.line_items.first.to_date.end_of_month
 
       context.invoices_count = SpreeCmCommissioner::Invoice.where(
         vendor: order.line_items.first.vendor,
@@ -34,7 +34,7 @@ module SpreeCmCommissioner
       context.invoice = SpreeCmCommissioner::Invoice.where(
         vendor: order.line_items.first.vendor,
         order: order,
-        date: order.line_items.first.from_date
+        date: order.line_items.first.to_date
       ).first_or_create do |invoice|
         invoice.invoice_number = context.invoice_number
       end

--- a/app/queries/spree_cm_commissioner/subscription_revenue_overview_query.rb
+++ b/app/queries/spree_cm_commissioner/subscription_revenue_overview_query.rb
@@ -42,7 +42,7 @@ module SpreeCmCommissioner
     def build_subquery(overdue: false)
       base_query = Spree::Order.subscription
                                .joins(:line_items)
-                               .where(line_items: { vendor_id: vendor_id, from_date: from_date..to_date })
+                               .where(line_items: { vendor_id: vendor_id, to_date: from_date..to_date })
 
       unless spree_current_user.has_spree_role?('admin')
         base_query = base_query.joins(subscription: :customer)
@@ -50,7 +50,7 @@ module SpreeCmCommissioner
       end
 
       if overdue
-        base_query = base_query.where.not(payment_state: :paid)
+        base_query = base_query.where(payment_state: :balance_due)
                                .where('line_items.due_date < ?', current_date)
       end
 

--- a/app/views/spree/billing/payments/_list.html.erb
+++ b/app/views/spree/billing/payments/_list.html.erb
@@ -30,12 +30,12 @@
               <span class="d-flex justify-content-center payment-action-buttons">
                 <% payment.actions.each do |action| %>
                   <% if action == 'credit' %>
-                    <%= link_to_with_icon('exit.svg', Spree.t(:refund), new_billing_order_payment_refund_path(order, payment), no_text: true, class: "btn btn-light btn-sm") if can?(:create, Spree::Refund) %>
+                    <%= link_to_with_icon('exit.svg', Spree.t(:refund), new_billing_order_payment_refund_path(@order, payment), no_text: true, class: "btn btn-light btn-sm") if can?(:create, Spree::Refund) %>
                   <% elsif action == 'capture' %>
-                    <%= link_to_with_icon("#{action}.svg", Spree.t(action), nil, no_text: true, data: { toggle: 'modal', target: '#capture-modal' }, class: "btn btn-light btn-sm") %>
+                    <%= link_to_with_icon("#{action}.svg", Spree.t(action), nil, no_text: true, data: { toggle: 'modal', target: "#capture-modal-#{@order.id}" }, class: "btn btn-light btn-sm") %>
                     <%= render partial: 'spree/billing/shared/pop_up_confirmation', locals: { action: action, order: @order, payment: payment } %>
                   <% elsif action == 'void' %>
-                    <%= link_to_with_icon("#{action}.svg", Spree.t(action), nil, no_text: true, data: { toggle: 'modal', target: '#void-modal' }, class: "btn btn-light btn-sm") %>
+                    <%= link_to_with_icon("#{action}.svg", Spree.t(action), nil, no_text: true, data: { toggle: 'modal', target: "#void-modal-#{@order.id}" }, class: "btn btn-light btn-sm") %>
                     <%= render partial: 'spree/billing/shared/pop_up_confirmation', locals: { action: action, order: @order, payment: payment } %>
                   <% end %>
                 <% end %>

--- a/app/views/spree/billing/reports/balance_due.html.erb
+++ b/app/views/spree/billing/reports/balance_due.html.erb
@@ -86,10 +86,10 @@
                       <% if action == 'credit' %>
                         <%= link_to_with_icon('exit.svg', Spree.t(:refund), new_billing_order_payment_refund_path(order, payment), no_text: true, class: "btn btn-light btn-sm") if can?(:create, Spree::Refund) %>
                       <% elsif action == 'capture' %>
-                        <%= link_to_with_icon("#{action}.svg", Spree.t(action), nil, no_text: true, data: { toggle: 'modal', target: '#capture-modal' }, class: "btn btn-light btn-sm") %>
+                        <%= link_to_with_icon("#{action}.svg", Spree.t(action), nil, no_text: true, data: { toggle: 'modal', target: "#capture-modal-#{order.id}" }, class: "btn btn-light btn-sm") %>
                         <%= render partial: 'spree/billing/shared/pop_up_confirmation', locals: { action: action, order: order, payment: payment } %>
                       <% elsif action == 'void' %>
-                        <%= link_to_with_icon("#{action}.svg", Spree.t(action), nil, no_text: true, data: { toggle: 'modal', target: '#void-modal' }, class: "btn btn-light btn-sm") %>
+                        <%= link_to_with_icon("#{action}.svg", Spree.t(action), nil, no_text: true, data: { toggle: 'modal', target: "#void-modal-#{order.id}" }, class: "btn btn-light btn-sm") %>
                         <%= render partial: 'spree/billing/shared/pop_up_confirmation', locals: { action: action, order: order, payment: payment } %>
                       <% end %>
                     <% end %>

--- a/app/views/spree/billing/reports/index.html.erb
+++ b/app/views/spree/billing/reports/index.html.erb
@@ -4,7 +4,9 @@
 <% content_for :sidebar do %>
   <%= render partial: 'date_range_picker' %><br>
 <% end %>
-<%= render partial: 'overview' %>
+<% if @revenue_totals.any? %>
+  <%= render partial: 'overview' %>
+<% end %>
 <br>
 <% unless @search.nil? || @orders.empty? %>
   <div class="table-responsive border rounded bg-whit mb-3">

--- a/app/views/spree/billing/shared/_pop_up_confirmation.html.erb
+++ b/app/views/spree/billing/shared/_pop_up_confirmation.html.erb
@@ -1,4 +1,4 @@
-<div id="capture-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="modalLabel" aria-hidden="true">
+<div id="capture-modal-<%= order.id %>" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="modalLabel" aria-hidden="true">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
@@ -18,7 +18,7 @@
   </div>
 </div>
 
-<div id="void-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="modalLabel" aria-hidden="true">
+<div id="void-modal-<%= order.id %>" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="modalLabel" aria-hidden="true">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
@@ -28,6 +28,7 @@
         </button>
       </div>
       <div class="modal-body">
+        <p><%= Spree.t('billing.invoice') %> : <%= order.invoice.invoice_number %></p>
         <%= form_with model: order, url: billing_order_path(order), id:"void-form", method: :put, remote: true do |f| %>
           <div class="form-group">
           <%= f.field_container :internal_note do %>
@@ -39,8 +40,7 @@
       </div>
       <div class="modal-footer  d-flex justify-content-between">
         <button type="button" class="btn btn-secondary" data-dismiss="modal"><%= Spree.t(:cancel) %></button>
-        <%= button_tag Spree.t(:confirm), onclick: "event.preventDefault();
-                submitVoidForm();", class: 'btn btn-primary' %>
+        <%= link_to Spree.t(:confirm), billing_order_payment_path(order, payment, e: 'void'), method: :put, onclick: "event.preventDefault(); submitVoidForm();", class: 'btn btn-primary' %>
       </div>
     </div>
   </div>
@@ -49,21 +49,13 @@
 <script>
   function submitVoidForm() {
     var form = $("#void-form");
+
     $.ajax({
       url: form.attr("action"),
       method: form.attr("method"),
       data: form.serialize(),
       success: function(response) {
-        $.ajax({
-          url: '<%= billing_order_payment_path(order, payment, e: 'void') %>',
-          method: 'PUT',
-          success: function(response) {
-            location.reload();
-          },
-          error: function(xhr, status, error) {
-            console.error("Second request error:", error);
-          }
-        });
+        console.log("Form submission successful:", response);
         location.reload();
       },
       error: function(xhr, status, error) {

--- a/spec/interactors/spree_cm_commissioner/invoice_creator_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/invoice_creator_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 RSpec.describe SpreeCmCommissioner::InvoiceCreator do
   let(:vendor) { create(:active_vendor, name: 'vendor') }
   let(:product) { create(:cm_product ) }
-  let(:line_item1) { create(:line_item, variant: product.master, from_date: '2023-06-23') }
-  let(:line_item2) { create(:line_item, variant: product.master, from_date: '2023-07-18') }
+  let(:line_item1) { create(:line_item, variant: product.master, from_date: '2023-06-15', to_date: '2023-07-15') }
+  let(:line_item2) { create(:line_item, variant: product.master, from_date: '2023-07-18', to_date: '2023-08-15') }
 
   let(:order1) { create(:order, line_items: [line_item1]) }
   let(:order2) { create(:order, line_items: [line_item2]) }
@@ -14,7 +14,7 @@ RSpec.describe SpreeCmCommissioner::InvoiceCreator do
       result = described_class.new(order: order1)
       result.load_invoice_number
 
-      expect(result.context.invoice_number).to eq '0623-00001'
+      expect(result.context.invoice_number).to eq '0723-00001'
     end
   end
 
@@ -24,15 +24,15 @@ RSpec.describe SpreeCmCommissioner::InvoiceCreator do
       context2 = described_class.call(order: order1)
 
       expect(SpreeCmCommissioner::Invoice.count).to eq 1
-      expect(context1.invoice.invoice_number).to eq '0623-00001'
-      expect(context2.invoice.invoice_number).to eq '0623-00001'
+      expect(context1.invoice.invoice_number).to eq '0723-00001'
+      expect(context2.invoice.invoice_number).to eq '0723-00001'
     end
 
     it 'return invoice with 2 different order ' do
       context1 = described_class.call(order: order1)
       context2 = described_class.call(order: order2)
-      expect(context1.invoice.invoice_number).to eq '0623-00001'
-      expect(context2.invoice.invoice_number).to eq '0723-00001'
+      expect(context1.invoice.invoice_number).to eq '0723-00001'
+      expect(context2.invoice.invoice_number).to eq '0823-00001'
     end
 
   end

--- a/spec/interactors/spree_cm_commissioner/subscriptions_order_creator_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/subscriptions_order_creator_spec.rb
@@ -52,14 +52,15 @@ RSpec.describe SpreeCmCommissioner::SubscriptionsOrderCreator do
         before do
           travel_to 3.months.ago do
             today = Time.zone.today
-            three_months_ago = today.change(day: today.day < 15 ? 14 : 15)
+            three_months_ago = today.change(day: 15)
             create(:cm_subscription, customer: customer, quantity: 2, start_date: three_months_ago)
             create(:cm_subscription, customer: customer, quantity: 2, start_date: three_months_ago)
             create(:cm_subscription, customer: customer, quantity: 2, start_date:  three_months_ago)
             customer.last_invoice_date =  three_months_ago
           end
-          today = Time.zone.today.change(day: 14)
-          start_date =   today.day < 15 ?  (today - 1.month) : today
+          today = Time.zone.today
+          # start_date =   today.day < 15 ? today : (today - 1.month)
+          start_date =   today.change(day: 15) - 1.month
           customer.subscriptions.last.update(start_date: start_date)
         end
 
@@ -80,9 +81,10 @@ RSpec.describe SpreeCmCommissioner::SubscriptionsOrderCreator do
         before do
           travel_to 1.month.ago do
             today = Time.zone.today
-            start_date = today.change(day: today.day < 15 ? 15 : 15)
+            start_date = today.change(day: 15)
             create(:cm_subscription, customer: customer, quantity: 2, start_date: start_date)
           end
+          customer.update!(last_invoice_date: Time.zone.today)
         end
 
         it "doesn't create any orders" do
@@ -92,7 +94,7 @@ RSpec.describe SpreeCmCommissioner::SubscriptionsOrderCreator do
 
         it "doesn't update the last_invoice_date of the customer" do
           described_class.call(customer: customer)
-          expect(customer.last_invoice_date).to eq nil
+          expect(customer.last_invoice_date).to eq Time.zone.today
         end
       end
 

--- a/spec/queries/spree_cm_commissioner/subscription_revenue_overview_query_spec.rb
+++ b/spec/queries/spree_cm_commissioner/subscription_revenue_overview_query_spec.rb
@@ -18,20 +18,20 @@ RSpec.describe SpreeCmCommissioner::SubscriptionRevenueOverviewQuery do
   describe '#reports' do
     before do
       allow_any_instance_of(SpreeCmCommissioner::Subscription).to receive(:date_within_range).and_return(true)
-      create(:cm_subscription, start_date: '2024-05-15'.to_date, customer: customer1, price: 13.0, due_date: 5, quantity: 1)
-      create(:cm_subscription, start_date: '2024-05-16'.to_date, customer: customer2, price: 25.0, due_date: 5, quantity: 1)
-      create(:cm_subscription, start_date: '2024-05-17'.to_date, customer: customer3, price: 32.0, due_date: 5, quantity: 1)
-      SpreeCmCommissioner::SubscriptionsOrderCreator.call(customer: customer1)
-      SpreeCmCommissioner::SubscriptionsOrderCreator.call(customer: customer2)
-      SpreeCmCommissioner::SubscriptionsOrderCreator.call(customer: customer3)
+      create(:cm_subscription, start_date: (today - 1.month).change(day: 15), customer: customer1, price: 13.0, due_date: 5, quantity: 1)
+      create(:cm_subscription, start_date: (today - 1.month).change(day: 15), customer: customer2, price: 25.0, due_date: 5, quantity: 1)
+      create(:cm_subscription, start_date: (today - 1.month).change(day: 15), customer: customer3, price: 32.0, due_date: 5, quantity: 1)
+      SpreeCmCommissioner::SubscriptionsOrderCreator.call!(customer: customer1)
+      SpreeCmCommissioner::SubscriptionsOrderCreator.call!(customer: customer2)
+      SpreeCmCommissioner::SubscriptionsOrderCreator.call!(customer: customer3)
     end
-    it 'only return totals in January' do
+    it 'only return totals in May' do
       SpreeCmCommissioner::Subscription.all.each do |subscription|
         subscription.orders.each {|o| o.payments.last.capture! }
       end
 
       # # only for may
-      query = described_class.new(from_date: '2024-06-15', to_date: '2024-07-14', vendor_id: vendor.id, spree_current_user: spree_current_user)
+      query = described_class.new(from_date: today.beginning_of_month, to_date: today.end_of_month, vendor_id: vendor.id, spree_current_user: spree_current_user)
       result = query.reports
       puts "Debug: Result - #{result}"
       expect(query.reports).to match_array [


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8258e3f6-b2c9-478c-8e3f-c4476ff3150f)

How the bug happen:
- voided orders still show in overdue orders because its payment_state is not 'paid'

How to fix:
- make the query to show overdue orders when orders' payment_state is 'balance_due'