### PR TITLE
close #2057 add purchasable_on to product and taxon

### DIFF
--- a/app/models/spree_cm_commissioner/product_decorator.rb
+++ b/app/models/spree_cm_commissioner/product_decorator.rb
@@ -58,6 +58,8 @@ module SpreeCmCommissioner
       base.whitelisted_ransackable_attributes = %w[description name slug discontinue_on status vendor_id]
 
       base.after_update :update_variants_vendor_id, if: :saved_change_to_vendor_id?
+
+      base.enum purchasable_on: { both: 0, web: 1, app: 2 }
     end
 
     def associated_event

--- a/app/models/spree_cm_commissioner/taxon_decorator.rb
+++ b/app/models/spree_cm_commissioner/taxon_decorator.rb
@@ -41,6 +41,8 @@ module SpreeCmCommissioner
       base.before_save :set_slug
 
       base.whitelisted_ransackable_attributes |= %w[kind]
+
+      base.enum purchasable_on: { both: 0, web: 1, app: 2 }
     end
 
     def background_color

--- a/app/overrides/spree/admin/products/_form/purchasable_on_status.html.erb.deface
+++ b/app/overrides/spree/admin/products/_form/purchasable_on_status.html.erb.deface
@@ -1,0 +1,10 @@
+<!-- insert_before "[data-hook='admin_product_form_available_on']" -->
+
+<%= f.field_container :purchasable_on do %>
+  <%= f.label :purchasable_on, Spree.t('purchasable_on'), class: 'form-label' %>
+  <%= f.select :purchasable_on,
+        options_for_select([['Both', 'both'], ['Web', 'web'], ['App', 'app']], f.object.purchasable_on),
+        {  },
+        { class: 'select2 form-control' } %>
+  <%= f.error_message_on :purchasable_on, class: 'text-danger' %>
+<% end %>

--- a/app/overrides/spree/admin/taxons/_form/purchasable_on_status.html.erb.deface
+++ b/app/overrides/spree/admin/taxons/_form/purchasable_on_status.html.erb.deface
@@ -1,0 +1,10 @@
+<!-- insert_before "erb[loud]:contains('field_container :parent_id')" -->
+
+<%= f.field_container :purchasable_on do %>
+  <%= f.label :purchasable_on, Spree.t('purchasable_on'), class: 'form-label' %>
+  <%= f.select :purchasable_on,
+        options_for_select([['Both', 'both'], ['Web', 'web'], ['App', 'app']], f.object.purchasable_on),
+        {  },
+        { class: 'select2 form-control' } %>
+  <%= f.error_message_on :purchasable_on, class: 'text-danger' %>
+<% end %>

--- a/app/serializers/spree/v2/storefront/product_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/product_serializer_decorator.rb
@@ -11,7 +11,15 @@ module Spree
           base.has_one :default_state, serializer: :state
           base.has_one :venue, serializer: ::SpreeCmCommissioner::V2::Storefront::ProductPlaceSerializer
           base.attributes :need_confirmation, :product_type, :kyc, :allowed_upload_later, :allow_anonymous_booking, :use_video_as_default
-          base.attributes :reveal_description, :discontinue_on, :public_metadata
+          base.attributes :reveal_description, :discontinue_on, :public_metadata, :purchasable_on
+
+          base.attribute :purchasable_on_app do |product|
+            product.purchasable_on == 'app' || product.purchasable_on == 'both'
+          end
+
+          base.attribute :purchasable_on_web do |product|
+            product.purchasable_on == 'web' || product.purchasable_on == 'both'
+          end
         end
       end
     end

--- a/app/serializers/spree/v2/storefront/taxon_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/taxon_serializer_decorator.rb
@@ -11,7 +11,17 @@ module Spree
           base.has_one :web_banner, serializer: ::SpreeCmCommissioner::V2::Storefront::AssetSerializer
           base.has_one :home_banner, serializer: ::SpreeCmCommissioner::V2::Storefront::AssetSerializer
 
-          base.attributes :custom_redirect_url, :kind, :subtitle, :from_date, :to_date, :background_color, :foreground_color, :show_badge_status
+          base.attributes :custom_redirect_url, :kind, :subtitle, :from_date, :to_date,
+                          :background_color, :foreground_color, :show_badge_status,
+                          :purchasable_on
+
+          base.attribute :purchasable_on_app do |taxon|
+            taxon.purchasable_on == 'app' || taxon.purchasable_on == 'both'
+          end
+
+          base.attribute :purchasable_on_web do |taxon|
+            taxon.purchasable_on == 'web' || taxon.purchasable_on == 'both'
+          end
         end
       end
     end

--- a/config/initializers/spree_permitted_attributes.rb
+++ b/config/initializers/spree_permitted_attributes.rb
@@ -26,6 +26,7 @@ module Spree
       preferred_background_color
       preferred_foreground_color
       show_badge_status
+      purchasable_on
     ]
 
     @@store_attributes += [

--- a/db/migrate/20241118184033_add_purchasable_on_to_spree_taxons.rb
+++ b/db/migrate/20241118184033_add_purchasable_on_to_spree_taxons.rb
@@ -1,0 +1,5 @@
+class AddPurchasableOnToSpreeTaxons < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_taxons, :purchasable_on, :integer, null: false, default: 0, if_not_exists: true
+  end
+end

--- a/db/migrate/20241118184157_add_purchasable_on_to_spree_products.rb
+++ b/db/migrate/20241118184157_add_purchasable_on_to_spree_products.rb
@@ -1,0 +1,5 @@
+class AddPurchasableOnToSpreeProducts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_products, :purchasable_on, :integer, null: false, default: 0, if_not_exists: true
+  end
+end

--- a/spec/serializers/spree/v2/storefront/product_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/product_serializer_spec.rb
@@ -50,7 +50,10 @@ RSpec.describe Spree::V2::Storefront::ProductSerializer, type: :serializer do
         :allowed_upload_later,
         :allow_anonymous_booking,
         :discontinue_on,
-        :use_video_as_default
+        :use_video_as_default,
+        :purchasable_on,
+        :purchasable_on_app,
+        :purchasable_on_web
       )
     end
 

--- a/spec/serializers/spree/v2/storefront/taxon_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/taxon_serializer_spec.rb
@@ -47,7 +47,10 @@ RSpec.describe Spree::V2::Storefront::TaxonSerializer, type: :serializer do
         :to_date,
         :background_color,
         :foreground_color,
-        :show_badge_status
+        :show_badge_status,
+        :purchasable_on,
+        :purchasable_on_app,
+        :purchasable_on_web
       )
     end
 


### PR DESCRIPTION
### New Column Added: `purchasable_on` is used to determine whether a product or event can be purchased using both the web and app platforms, or if it is restricted to just one of them (either web or app).

In this PR, we’ve added a new column called `purchasable_on`. By default, this column is set to "Both," but it can also be configured to "Web" or "App."

| Screenshot | Description |
|------------|-------------|
| ![Screenshot 2024-11-19 at 2:53:50 AM](https://github.com/user-attachments/assets/3d37bb36-dfd2-4387-b7be-cc6b7c541c89) | Column Taxon`purchasable_on` in the database, with default value "Both". |

---

### New `TaxonSerializer` (with `purchasable_on`, `purchasable_on_app`, `purchasable_on_web`)

| Screenshot | Description |
|------------|-------------|
| ![Screenshot 2024-11-19 at 3:03:04 AM](https://github.com/user-attachments/assets/5af15c47-80d8-42bc-b982-71ba24e7c8ee) | New `TaxonSerializer` including fields: `purchasable_on`, `purchasable_on_app`, `purchasable_on_web`. |

---

| Screenshot | Description |
|------------|-------------|
| ![Screenshot 2024-11-19 at 2:55:43 AM](https://github.com/user-attachments/assets/f7186fa8-cf77-40c9-9130-0ae5226d235e) | Column Product `purchasable_on` in the database, with value "App".  |

---

### New `ProductSerializer` (with `purchasable_on`, `purchasable_on_app`, `purchasable_on_web`)

| Screenshot | Description |
|------------|-------------|
| ![Screenshot 2024-11-19 at 3:05:03 AM](https://github.com/user-attachments/assets/0038ec43-7734-4c91-8e41-5a183ed967bb) | New `ProductSerializer` including fields: `purchasable_on`, `purchasable_on_app`, `purchasable_on_web`. |


---
