### PR TITLE
close #2092 fix undefined-method-money-for-string

### DIFF
--- a/app/overrides/spree/admin/payments/_form/amount_text_field.html.erb.deface
+++ b/app/overrides/spree/admin/payments/_form/amount_text_field.html.erb.deface
@@ -1,0 +1,3 @@
+
+<!-- replace 'erb[loud]:contains("f.text_field :amount")' -->
+<%= f.text_field :amount, value: @order.display_outstanding_balance.try(:to_f), class: 'form-control' %>


### PR DESCRIPTION

Application spree_starter


⚠️ Error occurred in staging ⚠️
An *ActionView::Template::Error* occurred in *payments#new*.


Exception:
undefined method `money' for "$70.00":String


Set by controller:
{:user=>"160"}


Request:
```
* url : https://staging-server.contigo.asia/admin/orders/R130030278/payments/new
* http_method : GET
* ip_address : 96.9.87.114
* parameters : {"controller"=>"spree/admin/payments", "action"=>"new", "order_id"=>"R130030278"}
* timestamp : 2024-11-26 21:37:16 +0700
```


Backtrace:
```
* /app/vendor/bundle/ruby/3.2.0/gems/spree_backend-4.5.1/app/views/spree/admin/payments/_form.html.erb:4:in `_vendor_bundle_ruby_______gems_spree_backend_______app_views_spree_admin_payments__form_html_erb___2383139735947033560_603740'
* /app/vendor/bundle/ruby/3.2.0/gems/actionview-7.0.8/lib/action_view/base.rb:244:in `public_send'
* /app/vendor/bundle/ruby/3.2.0/gems/actionview-7.0.8/lib/action_view/base.rb:244:in `_run'
* /app/vendor/bundle/ruby/3.2.0/gems/actionview-7.0.8/lib/action_view/template.rb:157:in `block in render'
* /app/vendor/bundle/ruby/3.2.0/gems/activesupport-7.0.8/lib/active_support/notifications.rb:206:in `block in instrument'
```