### PR TITLE
close #1901 create update_taxons task and remove unnecessary attribute

### DIFF
--- a/app/controllers/spree/admin/taxons_controller_decorator.rb
+++ b/app/controllers/spree/admin/taxons_controller_decorator.rb
@@ -23,10 +23,6 @@ module Spree
 
       private
 
-      def taxon_params
-        params.require(:taxon).permit(permitted_taxon_attributes, :preferred_background_color, :preferred_foreground_color)
-      end
-
       def remove_asset(asset)
         if asset.destroy
           flash[:success] = Spree.t('notice_messages.icon_removed')

--- a/lib/tasks/update_taxons.rake
+++ b/lib/tasks/update_taxons.rake
@@ -1,0 +1,7 @@
+# recommend to be used in schedule.yml & manually access in /sidekiq/cron
+namespace :spree_cm_commissioner do
+  desc 'Update each Taxon'
+  task update_taxons: :environment do
+    Spree::Taxon.find_each(&:touch)
+  end
+end


### PR DESCRIPTION
```rb
# recommend to be used in schedule.yml & manually access in /sidekiq/cron
namespace :spree_cm_commissioner do
  desc 'Update each Taxon'
  task update_taxons: :environment do
    Spree::Taxon.find_each(&:touch)
  end
end
```

```rb
Spree::Taxon.find_each(&:touch) will iterate over each Taxon in batches and 
call touch on each one. This will update the updated_at timestamp of each Taxon, which will trigger the update callbacks.

you don't need to call .save after .touch.

The touch method in Rails updates the updated_at timestamp of a record and 
automatically saves the record to the database. It also triggers the save callbacks.

So, in your case, Spree::Taxon.find_each(&:touch) is 
sufficient to update the updated_at timestamp of each Taxon and save it to the database.
```