### PR TITLE
close #2069 fix set pin code error

### DIFF
--- a/config/initializers/spree_permitted_attributes.rb
+++ b/config/initializers/spree_permitted_attributes.rb
@@ -15,6 +15,7 @@ module Spree
       otp_email
       otp_phone_number
       confirm_pin_code_enabled
+      confirm_pin_code
     ]
     @@taxon_attributes += %i[
       category_icon


### PR DESCRIPTION
### Steps to Reproduce

1. Open **App Settings**.  
2. Set the **Confirm PIN Code** and turn it **On**.  
3. Test the PIN code in **Developer Mode**.  
4. Observe the error message:  
   - The PIN code is successfully updated to `spree_user`.  
   - However, the `pin_code` parameter is not permitted.




### Staging Exception
```
Application spree_starter


⚠️ Error occurred in staging ⚠️
A *BCrypt::Errors::InvalidHash* occurred in *confirm_pin_code_checkers#update*.


Exception:
invalid hash


Request:
```
* url : https://staging-server.contigo.asia/api/v2/storefront/confirm_pin_code_checkers?pin_code=111111&locale=en
* http_method : PATCH
* ip_address : 203.144.71.63
* parameters : {"pin_code"=>"111111", "locale"=>"en", "format"=>"json", "controller"=>"spree/api/v2/storefront/confirm_pin_code_checkers", "action"=>"update"}
* timestamp : 2024-11-21 10:50:46 +0700
```


Backtrace:
```
* /app/vendor/bundle/ruby/3.2.0/gems/bcrypt-3.1.19/lib/bcrypt/password.rb:60:in `initialize'
* /app/vendor/bundle/ruby/3.2.0/bundler/gems/commissioner-d62151b6f32a/app/interactors/spree_cm_commissioner/confirm_pin_code_checker.rb:14:in `new'
* /app/vendor/bundle/ruby/3.2.0/bundler/gems/commissioner-d62151b6f32a/app/interactors/spree_cm_commissioner/confirm_pin_code_checker.rb:14:in `validate_pin_code!'
* /app/vendor/bundle/ruby/3.2.0/bundler/gems/commissioner-d62151b6f32a/app/interactors/spree_cm_commissioner/confirm_pin_code_checker.rb:8:in `call'
* /app/vendor/bundle/ruby/3.2.0/gems/interactor-3.1.2/lib/interactor.rb:143:in `block in run!'
```
```