### PR TITLE
close #1787 send order details to telegram web app user when order completed

### DIFF
--- a/app/factory/spree_cm_commissioner/order_telegram_message_factory.rb
+++ b/app/factory/spree_cm_commissioner/order_telegram_message_factory.rb
@@ -22,13 +22,14 @@
 
 module SpreeCmCommissioner
   class OrderTelegramMessageFactory < TelegramMessageFactory
-    attr_reader :order, :vendor
+    attr_reader :order, :vendor, :show_details_link
 
-    def initialize(title:, order:, vendor: nil)
+    def initialize(title:, order:, subtitle: nil, show_details_link: nil, vendor: nil)
       @order = order
       @vendor = vendor
+      @show_details_link = show_details_link || false
 
-      super(title: title)
+      super(title: title, subtitle: subtitle)
     end
 
     def selected_line_items
@@ -78,6 +79,11 @@ module SpreeCmCommissioner
       text << "Name: #{order.name}"
       text << "Tel: #{inline_code(order.intel_phone_number || order.phone_number)}"
       text << "Email: #{inline_code(order.email)}" if order.email.present?
+
+      if show_details_link
+        text << ''
+        text << "<a href='#{Spree::Store.default.url}/orders/#{order.qr_data}'>More details</a>"
+      end
 
       text.compact.join("\n")
     end

--- a/app/factory/spree_cm_commissioner/telegram_message_factory.rb
+++ b/app/factory/spree_cm_commissioner/telegram_message_factory.rb
@@ -1,15 +1,17 @@
 module SpreeCmCommissioner
   class TelegramMessageFactory
-    attr_reader :title
+    attr_reader :title, :subtitle
 
-    def initialize(title:)
+    def initialize(title:, subtitle: nil)
       @title = title
+      @subtitle = subtitle
     end
 
     def message
       text = []
 
       text << header.presence
+      text << subtitle.presence if subtitle.present?
       text << body.presence
       text << footer.presence
 

--- a/app/interactors/spree_cm_commissioner/order_complete_telegram_sender.rb
+++ b/app/interactors/spree_cm_commissioner/order_complete_telegram_sender.rb
@@ -1,0 +1,40 @@
+module SpreeCmCommissioner
+  class OrderCompleteTelegramSender < BaseInteractor
+    delegate :order, to: :context
+
+    def call
+      context.user = Spree::User.find_by(id: order.user_id)
+      return context.fail!(message: 'User must be present') if context.user.blank?
+      return context.fail!(message: 'User is not connected to Telegram') if context.user.user_identity_providers.empty?
+
+      # current implmenetation of identity providers is only allow user to connect 1 Telegram account.
+      # but we loop here just in case those logics are changed.
+      context.user.user_identity_providers.telegram.each do |provider|
+        send(provider.telegram_chat_id)
+      end
+    end
+
+    def send(chat_id)
+      telegram_client.send_photo(
+        chat_id: chat_id,
+        photo: Rails.application.routes.url_helpers.qr_image_url(order.qr_data),
+        show_caption_above_media: false,
+        parse_mode: message_factory.parse_mode,
+        caption: message_factory.message
+      )
+    end
+
+    def message_factory
+      context.message_factory ||= OrderTelegramMessageFactory.new(
+        title: 'Booking Successful 🎉',
+        subtitle: 'Show the QR code above to the crew to check-in on the event day',
+        show_details_link: true,
+        order: order
+      )
+    end
+
+    def telegram_client
+      context.telegram_client ||= ::Telegram.bots[:default]
+    end
+  end
+end

--- a/app/jobs/spree_cm_commissioner/order_complete_telegram_sender_job.rb
+++ b/app/jobs/spree_cm_commissioner/order_complete_telegram_sender_job.rb
@@ -1,0 +1,10 @@
+# queue_webhooks_requests! already contains queue job, but before it prepare to call queue_webhooks_requests!,
+# it could raise serializer error which needed to be recorded in queue dashboard.
+module SpreeCmCommissioner
+  class OrderCompleteTelegramSenderJob < ApplicationJob
+    def perform(order_id)
+      order = Spree::Order.find(order_id)
+      SpreeCmCommissioner::OrderCompleteTelegramSender.call(order: order)
+    end
+  end
+end

--- a/app/models/concerns/spree_cm_commissioner/order_requestable.rb
+++ b/app/models/concerns/spree_cm_commissioner/order_requestable.rb
@@ -113,6 +113,7 @@ module SpreeCmCommissioner
 
     def notify_order_complete_app_notification_to_user
       SpreeCmCommissioner::OrderCompleteNotificationSender.call(order: self)
+      SpreeCmCommissioner::OrderCompleteTelegramSenderJob.perform_later(id) if user_id.present?
     end
 
     def send_order_requested_app_notification_to_user

--- a/app/models/spree_cm_commissioner/user_identity_provider.rb
+++ b/app/models/spree_cm_commissioner/user_identity_provider.rb
@@ -1,15 +1,21 @@
-require_dependency 'spree_cm_commissioner'
-
 module SpreeCmCommissioner
-  class UserIdentityProvider < ApplicationRecord
+  class UserIdentityProvider < Base
     enum identity_type: { :google => 0, :apple => 1, :facebook => 2, :telegram => 3 }
 
-    belongs_to :user, class_name: Spree.user_class.to_s
+    belongs_to :user, class_name: Spree.user_class.to_s, optional: false
 
     validates :sub, presence: true
     validates :sub, uniqueness: { scope: :identity_type }
 
     validates :identity_type, presence: true
     validates :identity_type, uniqueness: { scope: :user_id }
+
+    # sub is a telegram uid, which telegram considered a chatID if
+    # user have /started with bot.
+    def telegram_chat_id
+      return sub if telegram?
+
+      nil
+    end
   end
 end

--- a/spec/cassettes/SpreeCmCommissioner_OrderCompleteTelegramSender/_call/when_order_is_associated_with_a_user_user_is_connected_to_Telegram/send_photo_to_provider_chat_ID.yml
+++ b/spec/cassettes/SpreeCmCommissioner_OrderCompleteTelegramSender/_call/when_order_is_associated_with_a_user_user_is_connected_to_Telegram/send_photo_to_provider_chat_ID.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.telegram.org/botthis-is-bot-token/sendPhoto
+    body:
+      encoding: UTF-8
+      string: chat_id=2241690414&photo=https%3A%2F%2Fbookmeplus-api.ngrok.io%2Fi%2FR217269552-fC1OS8P6ohqr5X3Eiqc0GQ1723095552953&show_caption_above_media=false&parse_mode=HTML&caption=%3Cb%3EBooking+Successful+%F0%9F%8E%89%3C%2Fb%3E%0A%0AShow+the+QR+code+above+to+the+crew+to+check-in+on+the+event+day%0A%0AOrder+Number%3A%0A%3Ccode%3ER060218759%3C%2Fcode%3E%0A%0A%5B+x1+%5D%0A%3Cb%3EProduct+12939%3C%2Fb%3E%0A%0A%3Cb%3E%F0%9F%99%8D+Customer+Info%3C%2Fb%3E%0AName%3A+John+Doe%0ATel%3A+%3Ccode%3E%3C%2Fcode%3E%0AEmail%3A+%3Ccode%3Eruben%40rutherford.name%3C%2Fcode%3E%0A%0A%3Ca+href%3D%27www.example.com%2Forders%2FR060218759-U9Zct6gFBRkdqSJf62rnSw1723870715286%27%3EMore+details%3C%2Fa%3E
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 3.2.0 (2022-12-25))
+      Accept:
+      - "*/*"
+      Date:
+      - Sat, 17 Aug 2024 04:58:35 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Sat, 17 Aug 2024 04:58:37 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1237'
+      Connection:
+      - keep-alive
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, OPTIONS
+      Access-Control-Expose-Headers:
+      - Content-Length,Content-Type,Date,Server,Connection
+    body:
+      encoding: UTF-8
+      string: '{"ok":true,"result":{"message_id":4835,"from":{"id":6441690414,"is_bot":true,"first_name":"Contigo
+        Asia","username":"contigoasiabot"},"chat":{"id":2241690414,"first_name":"Thea","last_name":"Choem","username":"theachoem","type":"private"},"date":1723870716,"photo":[{"file_id":"AgACAgQAAxkDAAIS42bALfw2jjvfyW86W5IrxSitvIGDAALpszEbdjoFUmP4ieja25u9AQADAgADcwADNQQ","file_unique_id":"AQAD6bMxG3Y6BVJ4","file_size":2955,"width":90,"height":90},{"file_id":"AgACAgQAAxkDAAIS42bALfw2jjvfyW86W5IrxSitvIGDAALpszEbdjoFUmP4ieja25u9AQADAgADbQADNQQ","file_unique_id":"AQAD6bMxG3Y6BVJy","file_size":14787,"width":200,"height":200}],"caption":"Booking
+        Successful \ud83c\udf89\n\nShow the QR code above to the crew to check-in
+        on the event day\n\nOrder Number:\nR060218759\n\n[ x1 ]\nProduct 12939\n\n\ud83d\ude4d
+        Customer Info\nName: John Doe\nTel: \nEmail: ruben@rutherford.name\n\nMore
+        details","caption_entities":[{"offset":0,"length":21,"type":"bold"},{"offset":102,"length":10,"type":"code"},{"offset":121,"length":13,"type":"bold"},{"offset":136,"length":16,"type":"bold"},{"offset":181,"length":21,"type":"code"},{"offset":204,"length":12,"type":"text_link","url":"http://www.example.com/orders/R060218759-U9Zct6gFBRkdqSJf62rnSw1723870715286"}]}}'
+  recorded_at: Sat, 17 Aug 2024 04:58:37 GMT
+recorded_with: VCR 6.2.0

--- a/spec/interactors/spree_cm_commissioner/order_complete_telegram_sender_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/order_complete_telegram_sender_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::OrderCompleteTelegramSender do
+  describe '#call' do
+    context 'when order is not associated with user' do
+      let(:order) { create(:completed_order_with_totals, user: nil) }
+
+      it 'return fail' do
+        context = described_class.call(order: order)
+
+        expect(context.success?).to be false
+        expect(context.message).to eq 'User must be present'
+      end
+    end
+
+    context 'when order is associated with a user but user is not connected to telegram' do
+      let(:user) { create(:user) }
+      let(:order) { create(:completed_order_with_totals, user: user) }
+
+      it 'return fail' do
+        context = described_class.call(order: order)
+
+        expect(context.success?).to be false
+        expect(context.message).to eq 'User is not connected to Telegram'
+      end
+    end
+
+    context 'when order is associated with a user & user is connected to Telegram', :vcr do
+      let!(:provider1) { create(:user_identity_provider, user: user, identity_type: :telegram, sub: '2241690414') }
+      let!(:provider2) { create(:user_identity_provider, user: user, identity_type: :google) }
+
+      let(:user) { create(:user) }
+      let(:order) { create(:completed_order_with_totals, user: user) }
+      let(:telegram_client) { Telegram::Bot::Client.new(token: 'this-is-bot-token') }
+
+      it 'send photo to provider chat ID' do
+        expect(provider1.telegram_chat_id).to eq '2241690414'
+        expect(provider2.telegram_chat_id).to eq nil
+
+        expect_any_instance_of(described_class).to receive(:send).with('2241690414').once.and_call_original
+        expect_any_instance_of(described_class).to receive(:telegram_client).and_return(telegram_client)
+
+        expect(telegram_client).to receive(:send_photo).once.and_call_original
+
+        context = described_class.call(order: order)
+        expect(context.success?).to be true
+      end
+    end
+  end
+end

--- a/spec/jobs/spree_cm_commissioner/order_complete_telegram_sender_job_spec.rb
+++ b/spec/jobs/spree_cm_commissioner/order_complete_telegram_sender_job_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::OrderCompleteTelegramSenderJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:order) { create(:order) }
+
+  describe '#perform' do
+    it 'find order & call OrderCompleteTelegramSender interactor' do
+      subject = described_class.new
+
+      expect(Spree::Order).to receive(:find).with(order.id).and_call_original
+      expect(SpreeCmCommissioner::OrderCompleteTelegramSender).to receive(:call).with(order: order).and_call_original
+
+      subject.perform(order.id)
+    end
+  end
+
+  describe '.perform_now' do
+    it 'find order & call OrderCompleteTelegramSender interactor' do
+      expect(Spree::Order).to receive(:find).with(order.id).and_call_original
+      expect(SpreeCmCommissioner::OrderCompleteTelegramSender).to receive(:call).with(order: order).and_call_original
+
+      described_class.perform_now(order.id)
+    end
+  end
+end

--- a/spec/models/spree_cm_commissioner/user_identity_provider_spec.rb
+++ b/spec/models/spree_cm_commissioner/user_identity_provider_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe SpreeCmCommissioner::UserIdentityProvider, type: :model do
   let(:user) { create(:user) }
   let(:user_identity_provider) { create(:user_identity_provider, user: user) }
-  
+
   describe 'test association' do
     it { should belong_to(:user) }
   end
@@ -15,7 +15,7 @@ RSpec.describe SpreeCmCommissioner::UserIdentityProvider, type: :model do
   end
 
   describe 'create user identity provider' do
-    context 'return error when sub redundant' do 
+    context 'return error when sub redundant' do
       it 'when sub is not unique' do
         user_1 = create(:user)
         user_2 = create(:user)


### PR DESCRIPTION
Telegram user ID is a chat ID, so we can just send them directly.

<img width="378" alt="image" src="https://github.com/user-attachments/assets/848a9e1d-d0ef-412f-b6ad-abc7afedd7be">
