### PR TITLE
close #2128: add index to event_id in cm_guests to fix slow query

### DIFF
--- a/db/migrate/20241210103106_add_index_to_event_id_in_cm_guests.rb
+++ b/db/migrate/20241210103106_add_index_to_event_id_in_cm_guests.rb
@@ -1,0 +1,5 @@
+class AddIndexToEventIdInCmGuests < ActiveRecord::Migration[7.0]
+  def change
+    add_index :cm_guests, :event_id, if_not_exists: true
+  end
+end


### PR DESCRIPTION
**Fix Problem**
The query in SpreeCmCommissioner::Guest#find was slow due to a sequential scan on cm_guests, filtering by event_id and bib_prefix.

**Original query**
```sql
SELECT
  "cm_guests".*
FROM
  "cm_guests"
  INNER JOIN "spree_line_items" ON "spree_line_items"."id" = "cm_guests"."line_item_id"
  INNER JOIN "spree_orders" ON "spree_orders"."id" = "spree_line_items"."order_id"
WHERE
  "spree_orders"."completed_at" IS NOT NULL
  AND "spree_orders"."state" != ?
  AND "cm_guests"."event_id" = ?
  AND (
    "cm_guests"."bib_prefix" = ?
    OR "cm_guests"."bib_prefix" IS NULL
  )
```

**Before adding index** 
```
Nested Loop  (cost=0.56..64.49 rows=1 width=286) (actual time=10.331..10.332 rows=0 loops=1)
  ->  Nested Loop  (cost=0.28..64.01 rows=1 width=294) (actual time=10.327..10.328 rows=0 loops=1)
        ->  Seq Scan on cm_guests  (cost=0.00..55.70 rows=1 width=286) (actual time=10.327..10.327 rows=0 loops=1)
              Filter: ((((bib_prefix)::text = 'abc'::text) OR (bib_prefix IS NULL)) AND (event_id = 123))
              Rows Removed by Filter: 1380
        ->  Index Scan using spree_line_items_pkey on spree_line_items  (cost=0.28..8.30 rows=1 width=16) (never executed)
              Index Cond: (id = cm_guests.line_item_id)
  ->  Index Scan using spree_orders_pkey on spree_orders  (cost=0.28..0.49 rows=1 width=8) (never executed)
        Index Cond: (id = spree_line_items.order_id)
        Filter: ((completed_at IS NOT NULL) AND ((state)::text <> 'complete'::text))
Planning Time: 2.218 ms
Execution Time: 10.500 ms
```

**After adding index**
```
Nested Loop  (cost=0.84..17.09 rows=1 width=286) (actual time=0.011..0.012 rows=0 loops=1)
  ->  Nested Loop  (cost=0.56..16.60 rows=1 width=294) (actual time=0.010..0.011 rows=0 loops=1)
        ->  Index Scan using index_cm_guests_on_event_id on cm_guests  (cost=0.28..8.30 rows=1 width=286) (actual time=0.009..0.010 rows=0 loops=1)
              Index Cond: (event_id = 123)
              Filter: (((bib_prefix)::text = 'abc'::text) OR (bib_prefix IS NULL))
        ->  Index Scan using spree_line_items_pkey on spree_line_items  (cost=0.28..8.30 rows=1 width=16) (never executed)
              Index Cond: (id = cm_guests.line_item_id)
  ->  Index Scan using spree_orders_pkey on spree_orders  (cost=0.28..0.49 rows=1 width=8) (never executed)
        Index Cond: (id = spree_line_items.order_id)
        Filter: ((completed_at IS NOT NULL) AND ((state)::text <> 'complete'::text))
Planning Time: 0.882 ms
Execution Time: 0.106 ms
```
**Result(in development)**: Execution time improved 10.500 ms to  0.106 ms
