### PR TITLE
Close #2124 Add vendor state to vendor serializer

### DIFF
--- a/app/serializers/spree/v2/storefront/vendor_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/vendor_serializer_decorator.rb
@@ -3,7 +3,7 @@ module Spree
     module Storefront
       module VendorSerializerDecorator
         def self.prepended(base)
-          base.attributes :min_price, :max_price, :star_rating, :short_description, :full_address
+          base.attributes :min_price, :max_price, :star_rating, :short_description, :full_address, :state
 
           base.has_many :stock_locations
           base.has_many :variants, serializer: 'Spree::Variant'

--- a/spec/serializers/spree/v2/storefront/accommodation_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/accommodation_serializer_spec.rb
@@ -40,7 +40,8 @@ RSpec.describe Spree::V2::Storefront::AccommodationSerializer, type: :serializer
         :service_availabilities,
         :total_booking,
         :remaining,
-        :full_address
+        :full_address,
+        :state,
       )
     end
 

--- a/spec/serializers/spree/v2/storefront/vendor_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/vendor_serializer_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe Spree::V2::Storefront::VendorSerializer, type: :serializer do
         :max_price,
         :star_rating,
         :short_description,
-        :full_address
+        :full_address,
+        :state
       )
     end
 


### PR DESCRIPTION
Add vendor status to vendor serializer. So, in app, we can show vendor tile only when it is active.

<img width="293" alt="image" src="https://github.com/user-attachments/assets/8789a45f-35ea-41b1-ac47-c2835953df3d">

