### PR TITLE
close #2062 enchance guest_card ui avoid show null or N/A row

### DIFF
--- a/app/views/spree_cm_commissioner/guest_cards/show.html.erb
+++ b/app/views/spree_cm_commissioner/guest_cards/show.html.erb
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Document</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
     <style>
       body {
         margin: 0;
@@ -13,7 +14,7 @@
         justify-content: center;
         align-items: center;
         color: #1c1b20;
-        font-family: Arial, sans-serif;
+        font-family: 'Poppins', Arial, sans-serif;
       }
       .pass {
         background-color: white;
@@ -76,26 +77,36 @@
       <!-- Event Details -->
       <div class="details">
         <table>
-          <tr>
-            <td>Date & Time</td>
-            <td><%= event_date %></td>
-          </tr>
-          <tr>
-            <td>Venue</td>
-            <td><%= venue %></td>
-          </tr>
-          <tr>
-            <td>Full Name</td>
-            <td><%= full_name %></td>
-          </tr>
-          <tr>
-            <td>Phone Number</td>
-            <td><%= phone_number %></td>
-          </tr>
-          <tr>
-            <td>Pass Type</td>
-            <td><%= ticket_type %></td>
-          </tr>
+          <% if event_date.present? %>
+            <tr>
+              <td>Date & Time</td>
+              <td><%= event_date %></td>
+            </tr>
+          <% end %>
+          <% if venue.present? && venue != 'N/A' %>
+            <tr>
+              <td>Venue</td>
+              <td><%= venue %></td>
+            </tr>
+          <% end %>
+          <% if full_name.present? && full_name != 'N/A' %>
+            <tr>
+              <td>Full Name</td>
+              <td><%= full_name %></td>
+            </tr>
+          <% end %>
+          <% if phone_number.present? && phone_number != 'N/A' %>
+            <tr>
+              <td>Phone Number</td>
+              <td><%= phone_number %></td>
+            </tr>
+          <% end %>
+          <% if ticket_type.present? %>
+            <tr>
+              <td>Pass Type</td>
+              <td><%= ticket_type %></td>
+            </tr>
+          <% end %>
         </table>
       </div>
 


### PR DESCRIPTION
### Font and UI Enhancements

| Screenshot | Description |
|------------|-------------|
| <img width="1512" alt="Screenshot 2024-11-19 at 10 38 07 in the morning" src="https://github.com/user-attachments/assets/673b6f11-531e-4cfc-a8ef-18aee62fde37"> | **Before:** Phone Number and Full Name are displayed. The font is not consistent with the app's Poppins style. |
| <img width="1512" alt="Screenshot 2024-11-19 at 10 37 52 in the morning" src="https://github.com/user-attachments/assets/1fc29c42-5563-406f-a318-d1da00759397"> | **After:** UI enhanced to hide Phone Number and Full Name. Poppins font is used, consistent with the app. |
