### PR TITLE
close #2066 add deploy badge version to admin dashboard

### DIFF
--- a/app/overrides/spree/admin/shared/_version/deploy_tag_version_badge.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_version/deploy_tag_version_badge.html.erb.deface
@@ -1,0 +1,7 @@
+<!-- insert_after "erb[loud]:contains('Spree.version')" -->
+
+<p class="spree-version ml-3">
+  <span class="badge badge-pill badge-primary">
+    <%= "#{ENV['TAG_DEPLOY']} - #{ENV['TOUCH_REDEPLOY']}" %>
+  </span>
+</p>


### PR DESCRIPTION
## Assume Badge: Primary Deploy Version (1.2.3) ReDoply (3)

<img width="1512" alt="Screenshot 2024-11-20 at 10 20 05 in the morning" src="https://github.com/user-attachments/assets/b6754d00-ae7d-45dd-977a-5a5b98942328">

