### PR TITLE
close #1924 enchance guest_card qr render with js

### DIFF
--- a/app/controllers/spree/api/v2/storefront/qr_urls_controller.rb
+++ b/app/controllers/spree/api/v2/storefront/qr_urls_controller.rb
@@ -1,0 +1,34 @@
+module Spree
+  module Api
+    module V2
+      module Storefront
+        class QrUrlsController < ::Spree::Api::V2::ResourceController
+          # override
+          def resource_serializer
+            SpreeCmCommissioner::V2::Storefront::QrUrlSerializer
+          end
+
+          def show
+            url = find_url_by_qr_data(params[:id])
+            resource = Struct.new(:id, :url).new(id: params[:id], url: url)
+            render_serialized_payload { serialize_resource(resource) }
+          end
+
+          # currently only support guest QR
+          def find_url_by_qr_data(qr_data)
+            guest_qr_url(qr_data)
+          end
+
+          def guest_qr_url(qr_data)
+            guest = SpreeCmCommissioner::Guest.find_by!(token: qr_data)
+
+            host = Spree.cdn_host || Rails.application.routes.default_url_options[:host]
+            port = Rails.application.routes.default_url_options[:port]
+
+            Rails.application.routes.url_helpers.guest_cards_url(guest.token, host: host, port: port)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/spree_cm_commissioner/guest_cards_controller.rb
+++ b/app/controllers/spree_cm_commissioner/guest_cards_controller.rb
@@ -5,24 +5,15 @@ module SpreeCmCommissioner
     def show
       guest = SpreeCmCommissioner::Guest.find_by!(token: params[:id])
 
-      banner_src = cdn_image_url(guest.line_item.variant.guest_card_classes.first.background_image.attachment)
-      guest_qr_src = "data:image/png;base64,#{Base64.encode64(guest.generate_png_qr(108).to_s).gsub("\n", '')}"
-      event_date = guest.line_item.from_date.strftime('%d %b %Y | %I%p')
-      venue = guest.line_item.product.venue.place.name || 'N/A'
-      ticket_type = guest.line_item.name
-      seat_number = guest.seat_number || guest.formatted_bib_number || 'N/A'
+      # Cache the response
+      cache_key = "#{guest.id}-#{guest.updated_at}-#{guest.line_item.variant.guest_card_classes.first.updated_at}"
 
-      render(
-        template: 'spree_cm_commissioner/guest_cards/show',
-        locals: {
-          banner_src: banner_src,
-          guest_qr_src: guest_qr_src,
-          event_date: event_date,
-          venue: venue,
-          ticket_type: ticket_type,
-          seat_number: seat_number
-        }
-      )
+      Rails.cache.fetch(cache_key, expires_in: 12.hours) do
+        render(
+          template: 'spree_cm_commissioner/guest_cards/show',
+          locals: guest_card_locals(guest)
+        )
+      end
     end
 
     # TODO: render in PNG when url is end with .jpg using 'imgkit'
@@ -44,5 +35,53 @@ module SpreeCmCommissioner
 
     #   send_data image_data, type: 'image/jpeg', disposition: 'inline'
     # end
+
+    private
+
+    def guest_card_locals(guest)
+      {
+        banner_src: banner_src(guest),
+        logo_src: logo_src(guest),
+        guest_qr_data: guest.token,
+        event_date: event_date(guest),
+        venue: venue(guest),
+        ticket_type: guest.line_item.name,
+        seat_number: seat_number(guest),
+        full_name: full_name(guest),
+        phone_number: phone_number(guest)
+      }
+    end
+
+    def banner_src(guest)
+      cdn_image_url(guest.line_item.variant.guest_card_classes.first!.background_image.attachment)
+    end
+
+    def logo_src(guest)
+      cdn_image_url(guest.line_item.vendor.logo.attachment)
+    end
+
+    def event_date(guest)
+      guest.line_item.from_date.strftime('%d %b %Y | %I%p')
+    end
+
+    def venue(guest)
+      guest.line_item.product.venue.place.name || 'N/A'
+    end
+
+    def seat_number(guest)
+      guest.seat_number || guest.formatted_bib_number || 'N/A'
+    end
+
+    def full_name(guest)
+      guest.first_name.present? || guest.last_name.present? ? "#{guest.first_name} #{guest.last_name}" : 'N/A'
+    end
+
+    def phone_number(guest)
+      if guest.phone_number.present?
+        "#{guest.phone_number[0...-3]}***"
+      else
+        'N/A'
+      end
+    end
   end
 end

--- a/app/serializers/spree_cm_commissioner/v2/storefront/qr_url_serializer.rb
+++ b/app/serializers/spree_cm_commissioner/v2/storefront/qr_url_serializer.rb
@@ -1,0 +1,9 @@
+module SpreeCmCommissioner
+  module V2
+    module Storefront
+      class QrUrlSerializer < BaseSerializer
+        attributes :url
+      end
+    end
+  end
+end

--- a/app/views/spree_cm_commissioner/guest_cards/show.html.erb
+++ b/app/views/spree_cm_commissioner/guest_cards/show.html.erb
@@ -9,13 +9,18 @@
         margin: 0;
         padding: 0;
         width: 100%;
-        max-width: 600px;
+        height: 100vh;
+        display: flex;
+        justify-content: center;
+        align-items: center;
         color: #1c1b20;
         font-family: Arial, sans-serif;
       }
       .pass {
         background-color: white;
         padding: 0 0 16px 0;
+        max-width: 600px;
+        width: 100%;
       }
       .banner {
         width: 100%;
@@ -51,12 +56,14 @@
       }
       .qr-code {
         text-align: center;
+        margin-top: 20px;
       }
       .qr-code img {
         width: 108px;
         height: 108px;
       }
     </style>
+    <script type="text/javascript" src="https://unpkg.com/qr-code-styling@1.5.0/lib/qr-code-styling.js"></script>
   </head>
   <body>
     <div class="pass">
@@ -78,6 +85,14 @@
             <td>Ticket Type</td>
             <td><%= ticket_type %></td>
           </tr>
+          <tr>
+            <td>Full Name</td>
+            <td><%= full_name %></td>
+          </tr>
+          <tr>
+            <td>Phone Number</td>
+            <td><%= phone_number %></td>
+          </tr>
         </table>
       </div>
 
@@ -89,7 +104,28 @@
         This QR code is used for individual check-in
       </div>
       <div class="seat-number">No. <%= seat_number %></div>
-      <div class="qr-code"><img src="<%= guest_qr_src %>" alt="QR Code" /></div>
+      <div id="canvas" class="qr-code"></div>
     </div>
+
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+        var qrCode = new QRCodeStyling({
+          width: 150,
+          height: 150,
+          data: "<%= guest_qr_data %>",
+          image: "<%= logo_src %>",
+          dotsOptions: {
+            color: "#000000",
+            type: "rounded"
+          },
+          imageOptions: {
+            crossOrigin: "anonymous",
+            hideBackgroundDots: true
+          }
+        });
+
+        qrCode.append(document.getElementById("canvas"));
+      });
+    </script>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -436,6 +436,7 @@ Spree::Core::Engine.add_routes do
           resource :homepage_background, controller: :homepage_background, only: [:show]
         end
 
+        resources :qr_urls, only: [:show]
         resources :guest_qrs, only: [:show]
         resources :guests, only: %i[create update show] do
           resources :id_cards


### PR DESCRIPTION
### In the PR allow App to scan guest qr and return back the Qr_Url to open the WebView
GET : {{BASE_URL}}/api/v2/storefront/qr_urls/:token
#### response
```json
{
   {
    "data": {
        "id": "f64e1a42-abde-46db-8859-ee94c639afdb",
        "type": "qr_url",
        "attributes": {
            "url": "http://127.0.0.1:4000/g/f64e1a42-abde-46db-8859-ee94c639afdb"
        }
    }
}
}
```

#### Guest Card WebView

<img width="1512" alt="Screenshot 2024-09-11 at 3 46 32 in the afternoon" src="https://github.com/user-attachments/assets/d5beaa81-74aa-4ead-b7c8-d7025f017148">

<img width="1512" alt="Screenshot 2024-09-11 at 4 21 26 in the afternoon" src="https://github.com/user-attachments/assets/88d039f2-b341-4828-910e-4551a33bb662">

