### PR TITLE
close #1926 add last invoice remaining to current invoice total as adjustment

### DIFF
--- a/app/models/spree_cm_commissioner/vendor_decorator.rb
+++ b/app/models/spree_cm_commissioner/vendor_decorator.rb
@@ -10,7 +10,7 @@ module SpreeCmCommissioner
 
       base.attr_accessor :service_availabilities
 
-      base.store :preferences, accessors: %i[account_name account_number penalty_rate]
+      base.store :preferences, accessors: %i[account_name account_number penalty_rate penalty_label]
 
       base.before_save :generate_code, if: :code.nil?
 

--- a/app/views/spree/billing/vendors/_form.html.erb
+++ b/app/views/spree/billing/vendors/_form.html.erb
@@ -35,23 +35,29 @@
     </div>
   <% end %>
   <div class='row'>
-    <div class='col-4'>
+    <div class='col-6'>
       <%= f.field_container :preferences do %>
         <%= f.label Spree.t('billing.account_name') %>
         <%= f.text_field :account_name, class: 'form-control' %>
       <% end %>
     </div>
-    <div class='col-4'>
+    <div class='col-6'>
       <%= f.field_container :preferences do %>
         <%= f.label Spree.t('billing.account_number') %>
         <%= f.text_field :account_number, class: 'form-control' %>
       <% end %>
-  </div>
-  <div class='col-4'>
+    </div>
+    <div class='col-6'>
+      <%= f.field_container :preferences do %>
+        <%= f.label Spree.t('billing.penalty_label') %>
+        <%= f.text_field :penalty_label, class: 'form-control' %>
+      <% end %>
+    </div>
+    <div class='col-6'>
       <%= f.field_container :preferences do %>
         <%= f.label Spree.t('billing.penalty_rate') %>
         <%= f.text_field :penalty_rate, class: 'form-control' %>
       <% end %>
-  </div>
+    <div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -275,6 +275,7 @@ en:
       match_all: "All line items must from selected age group"
     billing:
       penalty_rate: 'Penalty Rate in %'
+      penalty_label: "Penalty Label"
       customer_id: "Customer ID"
       subscription:
         quantity_is_missing: "Quantity cannot be nil or zero."

--- a/lib/spree_cm_commissioner/test_helper/factories/subscription_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/subscription_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     customer { create(:cm_customer) }
 
     transient do
-      price { 10.0 }
+      price { 30.0 }
       month { 1 }
       due_date { 5 }
       payment_option { 'pre-paid' }


### PR DESCRIPTION
### Last month invoice ###
- Total: 38400
- Paid: 28400
- Remaining: 10000
<img width="1177" alt="image" src="https://github.com/user-attachments/assets/9965925e-8f28-4a9c-a7c1-d5cf560add35">

### Current month invoice ###
- Item Total: 38400
- Adjustment(Penalty) : Remaining + 3%  = 10300
- Total: 48700
<img width="1176" alt="image" src="https://github.com/user-attachments/assets/24f1376d-4f9d-4d38-86fc-89b6a373b2ea">
<img width="849" alt="image" src="https://github.com/user-attachments/assets/08ddc4f2-8ad0-4b5c-a654-6a93330532c5">

