### PR TITLE
close #1989 allow customer to have store credits

### DIFF
--- a/app/controllers/spree/billing/roles_controller.rb
+++ b/app/controllers/spree/billing/roles_controller.rb
@@ -73,7 +73,8 @@ module Spree
           'spree/billing/adjustments' => %w[index create new edit show update destroy],
           'spree/billing/payments' => %w[index create new edit show update destroy],
           'spree/billing/invoice' => %w[index show print_invoice_date],
-          'spree/billing/addresses' => %w[index create new edit show update destroy]
+          'spree/billing/addresses' => %w[index create new edit show update destroy],
+          'spree/billing/store_credits' => %w[index create new edit show update destroy]
         }
       end
 

--- a/app/controllers/spree/billing/store_credits_controller.rb
+++ b/app/controllers/spree/billing/store_credits_controller.rb
@@ -1,0 +1,117 @@
+module Spree
+  module Billing
+    class StoreCreditError < StandardError; end
+
+    class StoreCreditsController < Spree::Billing::BaseController
+      before_action :load_user
+      before_action :load_options
+      before_action :load_categories, only: %i[new edit]
+      before_action :load_store_credit, only: %i[new edit update]
+      before_action :ensure_unused_store_credit, only: [:update]
+
+      def index
+        @store_credits = @user.store_credits.for_store(current_store).includes(:category).reverse_order
+      end
+
+      def create
+        @store_credit = @user.store_credits.build(
+          permitted_store_credit_params.merge(
+            created_by: try_spree_current_user,
+            action_originator: try_spree_current_user,
+            store: current_store,
+            currency: current_store.default_currency,
+            category: Spree::StoreCreditCategory.where(name: 'Default').first
+          )
+        )
+
+        @duration = params[:store_credit][:duration].to_i
+        @store_credit.memo = params[:store_credit][:description]
+        @store_credit.amount = total_amount
+        if @store_credit.save
+          SpreeCmCommissioner::SubscriptionsPrepaidOrderCreator.call(customer: @customer, store_credit: @store_credit, duration: @duration)
+          flash[:success] = flash_message_for(@store_credit, :successfully_created)
+          redirect_to spree.billing_customer_store_credits_path(@customer)
+        else
+          load_categories
+          flash[:error] = Spree.t('store_credit.errors.unable_to_create')
+          render :new, status: :unprocessable_entity
+        end
+      end
+
+      def update
+        @store_credit.assign_attributes(permitted_store_credit_params)
+        @store_credit.created_by = try_spree_current_user
+
+        if @store_credit.save
+          flash[:success] = flash_message_for(@store_credit, :successfully_updated)
+          redirect_to spree.billing_customer_store_credits_path(@customer)
+        else
+          load_categories
+          flash[:error] = Spree.t('store_credit.errors.unable_to_update')
+          render :edit, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        @store_credit = @user.store_credits.for_store(current_store).find(params[:id])
+        ensure_unused_store_credit
+
+        if @store_credit.destroy
+          flash[:success] = flash_message_for(@store_credit, :successfully_removed)
+          respond_with(@store_credit) do |format|
+            format.html { redirect_to spree.billing_customer_store_credits_path(@customer) }
+            format.js { render_js_for_destroy }
+          end
+        else
+          render plain: Spree.t('store_credit.errors.unable_to_delete'), status: :unprocessable_entity
+        end
+      end
+
+      protected
+
+      def total_amount
+        @subscriptions.map(&:total_price).sum * @duration
+      end
+
+      def load_options
+        @subscriptions = @customer.subscriptions
+      end
+
+      def permitted_store_credit_params
+        params.require(:store_credit).permit(permitted_store_credit_attributes)
+      end
+
+      def collection_url(options = {})
+        billing_customer_store_credits_url(@customer, options)
+      end
+
+      def load_user
+        @customer = SpreeCmCommissioner::Customer.find(params[:customer_id])
+        @user = @customer.user
+
+        return if @user
+
+        flash[:error] = Spree.t(:user_not_found)
+        redirect_to spree.billing_customer_path(@customer)
+      end
+
+      def load_categories
+        @credit_categories = Spree::StoreCreditCategory.order(:name)
+      end
+
+      def load_store_credit
+        @store_credit = scope.find_by(id: params[:id]) || scope.new
+      end
+
+      def scope
+        current_store.store_credits
+      end
+
+      def ensure_unused_store_credit
+        return if @store_credit.amount_used.zero?
+
+        raise StoreCreditError, Spree.t('store_credit.errors.cannot_change_used_store_credit')
+      end
+    end
+  end
+end

--- a/app/interactors/spree_cm_commissioner/invoice_creator.rb
+++ b/app/interactors/spree_cm_commissioner/invoice_creator.rb
@@ -11,7 +11,6 @@ module SpreeCmCommissioner
     def load_invoice_number
       load_prefix
       load_invoices_count
-
       context.invoice_number = "#{context.prefix}-#{rjust_number(context.invoices_count)}"
     end
 

--- a/app/interactors/spree_cm_commissioner/subscriptions_prepaid_order_creator.rb
+++ b/app/interactors/spree_cm_commissioner/subscriptions_prepaid_order_creator.rb
@@ -1,0 +1,78 @@
+module SpreeCmCommissioner
+  class SubscriptionsPrepaidOrderCreator < BaseInteractor
+    delegate :customer, to: :context
+    delegate :store_credit, to: :context
+    delegate :duration, to: :context
+
+    def call
+      create_order
+      add_subscription_variant_to_line_item
+      create_adjustment
+      create_payment_and_capture
+      create_invoice
+    end
+
+    private
+
+    def create_invoice
+      SpreeCmCommissioner::InvoiceCreator.call(order: context.new_order) if context.new_order.present?
+    end
+
+    def create_order
+      context.new_order = customer.user.orders.create(
+        subscription_id: customer.subscriptions.first.id,
+        phone_number: context.customer.phone_number,
+        user_id: context.customer.user_id
+      )
+    end
+
+    def create_payment_and_capture
+      context.new_order.reload
+      default_payment_method = Spree::PaymentMethod::Check.available_on_back_end.first_or_create! do |method|
+        method.name ||= 'Invoice'
+        method.stores = [Spree::Store.default] if method.stores.empty?
+      end
+
+      Spree::Payment.create!(
+        order_id: context.new_order.id,
+        payment_method: default_payment_method,
+        amount: store_credit.amount
+      )
+      context.new_order.payments.last.capture!
+      context.new_order.update(state: 'complete', payment_state: 'paid', completed_at: Time.zone.now)
+    end
+
+    def create_adjustment
+      adjustment_total = if duration == 6
+                           customer.subscriptions.map(&:total_price).sum * customer.vendor.six_months_discount.to_i
+                         else
+                           customer.subscriptions.map(&:total_price).sum * customer.vendor.twelve_months_discount.to_i
+                         end
+      Spree::Adjustment.create!(
+        adjustable: context.new_order,
+        order: context.new_order,
+        adjustable_type: 'Spree::Order',
+        amount: -adjustment_total,
+        label: store_credit.memo || 'Prepaid Discount'
+      )
+      context.new_order.update_with_updater!
+    end
+
+    def add_subscription_variant_to_line_item
+      today = Time.zone.today
+      from_date = today
+      to_date = today + duration.month
+      customer.subscriptions.each do |subscription|
+        Spree::Cart::AddItem.call(
+          order: context.new_order,
+          variant: subscription.variant,
+          quantity: subscription.quantity * duration,
+          options: {
+            from_date: from_date,
+            to_date: to_date
+          }
+        )
+      end
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/subscription.rb
+++ b/app/models/spree_cm_commissioner/subscription.rb
@@ -49,8 +49,11 @@ module SpreeCmCommissioner
       variant.month
     end
 
+    def total_price
+      variant.price * quantity
+    end
+
     def display_total_price
-      total_price = variant.price * quantity
       Spree::Money.new(total_price.to_i, currency: variant.currency).to_s
     end
 

--- a/app/models/spree_cm_commissioner/vendor_decorator.rb
+++ b/app/models/spree_cm_commissioner/vendor_decorator.rb
@@ -10,7 +10,7 @@ module SpreeCmCommissioner
 
       base.attr_accessor :service_availabilities
 
-      base.store :preferences, accessors: %i[account_name account_number penalty_rate penalty_label]
+      base.store :preferences, accessors: %i[account_name account_number penalty_rate penalty_label six_months_discount twelve_months_discount]
 
       base.before_save :generate_code, if: :code.nil?
 

--- a/app/views/spree/billing/shared/_customer_credit_form.html.erb
+++ b/app/views/spree/billing/shared/_customer_credit_form.html.erb
@@ -1,0 +1,33 @@
+<% customer = SpreeCmCommissioner::Customer.find(params['customer_id']) %>
+<div class="modal fade" id="customerCredit" tabindex="-1" role="dialog" aria-labelledby="customerCreditLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="customerCreditLabel">Customer Credit</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <form action="<%= billing_customer_store_credits_path(customer) %>" method="post">
+        <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+
+        <div class="modal-body">
+          <%= fields_for :store_credit do |f| %>
+            <div class="form-group">
+              <%= f.label :duration, Spree.t(:duration) %>
+              <%= f.select :duration, options_for_select([['6 months', 6], ['12 months', 12]]), {}, class: 'form-control' %>
+            </div>
+            <div class="form-group">
+              <%= f.label :description, 'description' %>
+              <%= f.text_area :description, class: 'form-control', required: true, placeholder: 'Enter description' %>
+            </div>
+          <% end %>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+          <button type="submit" class="btn btn-primary">Create</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/app/views/spree/billing/shared/_customer_tabs.html.erb
+++ b/app/views/spree/billing/shared/_customer_tabs.html.erb
@@ -27,6 +27,14 @@
         class: "nav-link #{'active' if current == :orders}" %>
     </li>
   <% end %>
+  <% if spree_current_user.permissions.exists?(entry: 'spree/billing/store_credits', action: 'index') %>
+    <li class="nav-item">
+      <%= link_to_with_icon 'money.svg',
+        Spree.t(:store_credits),
+        spree.billing_customer_store_credits_path(@customer),
+        class: "nav-link #{'active' if current == :store_credits}" %>
+    </li>
+  <% end %>
   <% if spree_current_user.permissions.exists?(entry: 'spree/billing/addresses', action: 'index') %>
     <li class="nav-item">
       <%= link_to_with_icon 'pin-map.svg',

--- a/app/views/spree/billing/store_credits/_form.html.erb
+++ b/app/views/spree/billing/store_credits/_form.html.erb
@@ -1,0 +1,11 @@
+<div data-hook='admin_store_credit_form_fields'>
+  <%= f.field_container :memo do %>
+    <%= f.label :memo, Spree.t(:memo) %>
+    <%= f.text_area :memo, class: 'form-control' %>
+    <%= f.error_message_on :memo %>
+  <% end %>
+</div>
+
+<script>
+  $('#store_credit_currency').select2();
+</script>

--- a/app/views/spree/billing/store_credits/index.html.erb
+++ b/app/views/spree/billing/store_credits/index.html.erb
@@ -1,0 +1,44 @@
+<%= render partial: 'spree/billing/shared/customer_tabs', locals: { current: :store_credits } %>
+<%= render partial: 'spree/billing/shared/customer_credit_form', locals:{store_credit: :store_credit} %>
+<% content_for :page_actions do %>
+  <button type="button" class="btn btn-success" data-toggle="modal" data-target="#customerCredit" >
+    Add Credit
+  </button>
+<% end %>
+
+<% if @store_credits.any? %>
+<div class="table-responsive border rounded bg-white">
+  <table class="table">
+    <thead class="text-muted">
+      <th><%= Spree.t(:credited) %></th>
+      <th><%= Spree.t(:used) %></th>
+      <th><%= Spree.t(:category) %></th>
+      <th><%= Spree.t(:created_by) %></th>
+      <th><%= Spree.t(:issued_on) %></th>
+      <th data-hook="admin_store_credits_index_header_actions" class="actions"></th>
+    <thead class="text-muted">
+    <tbody>
+      <% @store_credits.each do |store_credit| %>
+        <tr>
+          <td><%= store_credit.display_amount.to_html %></td>
+          <td><%= store_credit.display_amount_used.to_html %></td>
+          <td><%= store_credit.category_name %></td>
+          <td><%= store_credit.created_by.first_name %></td>
+          <td><%= l store_credit.created_at.to_date %></td>
+          <td class="actions" data-hook="admin_store_credits_index_row_actions">
+            <span class="d-flex justify-content-end">
+              <% if store_credit.amount_used.zero? %>
+                <%= link_to_delete store_credit, no_text: true, url: spree.billing_customer_store_credit_path(@customer, store_credit) if can?(:destroy, store_credit) %>
+              <% end %>
+            </span>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+<% else %>
+  <div class="text-center no-objects-found m-5">
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::StoreCredit)) %>
+  </div>
+<% end %>

--- a/app/views/spree/billing/store_credits/new.html.erb
+++ b/app/views/spree/billing/store_credits/new.html.erb
@@ -1,0 +1,17 @@
+<%= render partial: 'spree/billing/shared/customer_tabs', locals: { current: :store_credits } %>
+
+<%= form_for @store_credit, url: spree.billing_customer_store_credits_path(@customer, @store_credit) do |f| %>
+  <div class="card">
+    <div class="card-header">
+      <%= Spree.t(:add_store_credit) %>
+    </div>
+    <div class="card-body">
+      <div class="field">
+        <%= label_tag :duration, Spree.t(:duration) %>
+        <%= select_tag :duration, options_for_select([['6 months', 6], ['12 months', 12]]), { class: 'form-control' } %>
+      </div>
+      <%= render partial: 'form', locals: { f: f } %>
+      <%= render partial: 'spree/admin/shared/new_resource_links', locals: { collection_url: spree.billing_customer_store_credits_path(@customer, @store_credit) } %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/spree/billing/vendors/_form.html.erb
+++ b/app/views/spree/billing/vendors/_form.html.erb
@@ -58,6 +58,18 @@
         <%= f.label Spree.t('billing.penalty_rate') %>
         <%= f.text_field :penalty_rate, class: 'form-control' %>
       <% end %>
-    <div>
+    </div>
+    <div class='col-6'>
+      <%= f.field_container :preferences do %>
+        <%= f.label Spree.t('billing.six_month_discount') %>
+        <%= f.text_field :six_months_discount, class: 'form-control' %>
+      <% end %>
+    </div>
+    <div class='col-6'>
+      <%= f.field_container :preferences do %>
+        <%= f.label Spree.t('billing.twelve_month_discount') %>
+        <%= f.text_field :twelve_months_discount, class: 'form-control' %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -190,6 +190,7 @@ en:
     send_failed_or_method_not_support: "Send failed or method not support"
     subscribe: "Use Service"
     full_name: "name"
+    store_credits: 'Credits'
     address: "Address"
     billing_address: "Billing Address"
     shipping_address: "Shipping Address"
@@ -274,6 +275,8 @@ en:
       match_any: "Some line items must from selected age group"
       match_all: "All line items must from selected age group"
     billing:
+      six_month_discount: '6 Months discount'
+      twelve_month_discount: "12 Months discount"
       penalty_rate: 'Penalty Rate in %'
       penalty_label: "Penalty Label"
       customer_id: "Customer ID"

--- a/config/locales/km.yml
+++ b/config/locales/km.yml
@@ -165,6 +165,7 @@ km:
     send_failed_or_method_not_support: "Send failed or method not support"
     subscribe: "ប្រើសេវាកម្ម"
     full_name: "ឈ្មោះពេញ"
+    store_credits: 'Credits'
     address: "អាសយដ្ឋាន"
     billing_address: "អាសយដ្ឋានទូទាត់"
     shipping_address: "អាសយដ្ឋានប្រើ​ប្រាស់"
@@ -241,6 +242,8 @@ km:
       match_any: "Some line items must from selected age group"
       match_all: "All line items must from selected age group"
     billing:
+      six_month_discount: 'Six Month discount'
+      twelve_month_discount: "Twelve Month discount"
       penalty_rate: 'ការផាកពិន័យគិតជាភាគរយ'
       code: "code"
       name: "name"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -313,6 +313,7 @@ Spree::Core::Engine.add_routes do
         resources :orders
         resources :subscriptions
         resources :addresses
+        resources :store_credits
       end
       resources :roles
       resources :users do

--- a/db/migrate/20240926082912_change_amount_precision_in_store_credits.rb
+++ b/db/migrate/20240926082912_change_amount_precision_in_store_credits.rb
@@ -1,0 +1,7 @@
+class ChangeAmountPrecisionInStoreCredits < ActiveRecord::Migration[7.0]
+  def change
+    change_column :spree_store_credits, :amount, :decimal, precision: 14, scale: 2
+    change_column :spree_store_credits, :amount_used, :decimal, precision: 14, scale: 2
+    change_column :spree_store_credits, :amount_authorized, :decimal, precision: 14, scale: 2
+  end
+end

--- a/db/migrate/20240926090253_change_amount_precision_in_store_credit_events.rb
+++ b/db/migrate/20240926090253_change_amount_precision_in_store_credit_events.rb
@@ -1,0 +1,6 @@
+class ChangeAmountPrecisionInStoreCreditEvents < ActiveRecord::Migration[7.0]
+  def change
+    change_column :spree_store_credit_events, :amount, :decimal, precision: 14, scale: 2
+    change_column :spree_store_credit_events, :user_total_amount, :decimal, precision: 14, scale: 2
+  end
+end

--- a/spec/interactors/spree_cm_commissioner/subscriptions_order_creator_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/subscriptions_order_creator_spec.rb
@@ -1,22 +1,11 @@
 require 'spec_helper'
 
 RSpec.describe SpreeCmCommissioner::SubscriptionsOrderCreator do
-  let(:vendor) { create(:vendor, code: 'VET', preferences: {penalty_rate: '3'}) }
+  let(:vendor) { create(:vendor, code: 'VET', preferences: {penalty_rate: '3', six_months_discount: '1'}) }
   let(:customer) { create(:cm_customer, vendor: vendor) }
 
-  let(:option_type) { create(:option_type, name: "due-date", attr_type: :integer) }
-  let(:option_value) { create(:option_value, name: "15", presentation: "5 Days", option_type: option_type) }
-
-  let(:product1) { create(:base_product, option_types: [option_type], subscribable: true, vendor: vendor) }
-  let(:product2) { create(:base_product, option_types: [option_type], subscribable: true, vendor: vendor) }
-  let(:variant1) { create(:cm_base_variant, option_values: [option_value], price: 30, product: product1, total_inventory: 10) }
-  let(:variant2) { create(:cm_base_variant, option_values: [option_value], price: 30, product: product2, total_inventory: 10) }
-
-  let(:stock_location) { create(:stock_location, vendor: vendor) }
-  let(:stock_item1) { create(:stock_item, stock_location: stock_location, variant: variant1, count_on_hand: 10) }
-  let(:stock_item2) { create(:stock_item, stock_location: stock_location, variant: variant2, count_on_hand: 10) }
   today = Time.zone.today
-  xdescribe ".call" do
+  describe ".call" do
     context "when customer has no subscription" do
       it "does nothing" do
         described_class.call(customer: customer, today: today)
@@ -123,6 +112,19 @@ RSpec.describe SpreeCmCommissioner::SubscriptionsOrderCreator do
           last_order = customer.orders.last
           expect(customer.orders.count).to eq 2
           expect(last_order.total).to eq last_order.item_total + order.outstanding_balance + penalty_rate_amount
+        end
+      end
+      context "when customer have store credit" do
+        before do
+          create(:cm_subscription, customer: customer, quantity: 2, start_date: Time.zone.now.last_month)
+          total = customer.subscriptions.map(&:total_price).sum * 6
+          create(:store_credit, user: customer.user, amount: total)
+        end
+        it 'capture with store credit' do
+          described_class.call(customer: customer, today: today)
+          expect(customer.orders.last.payments.last.source_type).to eq('Spree::StoreCredit')
+          expect(customer.orders.last.payments.last.state).to eq 'completed'
+          expect(customer.user.store_credits.last.amount_used).to eq customer.orders.last.total
         end
       end
     end

--- a/spec/interactors/spree_cm_commissioner/subscriptions_prepaid_order_creator_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/subscriptions_prepaid_order_creator_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::SubscriptionsPrepaidOrderCreator do
+  let(:vendor) { create(:vendor, code: 'VET', preferences: {penalty_rate: '3', six_months_discount: '1'}) }
+  let(:customer) { create(:cm_customer, vendor: vendor) }
+  let!(:subscription) {create(:cm_subscription, customer: customer, quantity: 5, start_date: Time.zone.now)}
+  describe ".call" do
+
+    context 'when creating a prepaid order' do
+      before do
+        total = customer.subscriptions.map(&:total_price).sum * 6
+        credit =  create(:store_credit, user: customer.user, amount: total)
+        described_class.call(customer: customer, store_credit: credit, duration: 6)
+      end
+
+      it 'creates a new order' do
+        expect(Spree::Order.count).to eq(1)
+        expect(Spree::Order.first.subscription_id).to eq(customer.subscriptions.first.id)
+      end
+
+      it 'creates an adjustment' do
+        adjustments = customer.orders.last.adjustments
+        expect(adjustments.count).to eq(1)
+        expect(adjustments.first.amount).to eq(-subscription.total_price)
+      end
+
+      it 'creates a payment and captures it' do
+        order = customer.orders.last
+        expect(order.payments.count).to eq(1)
+        expect(order.payment_state).to eq('paid')
+      end
+
+      it 'creates an invoice' do
+        order = customer.orders.last
+        expect(order.invoice).to be_present
+        expect(order.invoice.order_id).to eq(order.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Customer Tab
- [x] List customer's credits
- [x] Customer credit form
- [x] Options 6 months or 12 months
<img width="1192" alt="image" src="https://github.com/user-attachments/assets/452666fb-c191-426e-bdfb-1b49822fc9ee">
<img width="1192" alt="image" src="https://github.com/user-attachments/assets/8e29ff3d-f7e0-45ae-9aaf-9e6d92e8c037">

### StoreCredit Controller
- [x] calculate credit amount base on the active subscriptions
- [x] add credit to `customer.user`
- [x] trigger `SubscriptionsPrepaidOrderCreator` to create order and invoice for the credit

### SubscriptionsPrepaidOrderCreator
- [x] create order
- [x] create adjustment for discounted months set by admin in vendor's setting
- [x] automatically capture the payment
- [x] generate the invoice  

<img width="1435" alt="image" src="https://github.com/user-attachments/assets/03c63c98-4a21-413f-a7b1-77788d3f0b57">


### Monthly Invoice Recurring
- [x] check if the `customer.user` has sufficient credits to cover order's total
- [x] if so, create payment with `Spree::StoreCredit` as source type
- [x] capture the payment and update order as completed 