### PR TITLE
close #1866 improve telegram send message

### DIFF
--- a/app/controllers/spree_cm_commissioner/admin/orders_controller_decorator.rb
+++ b/app/controllers/spree_cm_commissioner/admin/orders_controller_decorator.rb
@@ -82,6 +82,9 @@ module SpreeCmCommissioner
           send_order_requested_telegram_alert_to_store
           send_order_accepted_telegram_alert_to_store
           send_order_rejected_telegram_alert_to_store
+
+          notify_order_complete_app_notification_to_user
+          notify_order_complete_telegram_notification_to_user
         ]
 
         @webhook_events = [

--- a/app/models/spree_cm_commissioner/order_decorator.rb
+++ b/app/models/spree_cm_commissioner/order_decorator.rb
@@ -2,8 +2,8 @@ module SpreeCmCommissioner
   module OrderDecorator
     def self.prepended(base) # rubocop:disable Metrics/MethodLength
       base.include SpreeCmCommissioner::PhoneNumberSanitizer
-      base.include SpreeCmCommissioner::OrderRequestable
       base.include SpreeCmCommissioner::OrderBibNumberConcern
+      base.include SpreeCmCommissioner::OrderRequestable
 
       base.scope :subscription, -> { where.not(subscription_id: nil) }
       base.scope :paid, -> { where(payment_state: :paid) }

--- a/app/serializers/spree_cm_commissioner/v2/storefront/guest_serializer.rb
+++ b/app/serializers/spree_cm_commissioner/v2/storefront/guest_serializer.rb
@@ -6,7 +6,12 @@ module SpreeCmCommissioner
 
         attributes :first_name, :last_name, :dob, :gender, :kyc_fields, :other_occupation, :created_at, :updated_at,
                    :qr_data, :social_contact_platform, :social_contact, :available_social_contact_platforms,
-                   :age, :emergency_contact, :other_organization, :expectation, :upload_later, :address, :seat_number, :formatted_bib_number
+                   :age, :emergency_contact, :other_organization, :expectation, :upload_later, :address, :formatted_bib_number
+
+        # temporary, once app release after cm-app v1.9.1, we no longer need this.
+        attribute :seat_number do |object|
+          object.seat_number || object.formatted_bib_number
+        end
 
         attribute :allowed_checkout, &:allowed_checkout?
         attribute :allowed_upload_later, &:allowed_upload_later?


### PR DESCRIPTION
## In this PR
- Improve telegram message
- Make sure guest generate before send telegram message
- Allow admin to resend order


<img width="449" alt="image" src="https://github.com/user-attachments/assets/1a672b16-c310-49f7-8ed7-07321e071564">

---

We can now go to order page to resend ticket:
<img width="1454" alt="image" src="https://github.com/user-attachments/assets/3eafeebd-554d-4244-a8f8-dcfa64537cec">
