### PR TITLE
close #1968 CRUD template_guests with soft_delete

### DIFF
--- a/app/controllers/spree/api/v2/storefront/template_guests_controller.rb
+++ b/app/controllers/spree/api/v2/storefront/template_guests_controller.rb
@@ -1,0 +1,79 @@
+module Spree
+  module Api
+    module V2
+      module Storefront
+        class TemplateGuestsController < ::Spree::Api::V2::ResourceController
+          before_action :require_spree_current_user
+
+          # override
+          def model_class
+            SpreeCmCommissioner::TemplateGuest
+          end
+
+          # override
+          def collection
+            spree_current_user.template_guests
+          end
+
+          # override
+          def collection_serializer
+            SpreeCmCommissioner::V2::Storefront::TemplateGuestSerializer
+          end
+
+          # override
+          def resource_serializer
+            SpreeCmCommissioner::V2::Storefront::TemplateGuestSerializer
+          end
+
+          def create
+            resource = spree_current_user.template_guests.create(template_guest_params)
+
+            if resource.save
+              render_serialized_payload(201) { serialize_resource(resource) }
+            else
+              render_error_payload(resource.errors, 400)
+            end
+          end
+
+          def update
+            resource = spree_current_user.template_guests.find(params[:id])
+            resource.assign_attributes(template_guest_params)
+
+            if resource.save
+              render_serialized_payload { serialize_resource(resource) }
+            else
+              render_error_payload(resource.errors, 400)
+            end
+          end
+
+          def destroy
+            resource = spree_current_user.template_guests.find(params[:id])
+
+            if resource.destroy
+              render json: { message: 'Template guest deleted successfully' }, status: :ok
+            else
+              render_error_payload(resource.errors, 400)
+            end
+          end
+
+          private
+
+          def template_guest_params
+            params.permit(
+              :first_name,
+              :last_name,
+              :dob,
+              :phone_number,
+              :emergency_contact,
+              :gender,
+              :occupation_id,
+              :other_occupation,
+              :nationality_id,
+              :is_default
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/interactors/spree_cm_commissioner/guest_id_card_manager.rb
+++ b/app/interactors/spree_cm_commissioner/guest_id_card_manager.rb
@@ -1,61 +1,7 @@
 module SpreeCmCommissioner
-  class GuestIdCardManager < BaseInteractor
-    delegate :card_type, :front_image_url, :back_image_url, :guest_id, to: :context
-
-    def call
-      if guest.id_card.blank? && front_image_url.present?
-        create_guest_id_card
-      elsif guest.id_card.present?
-        update_guest_id_card
-      else
-        context.fail!(message: 'Image url can not be empty')
-      end
-    end
-
-    def create_guest_id_card
-      id_card = guest.build_id_card(card_type: card_type)
-
-      manage_front_image(id_card)
-      manage_back_image(id_card) if back_image_url.present?
-
-      context.fail!(message: 'Failed to create Id card') unless context.success? && id_card.save
-      context.result = guest.id_card
-    end
-
-    def update_guest_id_card
-      manage_card_type(guest.id_card) if card_type.present?
-      manage_front_image(guest.id_card) if front_image_url.present?
-      manage_back_image(guest.id_card) if back_image_url.present?
-
-      context.fail!(message: 'Failed to update Id card') unless context.success? && guest.id_card.save
-      context.result = guest.id_card
-    end
-
-    def guest
-      SpreeCmCommissioner::Guest.find(guest_id)
-    end
-
-    def manage_card_type(id_card)
-      id_card.update(card_type: card_type)
-    end
-
-    def manage_front_image(id_card)
-      context = SpreeCmCommissioner::IdCardImageUpdater.call(
-        id_card: id_card,
-        image_url: front_image_url,
-        type: 'front_image'
-      )
-
-      context.fail!(message: 'Failed to update front image') unless context.success?
-    end
-
-    def manage_back_image(id_card)
-      context = SpreeCmCommissioner::IdCardImageUpdater.call(
-        id_card: id_card,
-        image_url: back_image_url,
-        type: 'back_image'
-      )
-      context.fail!(message: 'Failed to update back image') unless context.success?
+  class GuestIdCardManager < IdCardManager
+    def guestable
+      @guestable ||= SpreeCmCommissioner::Guest.find(context.guestable_id)
     end
   end
 end

--- a/app/interactors/spree_cm_commissioner/id_card_manager.rb
+++ b/app/interactors/spree_cm_commissioner/id_card_manager.rb
@@ -1,0 +1,65 @@
+module SpreeCmCommissioner
+  class IdCardManager < BaseInteractor
+    delegate :card_type, :front_image_url, :back_image_url, :guestable_id, to: :context
+
+    def call
+      if guest.id_card.blank? && front_image_url.present?
+        create_guest_id_card
+      elsif guest.id_card.present?
+        update_guest_id_card
+      else
+        context.fail!(message: 'Image url can not be empty')
+      end
+    end
+
+    def create_guest_id_card
+      id_card = guest.build_id_card(card_type: card_type)
+
+      manage_front_image(id_card)
+      manage_back_image(id_card) if back_image_url.present?
+
+      context.fail!(message: 'Failed to create Id card') unless context.success? && id_card.save
+      context.result = guest.id_card
+    end
+
+    def update_guest_id_card
+      manage_card_type(guest.id_card) if card_type.present?
+      manage_front_image(guest.id_card) if front_image_url.present?
+      manage_back_image(guest.id_card) if back_image_url.present?
+
+      context.fail!(message: 'Failed to update Id card') unless context.success? && guest.id_card.save
+      context.result = guest.id_card
+    end
+
+    def guest
+      guestable
+    end
+
+    def manage_card_type(id_card)
+      id_card.update(card_type: card_type)
+    end
+
+    def manage_front_image(id_card)
+      context = SpreeCmCommissioner::IdCardImageUpdater.call(
+        id_card: id_card,
+        image_url: front_image_url,
+        type: 'front_image'
+      )
+
+      context.fail!(message: 'Failed to update front image') unless context.success?
+    end
+
+    def manage_back_image(id_card)
+      context = SpreeCmCommissioner::IdCardImageUpdater.call(
+        id_card: id_card,
+        image_url: back_image_url,
+        type: 'back_image'
+      )
+      context.fail!(message: 'Failed to update back image') unless context.success?
+    end
+
+    def guestable
+      context.fail!(message: 'Image url can not be empty')
+    end
+  end
+end

--- a/app/interactors/spree_cm_commissioner/template_guest_id_card_manager.rb
+++ b/app/interactors/spree_cm_commissioner/template_guest_id_card_manager.rb
@@ -1,0 +1,7 @@
+module SpreeCmCommissioner
+  class TemplateGuestIdCardManager < IdCardManager
+    def guestable
+      @guestable ||= SpreeCmCommissioner::TemplateGuest.find(context.guestable_id)
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/guest.rb
+++ b/app/models/spree_cm_commissioner/guest.rb
@@ -31,7 +31,7 @@ module SpreeCmCommissioner
 
     belongs_to :event, class_name: 'Spree::Taxon'
 
-    has_one :id_card, class_name: 'SpreeCmCommissioner::IdCard', dependent: :destroy
+    has_one :id_card, as: :id_cardable, class_name: 'SpreeCmCommissioner::IdCard', dependent: :destroy
     has_one :check_in, class_name: 'SpreeCmCommissioner::CheckIn'
 
     preference :telegram_user_id, :string

--- a/app/models/spree_cm_commissioner/id_card.rb
+++ b/app/models/spree_cm_commissioner/id_card.rb
@@ -1,8 +1,11 @@
 module SpreeCmCommissioner
   class IdCard < SpreeCmCommissioner::Base
+    # Polymorphic association
+    belongs_to :id_cardable, polymorphic: true
+
     enum card_type: { :national_id_card => 0, :passport => 1, :student_id_card => 2 }
 
-    belongs_to :guest, class_name: 'SpreeCmCommissioner::Guest'
+    # belongs_to :guest, class_name: 'SpreeCmCommissioner::Guest'
 
     has_one :front_image, as: :viewable, dependent: :destroy, class_name: 'SpreeCmCommissioner::FrontImage'
     has_one :back_image, as: :viewable, dependent: :destroy, class_name: 'SpreeCmCommissioner::BackImage'

--- a/app/models/spree_cm_commissioner/template_guest.rb
+++ b/app/models/spree_cm_commissioner/template_guest.rb
@@ -1,0 +1,25 @@
+module SpreeCmCommissioner
+  class TemplateGuest < SpreeCmCommissioner::Base
+    acts_as_paranoid
+
+    enum :gender, { :other => 0, :male => 1, :female => 2 }
+
+    has_one :id_card, as: :id_cardable, class_name: 'SpreeCmCommissioner::IdCard', dependent: :destroy
+
+    belongs_to :user, class_name: 'Spree::User'
+    belongs_to :occupation, class_name: 'Spree::Taxon'
+    belongs_to :nationality, class_name: 'Spree::Taxon'
+
+    before_save :ensure_single_default
+
+    private
+
+    def ensure_single_default
+      return unless is_default && is_default_changed?
+
+      user.template_guests.where.not(id: id).find_each do |template_guest|
+        template_guest.update!(is_default: false)
+      end
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/user_decorator.rb
+++ b/app/models/spree_cm_commissioner/user_decorator.rb
@@ -17,6 +17,7 @@ module SpreeCmCommissioner
       base.has_many :user_events, class_name: 'SpreeCmCommissioner::UserEvent'
       base.has_many :events, through: :user_events, class_name: 'Spree::Taxon', source: 'taxon'
       base.has_many :guests, class_name: 'SpreeCmCommissioner::Guest', dependent: :destroy
+      base.has_many :template_guests, class_name: 'SpreeCmCommissioner::TemplateGuest', dependent: :destroy
 
       base.has_many :wished_items, class_name: 'Spree::WishedItem', through: :wishlists
       base.has_many :promotions, through: :promotion_rules, class_name: 'Spree::Promotion'

--- a/app/serializers/spree_cm_commissioner/v2/storefront/template_guest_serializer.rb
+++ b/app/serializers/spree_cm_commissioner/v2/storefront/template_guest_serializer.rb
@@ -1,0 +1,16 @@
+module SpreeCmCommissioner
+  module V2
+    module Storefront
+      class TemplateGuestSerializer < BaseSerializer
+        attributes :first_name, :last_name, :dob, :gender, :is_default, :phone_number, :emergency_contact,
+                   :occupation_id, :other_occupation, :nationality_id, :user_id,
+                   :deleted_at, :created_at, :updated_at
+
+        belongs_to :occupation, serializer: Spree::V2::Storefront::TaxonSerializer
+        belongs_to :nationality, serializer: Spree::V2::Storefront::TaxonSerializer
+
+        has_one :id_card, serializer: Spree::V2::Storefront::IdCardSerializer
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -445,6 +445,9 @@ Spree::Core::Engine.add_routes do
         resources :guests, only: %i[create update show] do
           resources :id_cards
         end
+        resources :template_guests, only: %i[index create show update destroy] do
+          resources :id_cards
+        end
         resources :user_guests do
           resources :id_cards
         end

--- a/db/migrate/20240926100138_create_spree_cm_commissioner_template_guests.rb
+++ b/db/migrate/20240926100138_create_spree_cm_commissioner_template_guests.rb
@@ -1,0 +1,20 @@
+class CreateSpreeCmCommissionerTemplateGuests < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cm_template_guests, if_not_exists: true do |t|
+      t.string :first_name
+      t.string :last_name
+      t.date :dob
+      t.integer :gender, default: 0
+      t.string :phone_number, limit: 50
+      t.string :emergency_contact, limit: 50
+      t.boolean :is_default, default: false
+      t.references :user, foreign_key: { to_table: :spree_users }
+      t.references :nationality, foreign_key: { to_table: :spree_taxons }
+      t.references :occupation, foreign_key: { to_table: :spree_taxons }
+      t.string :other_occupation
+      t.datetime :deleted_at, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240926120947_add_template_guest_id_to_spree_cm_commissioner_guest.rb
+++ b/db/migrate/20240926120947_add_template_guest_id_to_spree_cm_commissioner_guest.rb
@@ -1,0 +1,5 @@
+class AddTemplateGuestIdToSpreeCmCommissionerGuest < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :cm_guests, :template_guest, foreign_key: { to_table: :cm_template_guests }, index: true, if_not_exists: true
+  end
+end

--- a/db/migrate/20240927082749_migrate_guest_id_to_polymorphic_in_cm_id_cards.rb
+++ b/db/migrate/20240927082749_migrate_guest_id_to_polymorphic_in_cm_id_cards.rb
@@ -1,0 +1,9 @@
+class MigrateGuestIdToPolymorphicInCmIdCards < ActiveRecord::Migration[7.0]
+  def up
+    add_reference :cm_id_cards, :id_cardable, polymorphic: true, index: true
+  end
+
+  def down
+    remove_reference :cm_id_cards, :id_cardable, polymorphic: true, index: true
+  end
+end

--- a/lib/spree_cm_commissioner/test_helper/factories/id_card_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/id_card_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :id_card , class: SpreeCmCommissioner::IdCard do
     card_type { 1 }
-    guest { create(:guest) }
+    id_cardable { create(:guest) }
     front_image { create(:cm_front_image) }
     back_image { create(:cm_back_image) }
   end

--- a/lib/tasks/migrate_id_cards.rake
+++ b/lib/tasks/migrate_id_cards.rake
@@ -1,0 +1,9 @@
+# recommend to be used in schedule.yml & manually access in /sidekiq/cron
+namespace :spree_cm_commissioner do
+  desc 'Migrate guest_id to id_cardable in CmIdCards'
+  task migrate_id_cards: :environment do
+    SpreeCmCommissioner::IdCard.where.not(guest_id: nil).find_each do |id_card|
+      id_card.update(id_cardable_type: 'SpreeCmCommissioner::Guest', id_cardable_id: id_card.guest_id)
+    end
+  end
+end

--- a/spec/interactors/spree_cm_commissioner/id_card_manager_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/id_card_manager_spec.rb
@@ -1,31 +1,32 @@
 require 'spec_helper'
 
-RSpec.describe SpreeCmCommissioner::GuestIdCardManager  do
-  let(:id_card) { create(:id_card, card_type: 'passport') }
-
-  let(:guest_with_id_card) { create(:guest , id_card: id_card ) }
+RSpec.describe SpreeCmCommissioner::IdCardManager do
   let(:guest) { create(:guest) }
+  let(:id_card) { create(:id_card, card_type: 'passport', id_cardable: guest) }
+
+  let(:guest_with_id_card) { create(:guest, id_card: id_card) }
 
   let(:card_type) { 'student_id_card' }
-  let(:front_image_url) { "https://example/front_image.jpg" }
-  let(:back_image_url)  { "https://example/front_image.jpg" }
+  let(:front_image_url) { "https://example.com/front_image.jpg" }
+  let(:back_image_url)  { "https://example.com/back_image.jpg" }
 
   describe '.call' do
     context 'create_guest_id_card' do
-      it 'return error if front_image_url is nil' do
-       context = described_class.call(card_type: card_type, guest_id: guest.id)
+      it 'returns error if front_image_url is nil' do
+        context = described_class.call(card_type: card_type, guest_id: guest.id)
 
-       expect(context.success?).to eq false
-       expect(context.message).to eq 'Image url can not be empty'
+        expect(context.success?).to eq false
+        expect(context.message).to eq 'Image url can not be empty'
       end
 
-      it 'return id_card record if create success' do
+      it 'returns id_card record if create is successful' do
+        allow_any_instance_of(described_class).to receive(:guestable).and_return(guest)
         context = described_class.call(
-                                      card_type: card_type,
-                                      guest_id: guest.id,
-                                      front_image_url: front_image_url,
-                                      back_image_url: front_image_url
-                                    )
+          card_type: card_type,
+          guestable_id: guest.id,
+          front_image_url: front_image_url,
+          back_image_url: back_image_url
+        )
         allow(context).to receive(:manage_front_image).and_return(instance_double("context", success?: true))
         allow(context).to receive(:manage_back_image).and_return(instance_double("context", success?: true))
 
@@ -34,25 +35,24 @@ RSpec.describe SpreeCmCommissioner::GuestIdCardManager  do
     end
 
     context 'update_guest_id_card' do
-      it 'update card type when present' do
-        described_class.call(card_type: card_type , guest_id: guest_with_id_card.id)
+      it 'updates card type when present' do
+        allow_any_instance_of(described_class).to receive(:guestable).and_return(guest_with_id_card)
+        described_class.call(card_type: card_type, guestable: guest_with_id_card.id)
 
         expect(id_card.reload.card_type).to eq(card_type)
       end
 
-      it 'update front_image when present' do
-
+      it 'updates front_image when present' do
         allow(SpreeCmCommissioner::IdCardImageUpdater).to receive(:call).with(
           id_card: id_card,
-          image_url: front_image_url ,
+          image_url: front_image_url,
           type: 'front_image'
         ).and_return(instance_double("context", success?: true))
 
         described_class.call(front_image_url: front_image_url, guest_id: guest_with_id_card.id)
       end
 
-      it 'update back_image when present' do
-
+      it 'updates back_image when present' do
         allow(SpreeCmCommissioner::IdCardImageUpdater).to receive(:call).with(
           id_card: id_card,
           image_url: back_image_url,


### PR DESCRIPTION
#### In this PR ? 
- we implement CRUD TemplateGuests
- Migrate cm_id_cards guest_id column to polymophic make it Upload with both CmGuests and CmSavedGuests

GET: {{BASE_URL}}/api/v2/storefront/template_guests
```json
{
    "data": {
        "id": "1",
        "type": "template_guest",
        "attributes": {
            "first_name": "Leng",
            "last_name": "JinWoo",
            "dob": "1992-07-12",
            "gender": "male",
            "is_default": true,
            "phone_number": null,
            "emergency_contact": null,
            "occupation_id": 86,
            "other_occupation": "testing",
            "nationality_id": 177,
            "user_id": 74,
            "deleted_at": null,
            "created_at": "2024-10-17T14:54:16.708+07:00",
            "updated_at": "2024-10-17T14:54:16.708+07:00"
        },
        "relationships": {
            "occupation": {
                "data": {
                    "id": "86",
                    "type": "taxon"
                }
            },
            "nationality": {
                "data": {
                    "id": "177",
                    "type": "taxon"
                }
            },
            "id_card": {
                "data": null
            }
        }
    }
}
```
### Add this to schedule.yml
```rb
_migrate_id_cards:
  status: disabled
  cron: "0 0 * * *"
  class: InvokeRakeTaskCron
  args:
    task: spree_cm_commissioner:migrate_id_cards
```