### PR TITLE
close #2094 add second to order state changes timestamp

### DIFF
--- a/app/overrides/spree/admin/state_changes/index/add_second_to_timestamp.html.erb.deface
+++ b/app/overrides/spree/admin/state_changes/index/add_second_to_timestamp.html.erb.deface
@@ -1,0 +1,7 @@
+<!-- replace "td:contains('pretty_time(state_change.created_at)')" -->
+<td>
+  <%= state_change.created_at.strftime('%B %d, %Y %I:%M:%S %p') %>
+  <% if state_change.created_at != state_change.updated_at %>
+    <small><%= Spree::StateChange.human_attribute_name(:updated) %>: <%= state_change.updated_at.strftime('%B %d, %Y %I:%M:%S %p') %></small>
+  <% end %>
+</td>


### PR DESCRIPTION
## Before
<img width="1512" alt="Screenshot 2024-11-27 at 12 02 39 in the afternoon" src="https://github.com/user-attachments/assets/5d7ebe3b-fce4-4618-93d5-db5c92d67905">

## After
<img width="1512" alt="Screenshot 2024-11-27 at 11 59 29 in the morning" src="https://github.com/user-attachments/assets/7d7cbf51-747d-4b80-94e6-161c859f8088">

