### PR TITLE
WIP #2042 create an api for event submissions

### DIFF
--- a/app/controllers/spree/api/v2/organizer/event_submission_controller.rb
+++ b/app/controllers/spree/api/v2/organizer/event_submission_controller.rb
@@ -1,0 +1,27 @@
+module Spree
+  module Api
+    module V2
+      module Organizer
+        class EventSubmissionController < ApplicationController
+          def collection
+            @taxon = Taxon.all
+          end
+
+          private
+
+          def collection_serializer
+            SpreeCmCommissioner::V2::Organizer::EventSubmissionSerializer
+          end
+
+          def resource_serializer
+            SpreeCmCommissioner::V2::Organizer::EventSubmissionSerializer
+          end
+
+          def submission_params
+            params.require(:taxon).permit(:name, :phone_number, :email, :image, :description)
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -485,6 +485,10 @@ Spree::Core::Engine.add_routes do
           resource :pie_chart_event_aggregators, only: %i[show]
         end
       end
+
+      namespace :organizer do
+        resources :event_submission
+      end
     end
 
     namespace :json_ld do


### PR DESCRIPTION
- [x] Create an API endpoint for submitting events, accessible through the organizer dashboard (required for cm-client integration).