### PR TITLE
close #2010 add support create 1-ticket order from chatrace

### DIFF
--- a/app/controllers/spree/api/chatrace/guests_controller.rb
+++ b/app/controllers/spree/api/chatrace/guests_controller.rb
@@ -34,6 +34,7 @@ module Spree
             last_name: guest.last_name,
             dob: guest.dob,
             gender: guest.gender,
+            age: guest.age,
             occupation: guest.occupation&.name || guest.other_occupation,
             entry_type: guest.entry_type,
             organization: guest.other_organization,
@@ -42,10 +43,12 @@ module Spree
             telegram_user_verified_at: guest.preferred_telegram_user_verified_at,
             order_number: order.number,
             order_email: order.email,
-            order_first_name: order.customer_address.firstname,
-            order_last_name: order.customer_address.lastname,
-            order_phone_number: order.intel_phone_number || order.customer_address.phone,
-            checked_in_at: guest.check_in&.confirmed_at
+            order_first_name: order.customer_address&.firstname,
+            order_last_name: order.customer_address&.lastname,
+            order_phone_number: order.intel_phone_number || order.customer_address&.phone,
+            checked_in_at: guest.check_in&.confirmed_at,
+            qr_data: guest.qr_data,
+            order_qr_data: order.qr_data
           }
         end
       end

--- a/app/controllers/spree/api/chatrace/orders_controller.rb
+++ b/app/controllers/spree/api/chatrace/orders_controller.rb
@@ -1,0 +1,31 @@
+# POST: api/chatrace/orders
+#
+module Spree
+  module Api
+    module Chatrace
+      class OrdersController < BaseController
+        def create
+          guest_token = SecureRandom.uuid
+
+          SpreeCmCommissioner::ChatraceOrderCreatorJob.perform_later(
+            guest_token: guest_token,
+            chatrace_user_id: params[:chatrace_user_id],
+            chatrace_api_host: params[:chatrace_api_host],
+            chatrace_return_flow_id: params[:chatrace_return_flow_id],
+            chatrace_access_token: params[:chatrace_access_token],
+            order_params: params.permit(
+              :order_email,
+              :order_phone_number,
+              :variant_id,
+              *SpreeCmCommissioner::Guest.csv_importable_columns
+            )
+          )
+
+          render_serialized_payload do
+            { queue_guest_token: guest_token }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/interactors/spree_cm_commissioner/chatrace_order_creator.rb
+++ b/app/interactors/spree_cm_commissioner/chatrace_order_creator.rb
@@ -1,0 +1,40 @@
+module SpreeCmCommissioner
+  class ChatraceOrderCreator < BaseInteractor
+    delegate :chatrace_user_id, :chatrace_return_flow_id,
+             :chatrace_api_host, :chatrace_access_token,
+             :guest_token, :order_params,
+             to: :context
+
+    def call
+      context.order_creator = create_order
+      return context.fail!(message: context.order_creator.message) unless context.order_creator.success?
+
+      notify_user
+    end
+
+    def create_order
+      SpreeCmCommissioner::OrderImporter::SingleGuest.call(
+        guest_token: guest_token,
+        params: order_params.slice(
+          :order_email,
+          :order_phone_number,
+          :variant_id,
+          *SpreeCmCommissioner::Guest.csv_importable_columns
+        )
+      )
+    end
+
+    def notify_user
+      client = Faraday.new(
+        url: "https://#{chatrace_api_host}",
+        headers: {
+          'X-ACCESS-TOKEN' => chatrace_access_token,
+          'Content-Type' => 'application/json'
+        }
+      )
+
+      response = client.post("/api/users/#{chatrace_user_id}/send/#{chatrace_return_flow_id}")
+      context.fail!(message: 'notify_user_failed') unless response.status == 200
+    end
+  end
+end

--- a/app/interactors/spree_cm_commissioner/order_importer/single_guest.rb
+++ b/app/interactors/spree_cm_commissioner/order_importer/single_guest.rb
@@ -1,0 +1,37 @@
+module SpreeCmCommissioner
+  module OrderImporter
+    class SingleGuest < BaseInteractor
+      delegate :params, :guest_token, to: :context
+
+      def call
+        return context.fail!(message: 'variant_id_is_required') if params[:variant_id].blank?
+        return context.fail!(message: 'email_or_phone_is_required') if params[:order_email].blank? && params[:order_phone_number].blank?
+
+        context.order = construct_order
+        context.fail!(message: order.errors.full_messages.to_sentence) unless context.order.save
+      end
+
+      def construct_order
+        guest_params = params.slice(*SpreeCmCommissioner::Guest.csv_importable_columns)
+        guest_params[:token] = guest_token if guest_token.present?
+
+        Spree::Order.new(
+          email: params[:order_email],
+          phone_number: params[:order_phone_number],
+          completed_at: Date.current,
+          state: 'complete',
+          payment_state: 'paid',
+          line_items_attributes: [
+            {
+              quantity: 1,
+              variant_id: params[:variant_id],
+              guests_attributes: [
+                guest_params
+              ]
+            }
+          ]
+        )
+      end
+    end
+  end
+end

--- a/app/jobs/spree_cm_commissioner/chatrace_order_creator_job.rb
+++ b/app/jobs/spree_cm_commissioner/chatrace_order_creator_job.rb
@@ -1,0 +1,9 @@
+module SpreeCmCommissioner
+  class ChatraceOrderCreatorJob < ApplicationJob
+    # :chatrace_user_id, :chatrace_return_flow_id, :chatrace_api_host, :chatrace_access_token
+    # :guest_token, :order_params
+    def perform(options)
+      SpreeCmCommissioner::ChatraceOrderCreator.call(options)
+    end
+  end
+end

--- a/app/models/spree_cm_commissioner/guest.rb
+++ b/app/models/spree_cm_commissioner/guest.rb
@@ -40,7 +40,6 @@ module SpreeCmCommissioner
     before_validation :set_event_id
     before_validation :assign_seat_number, if: -> { bib_number.present? }
 
-    validates :phone_number, uniqueness: { scope: :event_id }, allow_nil: true, if: -> { event_id.present? }
     validates :seat_number, uniqueness: { scope: :event_id }, allow_nil: true, if: -> { event_id.present? }
     validates :bib_index, uniqueness: true, allow_nil: true
 
@@ -51,6 +50,7 @@ module SpreeCmCommissioner
       %i[
         first_name last_name age dob gender other_occupation other_organization
         entry_type nationality_id other_organization expectation emergency_contact bib_number
+        preferred_telegram_user_id
       ]
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -479,6 +479,7 @@ Spree::Core::Engine.add_routes do
     end
 
     namespace :chatrace do
+      resources :orders, only: %i[create]
       resources :guests, only: %i[show update]
       resources :check_ins, only: [:create]
     end

--- a/lib/spree_cm_commissioner/test_helper/factories/product_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/product_factory.rb
@@ -116,5 +116,9 @@ FactoryBot.define do
         product.kyc = _evaluator.select_fields.map { |field| fields[field] }.sum
       end
     end
+
+    factory :cm_event_product do
+      taxons { [create(:cm_taxon_event_section, from_date: '2024-02-02'.to_date, to_date: '2024-03-03')] }
+    end
   end
 end

--- a/spec/cassettes/SpreeCmCommissioner_ChatraceOrderCreator/_call/when_params_order_params_are_valid/create_order_notify_user.yml
+++ b/spec/cassettes/SpreeCmCommissioner_ChatraceOrderCreator/_call/when_params_order_params_are_valid/create_order_notify_user.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://app.chatgd.com/api/users/734348432/send/1728985704288
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Access-Token:
+      - 1663219.TIr7mU295Hm0FIyD2hyxMSOed059Jrl4
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.3
+      Content-Length:
+      - '0'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.23.3
+      Date:
+      - Tue, 15 Oct 2024 10:56:16 GMT
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: "\n\n\n\n{\"success\":true}\n  "
+  recorded_at: Tue, 15 Oct 2024 10:56:16 GMT
+recorded_with: VCR 6.2.0

--- a/spec/interactors/spree_cm_commissioner/chatrace_order_creator_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/chatrace_order_creator_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::ChatraceOrderCreator, :vcr do
+  let(:product) { create(:cm_event_product) }
+  let(:variant) { product.master }
+  let(:queue_guest_token) { SecureRandom.uuid }
+
+  describe '.call' do
+    let(:chatrace_user_id) { '734348432' }
+    let(:chatrace_return_flow_id) { '1728985704288' }
+    let(:chatrace_api_host) { 'app.chatgd.com' }
+    let(:chatrace_access_token) { '1663219.TIr7mU295Hm0FIyD2hyxMSOed059Jrl4' }
+    let(:order_params) do
+      {
+        variant_id: variant.id,
+        order_email: 'sample@gmail.com',
+        order_phone_number: '+85512345678',
+        first_name: 'Thea',
+        last_name: 'Choem',
+        age: 20
+      }
+    end
+
+    context 'when params & order params are valid' do
+      it 'create order & notify user' do
+        context = described_class.call(
+          chatrace_user_id: chatrace_user_id,
+          chatrace_return_flow_id: chatrace_return_flow_id,
+          chatrace_api_host: chatrace_api_host,
+          chatrace_access_token: chatrace_access_token,
+          order_params: order_params,
+          guest_token: queue_guest_token,
+        )
+
+        expect(context.order_creator.order.state).to eq 'complete'
+        expect(context.order_creator.order.payment_state).to eq 'paid'
+        expect(context.order_creator.order.guests.first.token).to eq queue_guest_token
+      end
+    end
+
+    context 'when order params is invalid' do
+      let(:order_params) { { order_email: 'sample@gmail.com', age: 20 } }
+
+      it 'does not create order or notify user' do
+        context = described_class.call(
+          chatrace_user_id: chatrace_user_id,
+          chatrace_return_flow_id: chatrace_return_flow_id,
+          chatrace_api_host: chatrace_api_host,
+          chatrace_access_token: chatrace_access_token,
+          order_params: order_params,
+          guest_token: queue_guest_token,
+        )
+
+        expect(context.success?).to be false
+        expect(context.order_creator.success?).to be false
+        expect(context.message).to eq 'variant_id_is_required'
+      end
+    end
+  end
+end

--- a/spec/interactors/spree_cm_commissioner/order_importer/single_guest_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/order_importer/single_guest_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::OrderImporter::SingleGuest do
+  describe '#call' do
+    let(:product) { create(:cm_event_product) }
+    let(:variant) { product.master }
+
+    context 'when params is valid' do
+      let(:params) do
+        {
+          variant_id: variant.id,
+          order_email: 'sample@gmail.com',
+          order_phone_number: '+85512345678',
+          first_name: 'Thea',
+          last_name: 'Choem',
+          age: 20,
+        }
+      end
+
+      it 'created 1 order with 1 line item & 1 guest' do
+        context = described_class.call(params: params)
+
+        expect(context.success?).to be true
+
+        expect(context.order.state).to eq 'complete'
+        expect(context.order.payment_state).to eq 'paid'
+        expect(context.order.email).to eq params[:order_email]
+        expect(context.order.intel_phone_number).to eq params[:order_phone_number]
+
+        expect(context.order.line_items.size).to eq 1
+        expect(context.order.guests.size).to eq 1
+
+        expect(context.order.guests.first.first_name).to eq params[:first_name]
+        expect(context.order.guests.first.last_name).to eq params[:last_name]
+      end
+    end
+
+    context 'when no variant_id provide in params' do
+      let(:params) do
+        {
+          order_email: 'sample@gmail.com',
+          order_phone_number: '+85512345678',
+          first_name: 'Thea',
+          last_name: 'Choem',
+          age: 20,
+        }
+      end
+
+      it 'raise error' do
+        context = described_class.call(params: params)
+
+        expect(context.success?).to be false
+        expect(context.message).to eq 'variant_id_is_required'
+      end
+    end
+
+    context 'when no contact provide in params' do
+      let(:params) do
+        {
+          variant_id: variant.id,
+          first_name: 'Thea',
+          last_name: 'Choem',
+          age: 20,
+        }
+      end
+
+      it 'raise error' do
+        context = described_class.call(params: params)
+
+        expect(context.success?).to be false
+        expect(context.message).to eq 'email_or_phone_is_required'
+      end
+    end
+  end
+end

--- a/spec/jobs/spree_cm_commissioner/chatrace_order_creator_job_spec.rb
+++ b/spec/jobs/spree_cm_commissioner/chatrace_order_creator_job_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::ChatraceOrderCreatorJob, type: :job do
+  let(:product) { create(:cm_event_product) }
+  let(:variant) { product.master }
+
+  let(:options) do
+    {
+      chatrace_user_id: '734348432',
+      chatrace_return_flow_id: '1728985704288',
+      chatrace_api_host: 'app.chatgd.com',
+      chatrace_access_token: '1663219.TIr7mU295Hm0FIyD2hyxMSOed059Jrl4',
+      order_params: {
+        variant_id: variant.id,
+        order_email: 'sample@gmail.com',
+        order_phone_number: '+85512345678',
+        first_name: 'Thea',
+        last_name: 'Choem',
+        age: 20
+      }
+    }
+  end
+
+  describe '#perform' do
+    it 'calls ChatraceOrderCreator with the correct options' do
+      expect(SpreeCmCommissioner::ChatraceOrderCreator).to receive(:call).with(options)
+
+      described_class.perform_now(options)
+    end
+  end
+
+  describe 'job queueing' do
+    it 'enqueues the job' do
+      expect {
+        described_class.perform_later(options)
+      }.to have_enqueued_job(described_class)
+        .with(options)
+        .on_queue('default') # Assuming the default queue
+    end
+  end
+end


### PR DESCRIPTION
Data collection is handled by Chatrace. Once it is correct in chatrace bot, it send to BookMe+ with this new created API `/api/chatrace/orders`.

### Step 1:
Chatrace send to create order & we put those create in queue & respond queue_guest_token to chatrace.

API: `/api/chatrace/orders`
Body: 
```json
{
   "variant_id": 500,
   "order_phone_number": "{{bookmeplus_order_phone_number}}",
   "first_name": "{{first_name}}",
   "last_name": "{{last_name}}",
   "gender": "{{bookmeplus_guest_gender}}",
   "age": "{{bookmeplus_guest_age}}",
   "other_occupation": "{{bookmeplus_guest_career}}",
   "preferred_telegram_user_id": "{{user_id}}"
}
```

Response 200:
```json
{
   "queue_guest_token": "feda84d4-cc53-4974-ae7d-d64ec9f5e1f2"
}
```

### Step 2:
In BookMe+ system, once order created completed, it call chatrace API to continue the flow

### Step 3:
In Chatrace, once it receive request from BookMe+, it fetch guest details with 'queue_guest_token' then display to user.

<img width="588" alt="image" src="https://github.com/user-attachments/assets/2297384a-a4be-4ae6-b433-bd0befa1c89a">
