### PR TITLE
close #1859 fix wrong stock availability check when there is no booking

### DIFF
--- a/app/models/spree_cm_commissioner/variant_decorator.rb
+++ b/app/models/spree_cm_commissioner/variant_decorator.rb
@@ -16,6 +16,7 @@ module SpreeCmCommissioner
                                             }, through: :option_value_variants, source: :option_value
 
       base.has_many :video_on_demands, class_name: 'SpreeCmCommissioner::VideoOnDemand', dependent: :destroy
+      base.has_many :complete_line_items, -> { complete }, class_name: 'Spree::LineItem'
 
       base.has_many :variant_guest_card_class, class_name: 'SpreeCmCommissioner::VariantGuestCardClass'
       base.has_many :guest_card_classes, class_name: 'SpreeCmCommissioner::GuestCardClass', through: :variant_guest_card_class

--- a/app/queries/spree_cm_commissioner/variant_availability/non_permanent_stock_query.rb
+++ b/app/queries/spree_cm_commissioner/variant_availability/non_permanent_stock_query.rb
@@ -9,14 +9,22 @@ module SpreeCmCommissioner
       end
 
       def available?(quantity)
-        Spree::LineItem
+        reserve_variants =
+          Spree::LineItem
           .complete
           .select('(SUM(DISTINCT spree_stock_items.count_on_hand) - SUM(spree_line_items.quantity)) AS available_quantity')
           .joins(variant: :stock_items)
           .where(variant_id: variant.id)
           .where.not(id: except_line_item_id)
           .group(:variant_id)
-          .all? { |record| record.available_quantity - quantity >= 0 }
+
+        # there is a case when variant does not have any purchaces yet, it will return empty & always available true.
+        # in this case, we check with stock items directly.
+        if reserve_variants.any?
+          reserve_variants.all? { |record| record.available_quantity >= quantity }
+        else
+          variant.stock_items.sum(:count_on_hand) >= quantity
+        end
       end
     end
   end

--- a/app/services/spree_cm_commissioner/checkout/update_decorator.rb
+++ b/app/services/spree_cm_commissioner/checkout/update_decorator.rb
@@ -1,0 +1,16 @@
+module SpreeCmCommissioner
+  module Checkout
+    module UpdateDecorator
+      # override
+      def call(order:, params:, permitted_attributes:, request_env:)
+        return failure(order) unless order.ensure_line_items_are_in_stock
+
+        super
+      end
+    end
+  end
+end
+
+unless Spree::Checkout::Update.included_modules.include?(SpreeCmCommissioner::Checkout::UpdateDecorator)
+  Spree::Checkout::Update.prepend(SpreeCmCommissioner::Checkout::UpdateDecorator)
+end

--- a/spec/queries/spree_cm_commissioner/variant_availability/non_permanent_stock_query_spec.rb
+++ b/spec/queries/spree_cm_commissioner/variant_availability/non_permanent_stock_query_spec.rb
@@ -46,5 +46,15 @@ RSpec.describe SpreeCmCommissioner::VariantAvailability::NonPermanentStockQuery 
         expect(subject.available?(4)).to eq false
       end
     end
+
+    context 'when previously has no purchased line items' do
+      let(:available_quantity) { 5 }
+
+      it 'return availability base on quantity' do
+        expect(subject.available?(5)).to eq true
+        expect(subject.available?(6)).to eq false
+        expect(subject.available?(8)).to eq false
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem
When there is no booking yet, it returns empty array, so `[].all? = true` which mean no available.

## Solution
To fix this, I check if it empty, should check with stock items instead. This will trigger database 2 times. I will look for way to improve this later.

I also add a logic to recheck stock before updating order (update contact, create payment, etc) to prevent user from booking.