### PR TITLE
close #2058 invalidate cache for frequently use API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,7 @@ AWS_OUTPUT_BUCKET_NAME="output-production-cm"
 
 AWS_CF_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----
 -----END PRIVATE KEY-----"
+
+# for GET request with following host, it will be cached.
+CONTENT_HOST_URL=https://content.bookme.plus
+CONTENT_CACHE_MAX_AGE=7200

--- a/app/controllers/concerns/spree_cm_commissioner/content_cachable.rb
+++ b/app/controllers/concerns/spree_cm_commissioner/content_cachable.rb
@@ -1,0 +1,20 @@
+module SpreeCmCommissioner
+  module ContentCachable
+    extend ActiveSupport::Concern
+
+    included do
+      after_action :set_cache_control_for_cdn
+    end
+
+    def max_age
+      ENV.fetch('CONTENT_CACHE_MAX_AGE', '7200')
+    end
+
+    def set_cache_control_for_cdn
+      return unless request.get? || request.head?
+      return unless request.base_url == ENV['CONTENT_HOST_URL']
+
+      response.set_header('Cache-Control', "public, max-age=#{max_age}")
+    end
+  end
+end

--- a/app/controllers/spree_cm_commissioner/action_controller/api_decorator.rb
+++ b/app/controllers/spree_cm_commissioner/action_controller/api_decorator.rb
@@ -3,6 +3,7 @@ module SpreeCmCommissioner
     module ApiDecorator
       def self.prepended(base)
         base.include SpreeCmCommissioner::ExceptionNotificable
+        base.include SpreeCmCommissioner::ContentCachable
       end
 
       # Annonymous block: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/BlockForwarding

--- a/app/controllers/spree_cm_commissioner/application_controller_decorator.rb
+++ b/app/controllers/spree_cm_commissioner/application_controller_decorator.rb
@@ -2,6 +2,7 @@ module SpreeCmCommissioner
   module ApplicationControllerDecorator
     def self.prepended(base)
       base.include SpreeCmCommissioner::ExceptionNotificable
+      base.include SpreeCmCommissioner::ContentCachable
     end
 
     # Annonymous block: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/BlockForwarding

--- a/app/interactors/spree_cm_commissioner/invalidate_cache_request.rb
+++ b/app/interactors/spree_cm_commissioner/invalidate_cache_request.rb
@@ -1,0 +1,31 @@
+require 'aws-sdk-cloudfront'
+
+# pattern: '/api/v2/storefront/homepage_sections*'
+# https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/invalidation-access-logs.html
+
+module SpreeCmCommissioner
+  class InvalidateCacheRequest < BaseInteractor
+    delegate :pattern, to: :context
+
+    def call
+      client = ::Aws::CloudFront::Client.new(
+        region: ENV.fetch('AWS_REGION'),
+        access_key_id: ENV.fetch('AWS_ACCESS_KEY_ID'),
+        secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY'),
+        http_open_timeout: 15,
+        http_read_timeout: 60
+      )
+
+      context.response = client.create_invalidation(
+        distribution_id: ENV.fetch('ASSETS_SYNC_CF_DIST_ID'),
+        invalidation_batch: {
+          caller_reference: Time.now.to_i.to_s,
+          paths: {
+            quantity: 1,
+            items: [pattern]
+          }
+        }
+      )
+    end
+  end
+end

--- a/app/jobs/spree_cm_commissioner/invalidate_cache_request_job.rb
+++ b/app/jobs/spree_cm_commissioner/invalidate_cache_request_job.rb
@@ -1,0 +1,7 @@
+module SpreeCmCommissioner
+  class InvalidateCacheRequestJob < ApplicationJob
+    def perform(pattern)
+      SpreeCmCommissioner::InvalidateCacheRequest.call(pattern: pattern)
+    end
+  end
+end

--- a/app/views/spree/admin/homepage_section/index.html.erb
+++ b/app/views/spree/admin/homepage_section/index.html.erb
@@ -3,6 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
+  <%= button_link_to Spree.t(:clear_cache), admin_invalidate_api_caches_path(model: SpreeCmCommissioner::HomepageSection.name), method: :post, class: "btn btn-outline-primary" %>
   <%= button_link_to Spree.t(:new_homepage_section), new_admin_homepage_feed_homepage_section_path, { class: "btn-success", icon: 'add.svg', id: 'admin_new_homepage_section' } %>
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Spree::Core::Engine.add_routes do
   # Add your extension routes here
   namespace :admin do
+    post '/invalidate_api_caches', to: 'base#invalidate_api_caches'
+
     resources :promotions do
       resources :custom_dates_rules, controller: :promotion_custom_dates_rules, only: %i[edit update] do
         member do

--- a/spec/cassettes/SpreeCmCommissioner_InvalidateCacheRequest/_call/requested_to_invalidate_cache_return_response.yml
+++ b/spec/cassettes/SpreeCmCommissioner_InvalidateCacheRequest/_call/requested_to_invalidate_cache_return_response.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://cloudfront.amazonaws.com/2020-05-31/distribution/D12FAKEFAKE/invalidation
+    body:
+      encoding: UTF-8
+      string: <InvalidationBatch xmlns="http://cloudfront.amazonaws.com/doc/2020-05-31/"><Paths><Quantity>1</Quantity><Items><Path>/staging/422.html</Path></Items></Paths><CallerReference>1729834869</CallerReference></InvalidationBatch>
+    headers:
+      Accept-Encoding:
+      - ''
+      Content-Type:
+      - application/xml
+      User-Agent:
+      - aws-sdk-ruby3/3.209.1 ua/2.1 api/cloudfront#1.82.0 os/macos#23 md/arm64 lang/ruby#3.2.0
+        md/3.2.0 m/D
+      Host:
+      - cloudfront.amazonaws.com
+      X-Amz-Date:
+      - 20241025T054109Z
+      X-Amz-Content-Sha256:
+      - 4231c5527e8a773761d8806a1578ab2d799479bf369bd60e0f5a4af0f08afa9b
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=AXXXXXXXXXXXXXXXY/20241025/us-east-1/cloudfront/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=66b25acc5a915f366e1da91e6ab214dfe1eb55c183fb2196836d6df212c696eb
+      Content-Length:
+      - '222'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Amzn-Requestid:
+      - 4dc45b65-cabf-4d0a-8253-7955e851cacd
+      Location:
+      - https://cloudfront.amazonaws.com/2020-05-31/distribution/D12FAKEFAKE/invalidation/I2PGO1F2LAWEKXXYAKMN0P38N1
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '384'
+      Date:
+      - Fri, 25 Oct 2024 05:41:10 GMT
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?>
+        <Invalidation xmlns="http://cloudfront.amazonaws.com/doc/2020-05-31/"><Id>I2PGO1F2LAWEKXXYAKMN0P38N1</Id><Status>InProgress</Status><CreateTime>2024-10-25T05:41:11.383Z</CreateTime><InvalidationBatch><Paths><Quantity>1</Quantity><Items><Path>/staging/422.html</Path></Items></Paths><CallerReference>1729834869</CallerReference></InvalidationBatch></Invalidation>
+  recorded_at: Fri, 25 Oct 2024 05:41:11 GMT
+recorded_with: VCR 6.1.0

--- a/spec/interactors/spree_cm_commissioner/invalidate_cache_request_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/invalidate_cache_request_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::InvalidateCacheRequest do
+  before do
+    ENV['AWS_REGION'] = 'ap-southeast-1'
+    ENV['AWS_ACCESS_KEY_ID'] = 'AXXXXXXXXXXXXXXXY'
+    ENV['AWS_SECRET_ACCESS_KEY'] = 'VO103FAKEFAKEFAKE3020X=I230x1'
+    ENV['ASSETS_SYNC_CF_DIST_ID'] = 'D12FAKEFAKE'
+  end
+
+  describe '.call', :vcr do
+    it 'requested to invalidate cache & return response' do
+      context = described_class.call(pattern: '/staging/422.html')
+
+      expect(context.response.location).to eq "https://cloudfront.amazonaws.com/2020-05-31/distribution/D12FAKEFAKE/invalidation/I2PGO1F2LAWEKXXYAKMN0P38N1"
+      expect(context.response.invalidation.id).to eq "I2PGO1F2LAWEKXXYAKMN0P38N1"
+      expect(context.response.invalidation.status).to eq "InProgress"
+    end
+  end
+end

--- a/spec/jobs/spree_cm_commissioner/invalidate_cache_request_job_spec.rb
+++ b/spec/jobs/spree_cm_commissioner/invalidate_cache_request_job_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::InvalidateCacheRequestJob do
+  describe '#perform' do
+    it 'invokes StateUpdater.call' do
+      expect(SpreeCmCommissioner::InvalidateCacheRequest).to receive(:call).with(pattern: '/api/storefront/*')
+      described_class.new.perform('/api/storefront/*')
+    end
+  end
+end


### PR DESCRIPTION
## In this PR:
1. Invalidate cache
![image](https://github.com/user-attachments/assets/fe77240b-d492-491f-a96f-a31fa6decf79)

2. Set cache to header for GET or HEAD. eg. `content.bookme.plus`

Since we use MiniProfilerRails, we can't set cache control at all. It will override.

| MiniProfilerRails | MiniProfilerRails (I disabled it for test) |
| - | - |
| <img width="610" alt="image" src="https://github.com/user-attachments/assets/0c1d0e38-210a-44d4-b6aa-f8653c34980c"> | <img width="845" alt="image" src="https://github.com/user-attachments/assets/a9ebf0bb-3044-4238-832b-644c0f5152d5"> |


Related PR:
- Changes on app to request to CDN for frequently use API: https://github.com/bookmebus/cm-market-app/pull/1915
- Changes on client to request to CDN for frequently use API: https://github.com/bookmebus/cm-market-client/pull/267