### PR TITLE
close #1818 add organization to user

### DIFF
--- a/app/models/concerns/spree_cm_commissioner/taxon_kind.rb
+++ b/app/models/concerns/spree_cm_commissioner/taxon_kind.rb
@@ -3,7 +3,7 @@ module SpreeCmCommissioner
     extend ActiveSupport::Concern
 
     included do
-      enum kind: { category: 0, cms: 1, event: 2, occupation: 3, nationality: 4 }
+      enum kind: { category: 0, cms: 1, event: 2, occupation: 3, nationality: 4, organization: 5 }
     end
   end
 end

--- a/app/views/spree/admin/user_events/_new_user.html.erb
+++ b/app/views/spree/admin/user_events/_new_user.html.erb
@@ -13,12 +13,14 @@
     <%= form_with model: @object, url: { action: 'create' } do |f| %>
       <%= f.hidden_field :taxon_id, value: @taxon.id %>
       <div  class="form-group" data-hook="new_user">
-          <%= f.field_container :user do %>
+          <%= f.field_container :users do %>
             <%= f.label :user_id, Spree.t(:users) %>
-            <%= f.select :user_id,
-              options_from_collection_for_select(Spree::User.all, :id, :email),
-                { include_hidden: true },
-                class: 'select2 form-control' %>
+            <%= f.select :user_id, options_from_collection_for_select([], :id, :email),
+                                      { include_hidden: true },
+                                        data: { autocomplete_url_value: 'users_api_v2',
+                                                autocomplete_return_attr_value: 'email',
+                                                autocomplete_search_query_value: 'email_i_cont',
+                                                minimum_input_length: 3 } %>
             <%= f.error_message_on :user_id %>
           <% end %>
         </div>

--- a/app/views/spree/admin/user_events/_users.html.erb
+++ b/app/views/spree/admin/user_events/_users.html.erb
@@ -30,7 +30,7 @@
           <% user = user_event.user %>
           <tr id="<%= spree_dom_id user %>" data-hook="admin_taxonomy_taxon_user_events_index_rows">
             <td><%= user.id %></td>
-            <td><%= user.email %></td>
+            <td class='user_email'><%= link_to user.email, edit_admin_user_url(user) %></td>
             <td><%= user.created_at %></td>
             <td><%= user.updated_at %></td>
             <td data-hook="admin_taxonomy_taxon_user_events_index_row_actions" class="actions">


### PR DESCRIPTION
## Description

- Add new new kind called organization
- Add link in User Event index table that take user to edit user role (enhance flow)
- Integrate lazy load in User Events to improve loading speed.

## Demo


https://github.com/user-attachments/assets/7d22c1b0-89fa-4264-90e0-697bfe7ea7d4

