### PR TITLE
close #1792 fix undefine method line_items_number_cont

### DIFF
--- a/app/models/spree_cm_commissioner/line_item_decorator.rb
+++ b/app/models/spree_cm_commissioner/line_item_decorator.rb
@@ -19,7 +19,7 @@ module SpreeCmCommissioner
       base.validate :ensure_not_exceed_max_quantity_per_order, if: -> { variant&.max_quantity_per_order.present? }
 
       base.whitelisted_ransackable_associations |= %w[guests]
-      base.whitelisted_ransackable_attributes |= %w[to_date from_date]
+      base.whitelisted_ransackable_attributes |= %w[number to_date from_date]
 
       base.delegate :delivery_required?, :permanent_stock?,
                     to: :variant

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -1,6 +1,25 @@
 require 'spec_helper'
 
 RSpec.describe Spree::LineItem, type: :model do
+  describe '.whitelisted_ransackable_associations' do
+    it 'return expected associations' do
+      expect(described_class.whitelisted_ransackable_associations).to match_array([
+        "variant", "order", "tax_category", "guests"
+      ])
+    end
+  end
+
+
+  describe '.whitelisted_ransackable_attributes' do
+    it 'return expected attributes' do
+      expect(described_class.whitelisted_ransackable_attributes).to match_array([
+        "variant_id", "order_id", "tax_category_id", "quantity", "price", "cost_price", "cost_currency", "adjustment_total",
+        "additional_tax_total", "promo_total", "included_tax_total", "pre_tax_amount", "taxable_adjustment_total",
+        "non_taxable_adjustment_total", "number", "to_date", "from_date"
+      ])
+    end
+  end
+
   describe '#callback before_save' do
     let(:phnom_penh) { create(:state, name: 'Phnom Penh') }
     let!(:vendor) { create(:cm_vendor_with_product, name: 'Phnom Penh Hotel', default_state_id: phnom_penh.id) }

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1,6 +1,25 @@
 require 'spec_helper'
 
 RSpec.describe Spree::Order, type: :model do
+  describe '.whitelisted_ransackable_associations' do
+    it 'return expected associations' do
+      expect(described_class.whitelisted_ransackable_associations).to match_array([
+        "shipments", "user", "created_by", "approver", "canceler", "promotions", "bill_address", "ship_address",
+        "line_items", "store", "customer", "taxon", "payments", "invoice"
+      ])
+    end
+  end
+
+
+  describe '.whitelisted_ransackable_attributes' do
+    it 'return expected attributes' do
+      expect(described_class.whitelisted_ransackable_attributes).to match_array([
+        "completed_at", "email", "number", "state", "payment_state", "shipment_state", "total", "item_total",
+        "considered_risky", "channel", "intel_phone_number", "phone_number"
+      ])
+    end
+  end
+
   describe 'validations' do
     context 'state is either cart or address' do
       it 'not required present of email or phone number' do


### PR DESCRIPTION
```
undefined method `line_items_number_cont' for Ransack::Search<class: Spree::Order, base: Grouping <conditions: [Condition <attributes: ["completed_at"], predicate: not_null, values: ["1"]>], combinator: and>>:Ransack::Search
```

Error because there is a code change that remove :number from ransack attribute  from line item decorator. I add some test to avoid it being edited easily.

| |
| - |
| Before |
| <img width="1728" alt="image" src="https://github.com/user-attachments/assets/4fdc9759-3899-4ff2-b2b0-b22e47182215"> |
| Now |
| <img width="1728" alt="image" src="https://github.com/user-attachments/assets/def2828a-734b-4734-8271-aa1c9cffbb69"> |
