### PR TITLE
close #1862 add high demand to variants and line_items

### DIFF
--- a/app/models/spree_cm_commissioner/line_item_decorator.rb
+++ b/app/models/spree_cm_commissioner/line_item_decorator.rb
@@ -21,7 +21,7 @@ module SpreeCmCommissioner
       base.whitelisted_ransackable_associations |= %w[guests]
       base.whitelisted_ransackable_attributes |= %w[number to_date from_date]
 
-      base.delegate :delivery_required?, :permanent_stock?,
+      base.delegate :delivery_required?, :permanent_stock?, :high_demand,
                     to: :variant
       base.delegate :discontinue_on,
                     to: :product

--- a/app/overrides/spree/admin/variants/_form/add_high_demand_field.html.erb.deface
+++ b/app/overrides/spree/admin/variants/_form/add_high_demand_field.html.erb.deface
@@ -1,0 +1,13 @@
+<!-- insert_bottom "[data-hook='admin_variant_form_additional_fields']" -->
+
+<div class="form-row">
+  <div class="form-group col-md-12">
+    <%= f.field_container :high_demand do %>
+      <%= f.label :high_demand, Spree.t(:high_demand) %>
+      <%= f.radio_button :high_demand, true %>
+      <%= f.label :high_demand, Spree.t(:yes), value: true %>
+      <%= f.radio_button :high_demand, false %>
+      <%= f.label :high_demand, Spree.t(:no), value: false %>
+    <% end %>
+  </div>
+</div>

--- a/app/serializers/spree/v2/storefront/line_item_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/line_item_serializer_decorator.rb
@@ -6,11 +6,13 @@ module Spree
           base.attributes :from_date, :to_date, :need_confirmation, :product_type, :event_status, :amount, :display_amount,
                           :number, :qr_data,
                           :kyc, :kyc_fields, :remaining_total_guests, :number_of_guests,
-                          :completion_steps, :available_social_contact_platforms, :allow_anonymous_booking, :discontinue_on
+                          :completion_steps, :available_social_contact_platforms, :allow_anonymous_booking, :discontinue_on,
+                          :high_demand
 
           base.attribute :allowed_self_check_in, &:allowed_self_check_in?
           base.attribute :allowed_upload_later, &:allowed_upload_later?
           base.attribute :delivery_required, &:delivery_required?
+
           base.has_one :vendor
 
           base.belongs_to :order, serializer: Spree::V2::Storefront::OrderSerializer

--- a/app/serializers/spree/v2/storefront/variant_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/variant_serializer_decorator.rb
@@ -5,7 +5,7 @@ module Spree
         def self.prepended(base)
           base.attributes :need_confirmation, :product_type, :kyc, :allow_anonymous_booking,
                           :reminder_in_hours, :start_time, :delivery_option,
-                          :number_of_guests, :max_quantity_per_order, :discontinue_on
+                          :number_of_guests, :max_quantity_per_order, :discontinue_on, :high_demand
 
           base.attribute :delivery_required, &:delivery_required?
 

--- a/db/migrate/20240831141649_add_high_demand_to_spree_variants.rb
+++ b/db/migrate/20240831141649_add_high_demand_to_spree_variants.rb
@@ -1,0 +1,5 @@
+class AddHighDemandToSpreeVariants < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_variants, :high_demand, :boolean, default: false, if_not_exists: true
+  end
+end

--- a/spec/jobs/spree_cm_commissioner/telegram_start_message_sender_job_spec.rb
+++ b/spec/jobs/spree_cm_commissioner/telegram_start_message_sender_job_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe SpreeCmCommissioner::TelegramStartMessageSenderJob do
   let(:chat_id) { 123456 }
-  let(:telegram_bot_id) { 1 }
+  let(:telegram_bot_id) { telegram_bot.id }
 
   let(:telegram_bot) { create(:cm_telegram_bot) }
 

--- a/spec/serializers/spree/v2/storefront/line_item_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/line_item_serializer_spec.rb
@@ -56,11 +56,13 @@ RSpec.describe Spree::V2::Storefront::LineItemSerializer, type: :serializer do
         :available_social_contact_platforms,
         :allowed_upload_later,
         :allow_anonymous_booking,
-        :discontinue_on
+        :discontinue_on,
+        :high_demand
       )
 
       expect(subject[:data][:attributes][:qr_data]).to eq line_item.qr_data
       expect(subject[:data][:attributes][:number]).to eq line_item.number
+      expect(subject[:data][:attributes][:high_demand]).to eq line_item.high_demand
     end
 
     it 'returns exact accommodation relationships' do

--- a/spec/serializers/spree/v2/storefront/variant_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/variant_serializer_spec.rb
@@ -44,7 +44,8 @@ describe Spree::V2::Storefront::VariantSerializer, type: :serializer do
         :delivery_option,
         :delivery_required,
         :allow_anonymous_booking,
-        :discontinue_on
+        :discontinue_on,
+        :high_demand
       )
     end
 
@@ -64,6 +65,16 @@ describe Spree::V2::Storefront::VariantSerializer, type: :serializer do
 
       expect(stock_items[0][:attributes][:count_on_hand]).to eq 0
       expect(stock_items[1][:attributes][:count_on_hand]).to eq 0
+    end
+
+    it 'returns high_demand' do
+      variant.update!(high_demand: true)
+      expect(subject[:data][:attributes][:high_demand]).to eq(true)
+    end
+
+    it 'returns high_demand as false when it is not set' do
+      variant.update!(high_demand: false)
+      expect(subject[:data][:attributes][:high_demand]).to eq(false)
     end
   end
 end


### PR DESCRIPTION
### In this PR
We want just to Mark Variant of the Product High_demand Manually Update No | Yes , by default: false
- add high_demand in spree_variants
- add high_demand field to variant edit page
- add high_demand to variant serializer & its specs
- add high_demand to line item serializer (delegate from variant)

### DEMO 
https://github.com/user-attachments/assets/f4638d57-b9c9-4a50-8474-c2476bc27c5e

