### PR TITLE
close #1909 query for active customer for invoice recurring only

### DIFF
--- a/app/interactors/spree_cm_commissioner/subscriptions_order_cron_executor.rb
+++ b/app/interactors/spree_cm_commissioner/subscriptions_order_cron_executor.rb
@@ -2,7 +2,7 @@ module SpreeCmCommissioner
   class SubscriptionsOrderCronExecutor < BaseInteractor
     def call
       today = Time.zone.today
-      customers = SpreeCmCommissioner::Customer.where('active_subscriptions_count > ?', 0)
+      customers = SpreeCmCommissioner::Customer.where('active_subscriptions_count > ? and status = ?', 0, 0)
       customers.each do |customer|
         SpreeCmCommissioner::SubscriptionsOrderCreator.call(customer: customer, today: today)
       end

--- a/app/models/spree_cm_commissioner/customer.rb
+++ b/app/models/spree_cm_commissioner/customer.rb
@@ -9,6 +9,8 @@ module SpreeCmCommissioner
     before_validation :clone_billing_address, if: :use_billing?
     before_validation :create_customer_user, if: -> { user_id.nil? }
 
+    after_update :handle_status_change, if: :saved_change_to_status?
+
     attr_accessor :use_billing
 
     belongs_to :vendor, class_name: 'Spree::Vendor'
@@ -131,6 +133,13 @@ module SpreeCmCommissioner
       )
 
       update(user_id: user.id)
+    end
+
+    def handle_status_change
+      return unless saved_change_to_status?
+      return unless status_previously_was == 'inactive' && active?
+
+      update(last_invoice_date: Time.zone.today)
     end
   end
 end


### PR DESCRIPTION
- **close #1906 added customer deactivation**

- when customer is switched from `inactive` to `active`, update customer's last invoice date to `today`.
- query only active customer to perform invoice recurring.
