### PR TITLE
close #2122 void last invoice if penalty

### DIFF
--- a/app/interactors/spree_cm_commissioner/subscriptions_order_creator.rb
+++ b/app/interactors/spree_cm_commissioner/subscriptions_order_creator.rb
@@ -62,6 +62,15 @@ module SpreeCmCommissioner
         amount: context.last_order.outstanding_balance + penalty_rate_amount,
         label: customer.vendor.penalty_label || 'Penalty'
       )
+
+      void_previous_invoice
+    end
+
+    def void_previous_invoice
+      return if context.last_order.blank?
+
+      context.last_order.payments.last.void! if context.last_order.payments.last.present?
+      context.last_order.update(payment_state: 'failed')
     end
 
     def generate_invoice(last_invoice_date, month, active_subscriptions)

--- a/spec/controllers/spree/billing/report_controller_spec.rb
+++ b/spec/controllers/spree/billing/report_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Spree::Billing::ReportsController, type: :controller do
   describe 'overdue_report' do
     before do
       SpreeCmCommissioner::Subscription.all.each do |subscription|
-        subscription.orders.each {|o| o.payments.last.pend! }
+        subscription.orders.each {|o| o.payments.last.update(state: 'pending') }
       end
     end
 
@@ -49,7 +49,7 @@ RSpec.describe Spree::Billing::ReportsController, type: :controller do
   describe 'failed_report' do
     before do
       SpreeCmCommissioner::Subscription.all.each do |subscription|
-        subscription.orders.each {|o| o.payments.last.void! }
+        subscription.orders.each {|o| o.payments.last.update(state: 'void') }
       end
     end
 

--- a/spec/queries/spree_cm_commissioner/subscription_orders_query_spec.rb
+++ b/spec/queries/spree_cm_commissioner/subscription_orders_query_spec.rb
@@ -30,8 +30,6 @@ RSpec.describe SpreeCmCommissioner::SubscriptionOrdersQuery do
     end
 
     it 'return 0 overdues when due date == current date' do
-      subscription_jan2.orders.each {|o| o.payments.each{|p| p.pend! }} # pending = balance_due
-
       query = described_class.new(
         current_date: '2023-01-07'.to_date,
         vendor_id: customer.vendor.id,
@@ -46,7 +44,7 @@ RSpec.describe SpreeCmCommissioner::SubscriptionOrdersQuery do
     it 'return 1 overdues when due date < current date' do
       subscription_jan2
       SpreeCmCommissioner::SubscriptionsOrderCreator.call(customer: customer, today: today)
-      subscription_jan2.orders.each {|o| o.payments.each{|p| p.pend! }} # pending = balance_due
+      subscription_jan2.orders.each {|o| o.payments.each{|p| p.update(state: "pending") }}
       query = described_class.new(
         current_date: '2024-08-01'.to_date,
         vendor_id: customer.vendor.id,


### PR DESCRIPTION
Before:

- each month when creating a new invoice, if the last isn't paid, we add the last invoice amount with current invoice amount with additional penalty.
- but the last invoice remains in balance_due state which leads to incorrect monthly report .

New Changes:

- if the last invoice isn't paid, once the new invoice is created, we void the last invoice. 