### PR TITLE
close #2088 avoid carrying voided invoice forward

### DIFF
--- a/app/controllers/spree/billing/payments_controller.rb
+++ b/app/controllers/spree/billing/payments_controller.rb
@@ -61,6 +61,8 @@ module Spree
 
         flash[:success] = Spree.t(:payment_updated)
 
+        return if params[:e] == 'void_transaction'
+
         return unless @order.outstanding_balance.positive?
 
         @payment = @order.payments.build(amount: @order.outstanding_balance, payment_method: @order.collect_backend_payment_methods.first)

--- a/app/interactors/spree_cm_commissioner/subscriptions_order_creator.rb
+++ b/app/interactors/spree_cm_commissioner/subscriptions_order_creator.rb
@@ -52,6 +52,7 @@ module SpreeCmCommissioner
 
     def add_penalty_to_order
       return if context.last_order.blank?
+      return if context.last_order.payment_state == 'failed'
 
       penalty_rate_amount = context.last_order.outstanding_balance * customer.vendor.penalty_rate.to_f / 100
       Spree::Adjustment.create!(


### PR DESCRIPTION
- avoid adding penalty for voided invoice 
- fix a bug where a voiding a payment leads to a creation of another invoice