### PR TITLE
close #2150 remove nested translation for spree.currency

### DIFF
--- a/app/views/spree/billing/shared/_pop_up_confirmation.html.erb
+++ b/app/views/spree/billing/shared/_pop_up_confirmation.html.erb
@@ -12,7 +12,7 @@
           <div class="form-group d-flex justify-content-between">
             <%= I18n.t('spree.billing.amount_to_be_paid') %>
             <div class="row col-7 d-flex justify-content-between">
-              <%= I18n.t('spree.currency.riel') %>
+              <%= I18n.t('currency.riel') %>
               <%= text_field :amount_to_be_paid, '', placeholder: order.outstanding_balance.to_s, class: 'form-control', id: "#{payment.id}_amount_to_be_paid", style: 'width: 85%; margin-right: 5%;', disabled: true %>
             </div>
           </div>
@@ -20,28 +20,28 @@
           <div class="d-flex justify-content-between">
             <%= Spree.t(:dollar) %>
             <div id="payment-data" data-payment-id="<%= payment.id %>" class="form-group row col-7 d-flex justify-content-between">
-              <%= I18n.t('spree.currency.dollar') %>
+              <%= I18n.t('currency.dollar') %>
               <%= text_field :en_currency, '', class: 'form-control', style: 'width: 85%; margin-right: 5%;', id: "#{payment.id}_en_currency" %>
             </div>
           </div>
           <div class="form-group d-flex justify-content-between">
             <%= Spree.t(:riel) %>
             <div id="payment-data" data-payment-id="<%= payment.id %>" class="row col-7 d-flex justify-content-between">
-              <%= I18n.t('spree.currency.riel') %>
+              <%= I18n.t('currency.riel') %>
               <%= text_field :kh_currency, '', class: 'form-control', style: 'width: 85%; margin-right: 5%;', id: "#{payment.id}_kh_currency" %>
             </div>
           </div>
           <div class="form-group d-flex justify-content-between">
             <%= Spree.t(:total) %>
             <div class="row col-7 d-flex justify-content-between">
-              <%= I18n.t('spree.currency.riel') %>
+              <%= I18n.t('currency.riel') %>
               <%= f.text_field :amount, class: 'form-control', style: 'width: 85%; margin-right: 5%;', id: "#{payment.id}_total", disabled: true %>
             </div>
           </div>
           <div class="form-group d-flex justify-content-between">
             <%= I18n.t('spree.billing.amount_remaining') %>
             <div class="row col-7 d-flex justify-content-between">
-              <%= I18n.t('spree.currency.riel') %>
+              <%= I18n.t('currency.riel') %>
               <%= f.text_field :amount, class: 'form-control', style: 'width: 85%; margin-right: 5%;', id: "#{payment.id}_amount_remaining", disabled: true %>
             </div>
           </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -171,10 +171,11 @@ en:
   user:
     invalid_password: "Invalid Password"
 
+  currency:
+    dollar: "$"
+    riel: "៛"
+
   spree:
-    currency:
-      dollar: "$"
-      riel: "៛"
     cancel: "Cancel"
     confirm: "Confirm"
     en: "English"

--- a/config/locales/km.yml
+++ b/config/locales/km.yml
@@ -148,6 +148,10 @@ km:
   user:
     invalid_password: "Current password is not valid"
 
+  currency:
+    dollar: "$"
+    riel: "៛"
+
   spree:
     km: "ភាសារខ្មែរ"
     date_of_birth: "ថ្ងៃខែឆ្នាំកំណើត"


### PR DESCRIPTION
Should never use nested value under spree:

```yml
# ❌
spree:
  currency:
    dollar: "$"
    riel: "៛"

# ✅
spree:
  dollar: "$"
  riel: "៛"
  currency: "Currency"
```

We should follow spree which is a key value translation. `Spree.t(:currency)`

<img width="500" alt="image" src="https://github.com/user-attachments/assets/af3dfb2d-2821-43d3-84fe-4682a75345cd" />
