### PR TITLE
close #2156: lock db when generate bib_index to fix concurrency

### DIFF
--- a/spec/models/spree_cm_commissioner/guest_spec.rb
+++ b/spec/models/spree_cm_commissioner/guest_spec.rb
@@ -309,7 +309,6 @@ RSpec.describe SpreeCmCommissioner::Guest, type: :model do
       end
     end
 
-
     context "when guest in the same event" do
       context "when guest has the same prefix" do
         let(:line_item) { create(:line_item, order: order, variant: product_with_bib1.variants.first) }
@@ -324,6 +323,23 @@ RSpec.describe SpreeCmCommissioner::Guest, type: :model do
           expect(guest2.bib_number).to eq 2
           expect(guest1.formatted_bib_number).to eq '3KM001'
           expect(guest2.formatted_bib_number).to eq '3KM002'
+        end
+      end
+
+      context "when multiple generate_bib! concurrently" do
+        let(:line_item) { create(:line_item, order: order, variant: product_with_bib1.variants.first) }
+        let(:guest1) { create(:guest, line_item: line_item, seat_number: 1) }
+        let(:guest2) { create(:guest, line_item: line_item, seat_number: 2) }
+        let(:bib_prefix) { line_item.variant.bib_prefix }
+
+        it 'ensures unique bib_numbers and bib_index for each guest' do
+          threads = []
+          threads << Thread.new { guest1.generate_bib! }
+          threads << Thread.new { guest2.generate_bib! }
+          threads.each(&:join)
+
+          bib_indices = SpreeCmCommissioner::Guest.where(event_id: guest1.event_id, bib_prefix: bib_prefix).pluck(:bib_index)
+          expect(bib_indices.uniq.size).to eq(2)
         end
       end
 


### PR DESCRIPTION
- When payment is `completed`, the order will update the state to `complete` and trigger guest to `generate_bib!` (`SpreeCmCommissioner::OrderBibNumberConcern`)
- The bib_index is validated as unique
- Users may make payments simultaneously that make the guest_bib_index duplicate and raise errors.
- If applying a queue, it may cause a delay and need to update the UI to handle the delay.
- So we apply lock db with pessimistic lock.