### PR TITLE
close #1810 allow subscription start_date to be in the past

### DIFF
--- a/app/controllers/spree/billing/customers_controller.rb
+++ b/app/controllers/spree/billing/customers_controller.rb
@@ -32,8 +32,9 @@ module Spree
       # POST  /billing/customers/:customer_id/re_create_order
       # billing_customer_re_create_order_path
       def re_create_order
+        today = Time.zone.today
         customer = model_class.find_by(id: params[:customer_id])
-        result = SpreeCmCommissioner::SubscriptionsOrderCreator.call(customer: customer)
+        result = SpreeCmCommissioner::SubscriptionsOrderCreator.call(customer: customer, today: today)
 
         if result.failure?
           flash[:error] = I18n.t('spree.billing.customers.re_create_order.fails', error: result.error)

--- a/app/interactors/spree_cm_commissioner/subscriptions_order_creator.rb
+++ b/app/interactors/spree_cm_commissioner/subscriptions_order_creator.rb
@@ -1,8 +1,8 @@
 module SpreeCmCommissioner
   class SubscriptionsOrderCreator < BaseInteractor
     delegate :customer, to: :context
+    delegate :today, to: :context
     def call
-      today = Time.zone.today
       if today.day < 15
         period_start = (today - 1.month).change(day: 15)
         period_end = today.change(day: 14)
@@ -25,7 +25,7 @@ module SpreeCmCommissioner
         month = i
         generate_invoice(last_invoice_date, month, active_subscriptions)
       end
-      context.customer.update(last_invoice_date: Time.zone.now)
+      context.customer.update(last_invoice_date: today)
     end
 
     private

--- a/app/interactors/spree_cm_commissioner/subscriptions_order_cron_executor.rb
+++ b/app/interactors/spree_cm_commissioner/subscriptions_order_cron_executor.rb
@@ -1,9 +1,10 @@
 module SpreeCmCommissioner
   class SubscriptionsOrderCronExecutor < BaseInteractor
     def call
+      today = Time.zone.today
       customers = SpreeCmCommissioner::Customer.where('active_subscriptions_count > ?', 0)
       customers.each do |customer|
-        SpreeCmCommissioner::SubscriptionsOrderCreator.call(customer: customer)
+        SpreeCmCommissioner::SubscriptionsOrderCreator.call(customer: customer, today: today)
       end
     end
   end

--- a/app/models/spree_cm_commissioner/subscription.rb
+++ b/app/models/spree_cm_commissioner/subscription.rb
@@ -17,26 +17,9 @@ module SpreeCmCommissioner
       validate :variant_in_stock?
       validate :product_active?
       validate :variant_subscribed?
-      validate :date_within_range
     end
 
     after_commit :update_customer_active_subscriptions_count
-
-    def date_within_range
-      today = Time.zone.today
-      if today.day < 15
-        period_start = (today - 1.month).change(day: 15)
-        period_end = today.change(day: 14)
-      else
-        period_start = today.change(day: 15)
-        period_end = (today + 1.month).change(day: 14)
-      end
-      period = period_start..period_end
-
-      return if period.cover?(start_date) || start_date > period_end
-
-      errors.add(:subscription, I18n.t('subscription.validation.out_of_range'))
-    end
 
     def quanitiy_is_not_nil?
       return false unless quantity.nil? || quantity.zero?

--- a/spec/queries/spree_cm_commissioner/subscription_orders_query_spec.rb
+++ b/spec/queries/spree_cm_commissioner/subscription_orders_query_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe SpreeCmCommissioner::SubscriptionOrdersQuery do
+  today = Time.zone.today
   let(:customer) { create(:cm_customer, last_invoice_date: "2024-06-14") }
   let(:spree_current_user) { create(:user) }
   let(:admin_role) { create(:role, name: 'admin') }
@@ -44,7 +45,7 @@ RSpec.describe SpreeCmCommissioner::SubscriptionOrdersQuery do
 
     it 'return 1 overdues when due date < current date' do
       subscription_jan2
-      SpreeCmCommissioner::SubscriptionsOrderCreator.call(customer: customer)
+      SpreeCmCommissioner::SubscriptionsOrderCreator.call(customer: customer, today: today)
       subscription_jan2.orders.each {|o| o.payments.each{|p| p.void! }}
       query = described_class.new(
         current_date: '2024-08-01'.to_date,

--- a/spec/queries/spree_cm_commissioner/subscription_revenue_overview_query_spec.rb
+++ b/spec/queries/spree_cm_commissioner/subscription_revenue_overview_query_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe SpreeCmCommissioner::SubscriptionRevenueOverviewQuery do
       create(:cm_subscription, start_date: (today - 1.month).change(day: 15), customer: customer1, price: 13.0, due_date: 5, quantity: 1)
       create(:cm_subscription, start_date: (today - 1.month).change(day: 15), customer: customer2, price: 25.0, due_date: 5, quantity: 1)
       create(:cm_subscription, start_date: (today - 1.month).change(day: 15), customer: customer3, price: 32.0, due_date: 5, quantity: 1)
-      SpreeCmCommissioner::SubscriptionsOrderCreator.call!(customer: customer1)
-      SpreeCmCommissioner::SubscriptionsOrderCreator.call!(customer: customer2)
-      SpreeCmCommissioner::SubscriptionsOrderCreator.call!(customer: customer3)
+      SpreeCmCommissioner::SubscriptionsOrderCreator.call!(customer: customer1, today: today)
+      SpreeCmCommissioner::SubscriptionsOrderCreator.call!(customer: customer2, today: today)
+      SpreeCmCommissioner::SubscriptionsOrderCreator.call!(customer: customer3, today: today)
     end
     it 'only return totals in May' do
       SpreeCmCommissioner::Subscription.all.each do |subscription|
@@ -60,7 +60,7 @@ RSpec.describe SpreeCmCommissioner::SubscriptionRevenueOverviewQuery do
     before do
       allow_any_instance_of(SpreeCmCommissioner::Subscription).to receive(:date_within_range).and_return(true)
       create(:cm_subscription, start_date: '2024-05-15'.to_date, customer: customer1, price: 13.0, due_date: 5, quantity: 1)
-      SpreeCmCommissioner::SubscriptionsOrderCreator.call(customer: customer1)
+      SpreeCmCommissioner::SubscriptionsOrderCreator.call(customer: customer1, today: today)
     end
     it 'return reports + overdue on feb' do
       SpreeCmCommissioner::Subscription.last.orders[0].payments.each{|p| p.pend!}

--- a/spec/services/spree_cm_commissioner/penalty_calculator_spec.rb
+++ b/spec/services/spree_cm_commissioner/penalty_calculator_spec.rb
@@ -2,14 +2,14 @@ require "spec_helper"
 
 RSpec.describe SpreeCmCommissioner::PenaltyCalculator do
   let(:customer) { create(:cm_customer, last_invoice_date:'2024-06-14' ) }
-
+  today = Time.zone.today
   describe '.calculate_penalty_in_days' do
     before do
       allow_any_instance_of(SpreeCmCommissioner::Subscription).to receive(:date_within_range).and_return(true)
     end
     it 'returns the penalty length in days' do
       subscription = create(:cm_subscription, customer: customer, start_date: '2024-06-14'.to_date, price: 13.0, month: 1, due_date: 15, quantity: 1 )
-      SpreeCmCommissioner::SubscriptionsOrderCreator.call(customer: customer)
+      SpreeCmCommissioner::SubscriptionsOrderCreator.call(customer: customer, today: today)
       due_date = subscription.orders.first.line_items.last.due_date
       current_date = Time.new(2024,8,01,12,0,0) # 01st August 2024
       expected_penalty_in_days = 3


### PR DESCRIPTION
- **Subscription `start_date` can now be set in the past when creating a new subscription**

- **Add  `today` param to invoice recurring method for easier testing**
`SpreeCmCommissioner::SubscriptionsOrderCreator.call(customer: customer, today: today)`

- **Fixed bugs that caused `report_controller_spec` to fails**
