### PR TITLE
Close #1972 allow admin to enable or disable self check in

### DIFF
--- a/app/models/concerns/spree_cm_commissioner/product_delegation.rb
+++ b/app/models/concerns/spree_cm_commissioner/product_delegation.rb
@@ -11,6 +11,7 @@ module SpreeCmCommissioner
                :accommodation?, :service?, :ecommerce?,
                :associated_event,
                :allow_self_check_in,
+               :allow_self_check_in?,
                to: :product
     end
   end

--- a/app/models/spree_cm_commissioner/line_item_decorator.rb
+++ b/app/models/spree_cm_commissioner/line_item_decorator.rb
@@ -80,7 +80,7 @@ module SpreeCmCommissioner
     end
 
     def allowed_self_check_in?
-      ecommerce? && guests.any?
+      allow_self_check_in?
     end
 
     def amount_per_guest

--- a/app/overrides/spree/admin/products/_form/allow_self_check_in.html.erb.deface
+++ b/app/overrides/spree/admin/products/_form/allow_self_check_in.html.erb.deface
@@ -1,4 +1,4 @@
-<!-- insert_after "[data-hook='admin_product_form_subscribable']" -->
+<!-- insert_after "[data-hook='admin_product_form_promotionable']" -->
 
 <div data-hook="admin_product_form_allow_self_check_in">
   <%= f.field_container :allow_self_check_in do %>


### PR DESCRIPTION
### Demo 
[![Watch the video](https://github.com/user-attachments/assets/2c4884fb-96ef-400f-8a57-c093c49f0efb)](https://github.com/user-attachments/assets/093eb7f4-6a4b-4977-8b70-a2610cd49794)
### Screenshot
![image](https://github.com/user-attachments/assets/2c4884fb-96ef-400f-8a57-c093c49f0efb)  

**Description:**
- Add allow self check-in field in admin dashboard.
-  By default  in App ,  self check-in button in each product is hidden unless the admin allow by checks  the allow self check-in box for that product .
