### PR TITLE
close #1826 support multiple telegram web bot

### DIFF
--- a/app/controllers/spree/admin/telegram_bots_controller.rb
+++ b/app/controllers/spree/admin/telegram_bots_controller.rb
@@ -1,0 +1,29 @@
+module Spree
+  module Admin
+    class TelegramBotsController < Spree::Admin::ResourceController
+      helper_method :obfuscate_token
+
+      def obfuscate_token(token)
+        return nil if token.blank?
+        return nil if token.length <= 10
+
+        "#{token[0, 5]}#{'*' * (token.length - 10)}#{token[-5, 5]}"
+      end
+
+      # override
+      def model_class
+        SpreeCmCommissioner::TelegramBot
+      end
+
+      # override
+      def object_name
+        'spree_cm_commissioner_telegram_bot'
+      end
+
+      # override
+      def collection_url(options = {})
+        admin_telegram_bots_url(options)
+      end
+    end
+  end
+end

--- a/app/interactors/spree_cm_commissioner/user_telegram_web_app_authenticator.rb
+++ b/app/interactors/spree_cm_commissioner/user_telegram_web_app_authenticator.rb
@@ -1,16 +1,20 @@
 module SpreeCmCommissioner
   class UserTelegramWebAppAuthenticator < BaseInteractor
-    delegate :telegram_init_data, to: :context
+    delegate :telegram_init_data, :telegram_bot_username, to: :context
 
     def call
-      return context.fail!(message: 'invalid_init_data') unless checker_context.success?
+      return context.fail!(message: 'telegram_bot_username_is_not_valid_or_not_exist_in_db') if telegram_bot.blank?
+      return context.fail!(message: 'invalid_init_data') if checker.blank?
 
-      context.telegram_user = ActiveSupport::JSON.decode(checker_context.decoded_telegram_init_data['user'])
+      context.telegram_user = ActiveSupport::JSON.decode(checker.checker_context.decoded_telegram_init_data['user'])
       context.user = find_or_create_telegram_user
     end
 
     def find_or_create_telegram_user
       identity = SpreeCmCommissioner::UserIdentityProvider.telegram.find_or_initialize_by(sub: context.telegram_user['id'])
+
+      provider_telegram_bot = identity.user_identity_provider_telegram_bots.where(telegram_bot_id: telegram_bot.id).first_or_initialize
+      provider_telegram_bot.last_sign_in_at = Time.zone.now
 
       if identity.new_record?
         user = Spree::User.new do |u|
@@ -20,22 +24,26 @@ module SpreeCmCommissioner
           u.password = SecureRandom.base64(16)
           u.user_identity_providers = [identity]
         end
+
         user.save!
         user
       else
+        provider_telegram_bot.save!
         identity.user
       end
     end
 
-    def checker_context
-      context.checker_context ||= SpreeCmCommissioner::TelegramWebAppInitDataValidator.call(
-        telegram_init_data: telegram_init_data,
-        bot_token: telegram_bot_token
-      )
+    def checker
+      result = TelegramWebAppInitDataValidator.call(telegram_init_data: telegram_init_data, bot_token: telegram_bot.token)
+      context.checker ||= checker_struct.new(result, telegram_bot) if result.success?
     end
 
-    def telegram_bot_token
-      ENV.fetch('DEFAULT_TELEGRAM_BOT_API_TOKEN', nil)
+    def telegram_bot
+      context.telegram_bot ||= TelegramBot.find_by(username: telegram_bot_username)
+    end
+
+    def checker_struct
+      Struct.new(:checker_context, :telegram_bot)
     end
   end
 end

--- a/app/models/spree_cm_commissioner/telegram_bot.rb
+++ b/app/models/spree_cm_commissioner/telegram_bot.rb
@@ -1,0 +1,10 @@
+module SpreeCmCommissioner
+  class TelegramBot < Base
+    # eg. bookmeplus_bot, no start with @
+    validates :username, presence: true
+    validates :token, presence: true
+
+    has_many :user_identity_provider_telegram_bots
+    has_many :user_identity_providers, through: :user_identity_provider_telegram_bots
+  end
+end

--- a/app/models/spree_cm_commissioner/user_identity_provider.rb
+++ b/app/models/spree_cm_commissioner/user_identity_provider.rb
@@ -10,6 +10,9 @@ module SpreeCmCommissioner
     validates :identity_type, presence: true
     validates :identity_type, uniqueness: { scope: :user_id }
 
+    has_many :user_identity_provider_telegram_bots
+    has_many :telegram_bots, through: :user_identity_provider_telegram_bots
+
     # sub is a telegram uid, which telegram considered a chatID if
     # user have /started with bot.
     def telegram_chat_id

--- a/app/models/spree_cm_commissioner/user_identity_provider_telegram_bot.rb
+++ b/app/models/spree_cm_commissioner/user_identity_provider_telegram_bot.rb
@@ -1,0 +1,10 @@
+module SpreeCmCommissioner
+  class UserIdentityProviderTelegramBot < Base
+    belongs_to :user_identity_provider, optional: false
+    belongs_to :telegram_bot, optional: false
+
+    def self.last_sign_in
+      order(last_sign_in_at: :desc).first
+    end
+  end
+end

--- a/app/overrides/spree/admin/shared/sub_menu/_integrations/telegram_bot.html.erb.deface
+++ b/app/overrides/spree/admin/shared/sub_menu/_integrations/telegram_bot.html.erb.deface
@@ -1,0 +1,3 @@
+<!-- insert_bottom "[data-hook='admin_integrations']" -->
+
+<%= tab :telegram_bots, match_path: '/telegram_bots', label: 'Telegram Bots' if can? :manage, SpreeCmCommissioner::TelegramBot %>

--- a/app/services/spree_cm_commissioner/user_authenticator.rb
+++ b/app/services/spree_cm_commissioner/user_authenticator.rb
@@ -19,7 +19,7 @@ module SpreeCmCommissioner
         options = { id_token: params[:id_token] }
         SpreeCmCommissioner::UserIdTokenAuthenticator.call(options)
       when 'telegram_web_app_auth'
-        options = { telegram_init_data: params[:telegram_init_data] }
+        options = { telegram_init_data: params[:telegram_init_data], telegram_bot_username: params[:tg_bot] }
         SpreeCmCommissioner::UserTelegramWebAppAuthenticator.call(options)
       end
     end
@@ -27,7 +27,7 @@ module SpreeCmCommissioner
     def self.flow_type(params)
       return 'login_auth' if params.key?(:username) && params.key?(:password)
       return 'social_auth' if params.key?(:id_token)
-      return 'telegram_web_app_auth' if params.key?(:telegram_init_data)
+      return 'telegram_web_app_auth' if params.key?(:telegram_init_data) && params.key?(:tg_bot)
 
       raise exception(I18n.t('authenticator.invalid_or_missing_params'))
     end

--- a/app/views/spree/admin/telegram_bots/_form.html.erb
+++ b/app/views/spree/admin/telegram_bots/_form.html.erb
@@ -1,0 +1,16 @@
+<div data-hook="admin_telegram_bot_form_fields" class= "row">
+   <div class="col-6">
+    <%= f.field_container :username do %>
+      <%= f.label :username, Spree.t(:username) %> <span class="required">*</span>
+      <%= f.text_field :username, class: 'form-control', placeholder: 'eg. bookmeplus_bot', disabled: @object.persisted? %>
+      <%= f.error_message_on :username %>
+    <% end %>
+  </div>
+  <div class="col-6">
+    <%= f.field_container :token do %>
+      <%= f.label :token, Spree.t(:token) %> <span class="required">*</span>
+      <%= f.text_field :token, class: 'form-control', value: nil, placeholder: obfuscate_token(f.object.token) %>
+      <%= f.error_message_on :token %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/spree/admin/telegram_bots/edit.html.erb
+++ b/app/views/spree/admin/telegram_bots/edit.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title do %>
+  <%= link_to Spree.t('telegram_bots.title'), spree.admin_telegram_bots_url %> / @<%= @object.username %>
+<% end %>
+
+<div data-hook="admin_telegram_bots" class="card mb-3">
+  <div class="card-header">
+    <h5 class="card-title mb-0 h6">
+      <%= Spree.t('telegram_bots.title') %>
+    </h5>
+  </div>
+  <div class="card-body">
+    <div data-hook="admin_telegram_bots_edit_form_header">
+      <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @object} %>
+    </div>
+    <div data-hook="admin_telegram_bots_edit_form">
+      <%= form_with model: @object, url: { action: 'update' } do |f| %>
+        <%= render partial: 'form', locals: { f: f } %>
+        <div data-hook="admin_telegram_bots_edit_form_button">
+          <%= render partial: 'spree/admin/shared/edit_resource_links' %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/spree/admin/telegram_bots/index.html.erb
+++ b/app/views/spree/admin/telegram_bots/index.html.erb
@@ -1,0 +1,43 @@
+<% content_for :page_title do %>
+  <%= link_to Spree.t('telegram_bots.title'), spree.admin_telegram_bots_url %>
+<% end %>
+
+<% content_for :page_actions do %>
+  <%= button_link_to Spree.t(:new_telegram_bot), new_admin_telegram_bot_path, class: "btn-success", icon: 'add.svg' %>
+<% end if can? :create, SpreeCmCommissioner::TelegramBot %>
+
+<% if @telegram_bots.any? %>
+  <div class="table-responsive border rounded bg-white mb-3">
+    <table class="table" id="listing_telegram_bots" data-hook>
+      <thead class="text-muted">
+        <tr data-hook="admin_user_telegram_bots_index_headers">
+          <th><%= Spree.t(:id) %></th>
+          <th><%= Spree.t(:username) %></th>
+          <th><%= Spree.t(:created_at) %></th>
+          <th><%= Spree.t(:updated_at) %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @telegram_bots.each do |telegram_bot| %>
+          <tr id="<%= spree_dom_id telegram_bot %>" data-hook="admin_telegram_bots_index_rows">
+            <td><%= telegram_bot.id %></td>
+            <td><%= telegram_bot.username %></td>
+            <td><%= telegram_bot.created_at %></td>
+            <td><%= telegram_bot.updated_at %></td>
+
+            <td data-hook="admin_telegram_bots_index_row_actions" class="actions">
+              <span class="d-flex justify-content-end">
+                <%= link_to_edit telegram_bot, url: edit_admin_telegram_bot_path(telegram_bot), no_text: true if can?(:edit, telegram_bot) %>
+                <%= link_to_delete telegram_bot, url: admin_telegram_bot_path(telegram_bot), no_text: true if can?(:delete, telegram_bot) %>
+              </span>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% else %>
+  <small class="form-text text-muted">
+      <%= raw Spree.t('telegram_bots.empty_info') %>
+   </small>
+<% end %>

--- a/app/views/spree/admin/telegram_bots/new.html.erb
+++ b/app/views/spree/admin/telegram_bots/new.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title do %>
+  <%= link_to Spree.t('telegram_bots.title'), spree.admin_telegram_bots_url %>
+<% end %>
+
+<div data-hook="admin_telegram_bots" class="card mb-3">
+  <div class="card-header">
+    <h5 class="card-title mb-0 h6">
+      <%= Spree.t('telegram_bots.title') %>
+    </h5>
+  </div>
+  <div class="card-body">
+    <div data-hook="admin_telegram_bots_edit_form_header">
+      <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @object } %>
+    </div>
+    <div data-hook="admin_telegram_bots_edit_form">
+        <%= form_with model: @object, url: { action: 'create' } do |f| %>
+        <%= render partial: 'form', locals: { f: f } %>
+        <div data-hook="admin_new_telegram_bot_new_form_buttons">
+          <%= render partial: 'spree/admin/shared/new_resource_links' %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -239,6 +239,9 @@ en:
         name: "Create guest item adjustment"
         description: "Create guest item adjustment"
     term_and_condition_promotion: "Term And Condition Of Promotions"
+    telegram_bots:
+      title: "Telegram Bots"
+      empty_info: "No <b>Telegram Bot</b> found"
     date_rule:
       match_any: "Some line items must within selected date"
       match_all: "All line items must within selected date"

--- a/config/locales/km.yml
+++ b/config/locales/km.yml
@@ -215,6 +215,9 @@ km:
         name: "Create guest item adjustment"
         description: "Create guest item adjustment"
     term_and_condition_promotion: "Term And Condition Of Promotions"
+    telegram_bots:
+      title: "Telegram Bots"
+      empty_info: "No <b>Telegram Bot</b> found"
     date_rule:
       match_any: "Some line items must within selected date"
       match_all: "All line items must within selected date"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -228,6 +228,7 @@ Spree::Core::Engine.add_routes do
     end
 
     resources :user_events, except: %i[show edit update]
+    resources :telegram_bots
 
     resources :webhooks_subscribers do
       resources :rules, controller: :webhooks_subscriber_rules, except: %i[index show]

--- a/db/migrate/20240823093714_create_cm_telegram_bots.rb
+++ b/db/migrate/20240823093714_create_cm_telegram_bots.rb
@@ -1,0 +1,10 @@
+class CreateCmTelegramBots < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cm_telegram_bots, if_not_exists: true do |t|
+      t.string :username, index: true
+      t.string :token
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240823124521_create_cm_user_identity_provider_telegram_bots.rb
+++ b/db/migrate/20240823124521_create_cm_user_identity_provider_telegram_bots.rb
@@ -1,0 +1,12 @@
+class CreateCmUserIdentityProviderTelegramBots < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cm_user_identity_provider_telegram_bots, if_not_exists: true do |t|
+      t.references :telegram_bot, null: false, foreign_key: { to_table: :cm_telegram_bots }, index: { name: "index_user_identity_provider_tg_bots_on_tg_bot" }
+      t.references :user_identity_provider, null: false, foreign_key: { to_table: :cm_user_identity_providers }, index: { name: "index_user_identity_provider_tg_bots_on_user_identity_provider" }
+
+      t.datetime :last_sign_in_at
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/spree_cm_commissioner/test_helper/factories/telegram_bot_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/telegram_bot_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :cm_telegram_bot, class: SpreeCmCommissioner::TelegramBot do
+    token { '6441690414:AAFBpevRdBaRTXmalJR2vcSdPNzYoDnMEFk' }
+    username { 'contigoasiabot' }
+  end
+end

--- a/lib/spree_cm_commissioner/test_helper/factories/user_identity_provider_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/user_identity_provider_factory.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     sequence(:sub) { |n| "sub-#{n}" }
     identity_type { SpreeCmCommissioner::UserIdentityProvider.identity_types[:google] }
     email { 'fake@example.com' }
+    user { |t| t.association(:user) }
 
     trait :telegram do
       identity_type { SpreeCmCommissioner::UserIdentityProvider.identity_types[:telegram] }

--- a/spec/interactors/spree_cm_commissioner/order_complete_telegram_sender_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/order_complete_telegram_sender_spec.rb
@@ -26,21 +26,19 @@ RSpec.describe SpreeCmCommissioner::OrderCompleteTelegramSender do
     end
 
     context 'when order is associated with a user & user is connected to Telegram', :vcr do
-      let!(:provider1) { create(:user_identity_provider, user: user, identity_type: :telegram, sub: '2241690414') }
+      let!(:telegram_bot) { create(:cm_telegram_bot, token: 'this-is-bot-token') }
+      let!(:provider1) { create(:user_identity_provider, user: user, identity_type: :telegram, sub: '2241690414', telegram_bots: [telegram_bot]) }
       let!(:provider2) { create(:user_identity_provider, user: user, identity_type: :google) }
 
       let(:user) { create(:user) }
       let(:order) { create(:completed_order_with_totals, user: user) }
-      let(:telegram_client) { Telegram::Bot::Client.new(token: 'this-is-bot-token') }
 
       it 'send photo to provider chat ID' do
         expect(provider1.telegram_chat_id).to eq '2241690414'
         expect(provider2.telegram_chat_id).to eq nil
 
-        expect_any_instance_of(described_class).to receive(:send).with('2241690414').once.and_call_original
-        expect_any_instance_of(described_class).to receive(:telegram_client).and_return(telegram_client)
-
-        expect(telegram_client).to receive(:send_photo).once.and_call_original
+        expect_any_instance_of(described_class).to receive(:send).with(telegram_bot.token, '2241690414').once.and_call_original
+        expect_any_instance_of(::Telegram::Bot::Client).to receive(:send_photo).once.and_call_original
 
         context = described_class.call(order: order)
         expect(context.success?).to be true

--- a/spec/interactors/spree_cm_commissioner/user_telegram_web_app_authenticator_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/user_telegram_web_app_authenticator_spec.rb
@@ -7,50 +7,87 @@ RSpec.describe SpreeCmCommissioner::UserTelegramWebAppAuthenticator do
 
   describe '.call' do
     context 'when init data is VALID' do
-      before do
-        allow_any_instance_of(described_class).to receive(:telegram_bot_token).and_return(valid_bot_token)
+      let!(:telegram_bot) { create(:cm_telegram_bot, token: valid_bot_token) }
+
+      context 'when user is not yet connect with telegram provider' do
+        it 'create a new user' do
+          context = described_class.call(telegram_init_data: telegram_init_data, telegram_bot_username: telegram_bot.username)
+
+          expect(context.success?).to eq true
+
+          # created user
+          expect(context.user.id).to be_present
+          expect(context.user.first_name).to eq 'Spooky'
+          expect(context.user.last_name).to eq ''
+          expect(context.user.user_identity_providers.pluck(:sub)).to eq ['1029000609']
+          expect(context.user.user_identity_providers.pluck(:name)).to eq ['theacontigo']
+          expect(context.user.user_identity_providers.first.telegram_bots.pluck(:id)).to match_array [telegram_bot.id]
+
+          # reference data
+          expect(context.telegram_user['first_name']).to eq 'Spooky'
+          expect(context.telegram_user['last_name']).to eq ''
+          expect(context.telegram_user['id']).to eq 1029000609
+          expect(context.telegram_user['username']).to eq 'theacontigo'
+        end
       end
 
-      it 'create a new user when user not connect with telegram yet' do
+      context 'when user already connected to telegram provider' do
+        it 'create return old user when user already already connected before' do
+          context1 = described_class.call(telegram_init_data: telegram_init_data, telegram_bot_username: telegram_bot.username)
+          context2 = described_class.call(telegram_init_data: telegram_init_data, telegram_bot_username: telegram_bot.username)
 
-        context = described_class.call(telegram_init_data: telegram_init_data)
-
-        expect(context.success?).to eq true
-
-        # created user
-        expect(context.user.id).to be_present
-        expect(context.user.first_name).to eq 'Spooky'
-        expect(context.user.last_name).to eq ''
-        expect(context.user.user_identity_providers.pluck(:sub)).to eq ['1029000609']
-        expect(context.user.user_identity_providers.pluck(:name)).to eq ['theacontigo']
-
-        # reference data
-        expect(context.telegram_user['first_name']).to eq 'Spooky'
-        expect(context.telegram_user['last_name']).to eq ''
-        expect(context.telegram_user['id']).to eq 1029000609
-        expect(context.telegram_user['username']).to eq 'theacontigo'
+          expect(context1.success?).to eq true
+          expect(context2.success?).to eq true
+          expect(context1.user).to eq context2.user
+        end
       end
 
-      it 'create return old user when already connected before' do
-        context1 = described_class.call(telegram_init_data: telegram_init_data)
-        context2 = described_class.call(telegram_init_data: telegram_init_data)
+      context 'when user already connected to telegram provider but provider & telegram_bot is not yet connected' do
+        it 'create user_identity_provider_telegram_bots' do
+          # create existing
+          context1 = described_class.call(telegram_init_data: telegram_init_data, telegram_bot_username: telegram_bot.username)
+          expect(context1.user.user_identity_providers.first.telegram_bots.pluck(:id)).to match_array [telegram_bot.id]
 
-        expect(context1.success?).to eq true
-        expect(context2.success?).to eq true
-        expect(context1.user).to eq context2.user
+          # remove connection
+          SpreeCmCommissioner::UserIdentityProviderTelegramBot.delete_all
+          expect(context1.user.user_identity_providers.first.telegram_bots.pluck(:id)).to match_array []
+
+          # when call service again, it should reconnect provider & telegram_bot
+          context2 = described_class.call(telegram_init_data: telegram_init_data, telegram_bot_username: telegram_bot.username)
+
+          expect(context2.success?).to eq true
+          expect(context1.user).to eq context2.user
+          expect(context2.user.user_identity_providers.first.telegram_bots.pluck(:id)).to match_array [telegram_bot.id]
+        end
       end
     end
 
     context 'when init data is INVALID' do
-      before do
-        allow_any_instance_of(described_class).to receive(:telegram_bot_token).and_return(invalid_bot_token)
-      end
+      let!(:telegram_bot) { create(:cm_telegram_bot, token: invalid_bot_token) }
 
       it 'raise error' do
-        context = described_class.call(telegram_init_data: telegram_init_data)
+        context = described_class.call(telegram_init_data: telegram_init_data, telegram_bot_username: telegram_bot.username)
 
         expect(context.success?).to eq false
         expect(context.message).to eq 'invalid_init_data'
+      end
+    end
+
+    context 'when telegram_bot_username is invalid or not exist in db' do
+      let!(:telegram_bot) { create(:cm_telegram_bot) }
+
+      it 'return error' do
+        context = described_class.call(telegram_init_data: telegram_init_data, telegram_bot_username: 'this-bot-not-exist')
+
+        expect(context.success?).to eq false
+        expect(context.message).to eq 'telegram_bot_username_is_not_valid_or_not_exist_in_db'
+      end
+
+      it 'return error when not pass the telegram_bot_username' do
+        context = described_class.call(telegram_init_data: telegram_init_data)
+
+        expect(context.success?).to eq false
+        expect(context.message).to eq 'telegram_bot_username_is_not_valid_or_not_exist_in_db'
       end
     end
   end

--- a/spec/models/spree_cm_commissioner/telegram_bot_spec.rb
+++ b/spec/models/spree_cm_commissioner/telegram_bot_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::TelegramBot, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:username) }
+    it { is_expected.to validate_presence_of(:token) }
+  end
+
+  describe 'associations' do
+    it { is_expected.to have_many(:user_identity_provider_telegram_bots) }
+    it { is_expected.to have_many(:user_identity_providers).through(:user_identity_provider_telegram_bots) }
+  end
+end

--- a/spec/models/spree_cm_commissioner/user_identity_provider_telegram_bot_spec.rb
+++ b/spec/models/spree_cm_commissioner/user_identity_provider_telegram_bot_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::UserIdentityProviderTelegramBot, type: :model do
+  describe 'associations' do
+    it { is_expected.to belong_to(:user_identity_provider).required }
+    it { is_expected.to belong_to(:telegram_bot).required }
+  end
+
+  describe '.last_sign_in' do
+    let(:telegram_bot) { create(:cm_telegram_bot) }
+    let(:user_identity_provider1) { create(:user_identity_provider, :telegram) }
+    let(:user_identity_provider2) { create(:user_identity_provider, :telegram) }
+    let(:user_identity_provider3) { create(:user_identity_provider, :telegram) }
+
+    let!(:provider_telegram1) { described_class.create(telegram_bot: telegram_bot, user_identity_provider: user_identity_provider1, last_sign_in_at: Time.zone.now - 1.days)}
+    let!(:provider_telegram2) { described_class.create(telegram_bot: telegram_bot, user_identity_provider: user_identity_provider2, last_sign_in_at: Time.zone.now)}
+    let!(:provider_telegram3) { described_class.create(telegram_bot: telegram_bot, user_identity_provider: user_identity_provider3, last_sign_in_at: Time.zone.now - 2.days)}
+
+    it 'return last sign in' do
+      expect(described_class.last_sign_in).to eq provider_telegram2
+    end
+  end
+end

--- a/spec/queries/spree_cm_commissioner/line_item_searcher_query_spec.rb
+++ b/spec/queries/spree_cm_commissioner/line_item_searcher_query_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe SpreeCmCommissioner::LineItemSearcherQuery do
           let(:params) { { event_id: event.id, qr_data: complete_order_a.qr_data } }
 
           it 'return all line items in order' do
-            expect(subject.call).to eq complete_order_a.line_items
+            expect(subject.call).to match_array complete_order_a.line_items
           end
         end
 
@@ -63,7 +63,7 @@ RSpec.describe SpreeCmCommissioner::LineItemSearcherQuery do
         let(:params) { { event_id: event.id, qr_data: complete_line_item_a.qr_data } }
 
         it 'return all line items in order' do
-          expect(subject.call).to eq [complete_line_item_a]
+          expect(subject.call).to match_array [complete_line_item_a]
         end
       end
 
@@ -71,7 +71,7 @@ RSpec.describe SpreeCmCommissioner::LineItemSearcherQuery do
         let(:params) { { event_id: event.id, qr_data: guest_a.qr_data} }
 
         it 'return line items of guest' do
-          expect(subject.call).to eq [guest_a.line_item]
+          expect(subject.call).to match_array [guest_a.line_item]
         end
       end
 
@@ -85,13 +85,13 @@ RSpec.describe SpreeCmCommissioner::LineItemSearcherQuery do
           search_by_order_phone = described_class.new({ event_id: event.id, term: complete_order_a.reload.phone_number })
           search_by_line_item_number = described_class.new({ event_id: event.id, term: complete_line_item_a.reload.number })
 
-          expect(search_by_guest_first_name.call).to eq [guest_a.line_item]
-          expect(search_by_guest_last_name.call).to eq [guest_a.line_item]
-          expect(search_by_guest_full_name.call).to eq [guest_a.line_item]
-          expect(search_by_order_number.call).to eq complete_order_a.line_items
-          expect(search_by_order_email.call).to eq complete_order_a.line_items
-          expect(search_by_order_phone.call).to eq complete_order_a.line_items
-          expect(search_by_line_item_number.call).to eq [complete_line_item_a]
+          expect(search_by_guest_first_name.call).to match_array [guest_a.line_item]
+          expect(search_by_guest_last_name.call).to match_array [guest_a.line_item]
+          expect(search_by_guest_full_name.call).to match_array [guest_a.line_item]
+          expect(search_by_order_number.call).to match_array complete_order_a.line_items
+          expect(search_by_order_email.call).to match_array complete_order_a.line_items
+          expect(search_by_order_phone.call).to match_array complete_order_a.line_items
+          expect(search_by_line_item_number.call).to match_array [complete_line_item_a]
         end
       end
 
@@ -99,7 +99,7 @@ RSpec.describe SpreeCmCommissioner::LineItemSearcherQuery do
         let(:params) { { event_id: event.id } }
 
         it 'return all line items for the event' do
-          expect(subject.call).to eq [complete_line_item_a, complete_line_item_b]
+          expect(subject.call).to match_array [complete_line_item_a, complete_line_item_b]
         end
       end
     end

--- a/spec/services/spree_cm_commissioner/user_authenticator_spec.rb
+++ b/spec/services/spree_cm_commissioner/user_authenticator_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe SpreeCmCommissioner::UserAuthenticator do
   end
 
   describe '.flow_type' do
-    it 'return [telegram_web_app_auth] when params contain telegram_init_data' do
-      flow_type = described_class.flow_type({ telegram_init_data: 'anything-as-long-as-present' })
+    it 'return [telegram_web_app_auth] when params contain telegram_init_data & tg_bot' do
+      flow_type = described_class.flow_type({ telegram_init_data: 'anything-as-long-as-present', tg_bot: 'bookmeplus_bot' })
 
       expect(flow_type).to eq 'telegram_web_app_auth'
     end


### PR DESCRIPTION
## In this PR?
### 1. New telegram_bot MVC

| |
| - |
| a. Index |
| <img width="1728" alt="image" src="https://github.com/user-attachments/assets/c51908e6-9c98-49ab-90f4-de997eaae259"> |
| b. New |
| <img width="1728" alt="image" src="https://github.com/user-attachments/assets/6ca7a17e-9426-4d38-960d-5a62721c182a"> |
| c. Edit, we hide token here for security reasons, admin can read actual tokens from the database or @bot_father directly. |
| <img width="1728" alt="image" src="https://github.com/user-attachments/assets/b315eb72-b678-4ad2-9100-44e3a582bb63"> |

### 2. Make sure it create association between user identity provider & telegram when open bot
- Refactor UserTelegramWebAppAuthenticator for validate initData with telegram web bot from new model (TelegramBot).
  Client must pass tg_bot when authenticate in advance.
- Refactor OrderCompleteTelegramSender to send message to user with bot from new model instead of bot

> So we no longer need default telegram bot from env for Telegram web app related features

DEMO:

<img src="https://github.com/user-attachments/assets/312df926-1547-49ee-8ce6-d3f847c1e86f" width="350px" />
