### PR TITLE
close #2040 allow import guest infos when import

### DIFF
--- a/app/interactors/spree_cm_commissioner/import_csv_template_downloader.rb
+++ b/app/interactors/spree_cm_commissioner/import_csv_template_downloader.rb
@@ -5,9 +5,11 @@ module SpreeCmCommissioner
     def call
       headers = case import_type
                 when 'new_order'
-                  %w[order_channel variant_sku email phone_number first_name last_name]
+                  initial_headers = %w[order_channel variant_sku email]
+                  initial_headers + SpreeCmCommissioner::Guest.csv_importable_columns.map(&:to_s)
                 when 'existing_order'
-                  %w[order_number phone_number first_name last_name]
+                  initial_headers = %w[order_number guest_id]
+                  initial_headers + SpreeCmCommissioner::Guest.csv_importable_columns.map(&:to_s)
                 else
                   raise ArgumentError, 'Invalid import type'
                 end

--- a/app/models/spree_cm_commissioner/guest.rb
+++ b/app/models/spree_cm_commissioner/guest.rb
@@ -48,9 +48,9 @@ module SpreeCmCommissioner
 
     def self.csv_importable_columns
       %i[
-        first_name last_name age dob gender other_occupation other_organization
+        first_name last_name phone_number age dob gender address other_occupation
         entry_type nationality_id other_organization expectation emergency_contact bib_number
-        preferred_telegram_user_id
+        preferred_telegram_user_id seat_number
       ]
     end
 

--- a/app/views/spree/admin/guest_qr_codes/_guest_qr_code.html.erb
+++ b/app/views/spree/admin/guest_qr_codes/_guest_qr_code.html.erb
@@ -1,7 +1,7 @@
 <div class="card">
   <div class="card-body d-flex justify-content-center align-items-center flex-column">
     <div>
-      <% qrcode = RQRCode::QRCode.new(guest.line_item.order.qr_data) %>
+      <% qrcode = RQRCode::QRCode.new(guest.qr_data) %>
       <% png = qrcode.as_png(
         bit_depth: 1,
         border_modules: 1,
@@ -16,7 +16,9 @@
     </div>
     <div class="order-data">
       <div><%= guest.line_item.order.number %></div>
-      <div class="small"> <%= guest.formatted_bib_number %> </div>
+      <div class="small">
+        <%= (guest.full_name.presence || guest.formatted_bib_number).to_s[0...15] %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/spree/admin/guest_qr_codes/index.html.erb
+++ b/app/views/spree/admin/guest_qr_codes/index.html.erb
@@ -14,6 +14,9 @@
         <tr data-hook="admin_guests_index_headers">
           <th>No. </th>
           <th>Order Number</th>
+          <th>Name</th>
+          <th>Phone Number</th>
+          <th>Seat Number</th>
           <th>Bib Number</th>
           <th>Event</th>
           <th>Created At </th>
@@ -25,6 +28,9 @@
           <tr id="<%= spree_dom_id guest %>" data-hook="admin_guests_index_rows">
             <td ><%= @index_number + index %></td>
             <td><%= link_to guest.line_item.order.number, edit_admin_order_url(guest.line_item.order) %></td>
+            <td ><%= guest.full_name %></td>
+            <td ><%= guest.phone_number %></td>
+            <td ><%= guest.seat_number %></td>
             <td ><%= guest.formatted_bib_number %></td>
             <td ><%= guest.event&.name %></td>
             <td ><%= guest.created_at %></td>


### PR DESCRIPTION
### Things Improve 
- Allow Save and Update all Guest infos when Create or Update Order 
- Remove Empty column when import 
- Add Guest infos to Guest QRCode Page

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/ac702038-962a-48d1-9b12-3eeefce798be">
