### PR TITLE
close #2133 enchance N+1 admin/products

### DIFF
--- a/app/controllers/spree_cm_commissioner/admin/products_controller_decorator.rb
+++ b/app/controllers/spree_cm_commissioner/admin/products_controller_decorator.rb
@@ -5,6 +5,38 @@ module SpreeCmCommissioner
         # spree update user sign_in_count
         base.around_action :set_writing_role, only: %i[index]
       end
+
+      # Override
+      def collection
+        return @collection if @collection.present?
+
+        params[:q] ||= {}
+        params[:q][:deleted_at_null] ||= '1'
+        params[:q][:s] ||= 'name asc'
+
+        @collection = product_scope
+
+        @collection = @collection.with_deleted if params[:q][:deleted_at_null] == '0'
+
+        @search = @collection.ransack(params[:q].reject { |k, _v| k.to_s == 'deleted_at_null' })
+
+        @collection = @search.result
+                             .includes(*product_includes)
+                             .page(params[:page])
+                             .per(params[:per_page] || 10)
+
+        @collection
+      end
+
+      # Override
+      def product_includes
+        [
+          :vendor,
+          :shipping_category,
+          { master: :images },
+          :variants
+        ]
+      end
     end
   end
 end


### PR DESCRIPTION
# In this PR
- Overridden `collection` method to paginate with 10 items per page by default.
- Included associations with the product model:  vendor,  shipping_category, and variants to reduce N+1 queries.

# SQL Queries

### Vendor Query
```SQL
SELECT "spree_vendors".* 
FROM "spree_vendors" 
WHERE "spree_vendors"."deleted_at" IS NULL 
AND "spree_vendors"."id" IN ($1, $2, $3, $4, $5)
```

### Shipping Category Query
```SQL
SELECT "spree_shipping_categories".* 
FROM "spree_shipping_categories" 
WHERE "spree_shipping_categories"."id" IN ($1, $2)
```

### Variant Query
```SQL
SELECT "spree_variants".* 
FROM "spree_variants" 
WHERE "spree_variants"."deleted_at" IS NULL 
AND "spree_variants"."is_master" = $1 
AND "spree_variants"."product_id" IN ($2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
```