### PR TITLE
Close #2084 Enhance email confirmation background color on dark mode

### DIFF
--- a/app/views/spree_cm_commissioner/layouts/order_mailer.html.erb
+++ b/app/views/spree_cm_commissioner/layouts/order_mailer.html.erb
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <link href="https://fonts.googleapis.com/css2?family=Poppins&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-    <%= render partial: 'spree_cm_commissioner/order_mailer/mailer_stylesheets' %>
+      <%= render partial: 'spree_cm_commissioner/order_mailer/mailer_stylesheets' %>
   </head>
   <body>
     <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0" role="presentation" id="confirm-email">

--- a/app/views/spree_cm_commissioner/order_mailer/_mailer_stylesheets.html.erb
+++ b/app/views/spree_cm_commissioner/order_mailer/_mailer_stylesheets.html.erb
@@ -22,7 +22,7 @@
   }
   .email-body_inner {
     background-color: transparent;
-    padding-top: 2.5rem;
+    padding-top: 1.5rem;
   }
   #confirm-email .content-cell {
     background: white;
@@ -54,7 +54,7 @@
     background-repeat: no-repeat;
     border-radius: 1.5625rem 1.5625rem 0 0;
     background: #653ed7;
-    background: url(<%= image_path("mailer/event-mailer-bg.png") %>),
+    background: url(<%= image_path("mailer/event-mailer-bg.png") %>) center center / cover,
                 linear-gradient(45deg, #653ed7, rgba(0, 0, 255, 0) 70.71%),
                 linear-gradient(225deg, #653ed7, rgba(0, 0, 255, 0) 70.71%),
                 linear-gradient(330deg, #35ace0, rgba(0, 0, 255, 0) 70.71%),
@@ -240,7 +240,8 @@
   .content {
     padding: 1.5rem;
     border-radius: 0 0 1.5625rem 1.5625rem;
-    border: 0.0625rem solid #dddfe2;  }
+    border: 0.0625rem solid #dddfe2;
+  }
   .purchase {
     width: 100%;
     border-collapse: collapse;
@@ -262,15 +263,9 @@
   .align-center-vertical {
     vertical-align: middle;
   }
-  @media (prefers-color-scheme: dark) {
-    #confirm-email .content-cell {
-      background-color: #333333;
-    }
-  }
   .mail-icon {
     width: 1.5rem;
     height: 1.5rem;
     margin: auto;
   }
-
 </style>


### PR DESCRIPTION
fix content theme on dark mode 
|before|after|
|-|-|
|<img width="294" alt="image" src="https://github.com/user-attachments/assets/151d7f1c-242e-4e39-bd85-374c44dfd38b">|<img width="301" alt="image" src="https://github.com/user-attachments/assets/4f04a1ac-0b7f-48aa-9755-29bded746901">|