### PR TITLE
Close #2156: Add lock_version to guest to resolve duplicate bib issue

### DIFF
--- a/app/models/spree_cm_commissioner/guest.rb
+++ b/app/models/spree_cm_commissioner/guest.rb
@@ -5,8 +5,8 @@ module SpreeCmCommissioner
     delegate :kyc, to: :line_item, allow_nil: true
     delegate :allowed_upload_later?, to: :line_item, allow_nil: true
 
-    enum gender: { :other => 0, :male => 1, :female => 2 }
-    enum social_contact_platform: {
+    enum :gender, { :other => 0, :male => 1, :female => 2 }
+    enum :social_contact_platform, {
       :other => 0,
       :telegram => 1,
       :facebook => 2,
@@ -14,7 +14,7 @@ module SpreeCmCommissioner
       :whatsapp => 4,
       :line => 5,
       :viber => 6
-    }, _prefix: true
+    }, prefix: true
 
     scope :complete, -> { joins(:line_item).merge(Spree::LineItem.complete) }
     scope :complete_or_canceled, -> { joins(:line_item).merge(Spree::LineItem.complete_or_canceled) }
@@ -179,24 +179,21 @@ module SpreeCmCommissioner
       line_item.variant.bib_display_prefix?
     end
 
-    def generate_bib
-      return if bib_prefix.present?
-      return unless bib_required?
-      return if event_id.blank?
-
-      self.bib_prefix = line_item.variant.bib_prefix
-
-      last_bib_number = event.guests
-                             .where(bib_prefix: bib_prefix)
-                             .maximum(:bib_number) || 0
-
-      self.bib_number = last_bib_number + 1
-      self.bib_index = "#{event_id}-#{bib_prefix}-#{bib_number}"
-    end
-
     def generate_bib!
-      generate_bib
-      save!
+      return if bib_prefix.present? || !bib_required? || event_id.blank?
+
+      transaction do
+        reload # Reloads the record with the latest lock_version
+        self.bib_prefix = line_item.variant.bib_prefix
+
+        last_bib_number = event.guests
+                               .where(bib_prefix: bib_prefix)
+                               .maximum(:bib_number) || 0
+
+        self.bib_number = last_bib_number + 1
+        self.bib_index = "#{event_id}-#{bib_prefix}-#{bib_number}"
+        save!
+      end
     end
 
     # bib_number: 345, bib_prefix: 5KM, bib_zerofill: 5 => return 5KM00345

--- a/db/migrate/20241224095552_add_lock_version_to_guests.rb
+++ b/db/migrate/20241224095552_add_lock_version_to_guests.rb
@@ -1,0 +1,5 @@
+class AddLockVersionToGuests < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cm_guests, :lock_version, :integer, default: 0, null: false
+  end
+end

--- a/spec/models/spree_cm_commissioner/guest_spec.rb
+++ b/spec/models/spree_cm_commissioner/guest_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe SpreeCmCommissioner::Guest, type: :model do
     end
   end
 
-  describe '#generate_bib' do
+  describe '#generate_bib!' do
     let(:taxonomy) { create(:taxonomy, kind: :event) }
     let(:event1) { create(:taxon, name: 'BunPhum', taxonomy: taxonomy) }
     let(:event2) { create(:taxon, name: 'BunPhum 2', taxonomy: taxonomy) }
@@ -309,7 +309,6 @@ RSpec.describe SpreeCmCommissioner::Guest, type: :model do
       end
     end
 
-
     context "when guest in the same event" do
       context "when guest has the same prefix" do
         let(:line_item) { create(:line_item, order: order, variant: product_with_bib1.variants.first) }
@@ -324,6 +323,23 @@ RSpec.describe SpreeCmCommissioner::Guest, type: :model do
           expect(guest2.bib_number).to eq 2
           expect(guest1.formatted_bib_number).to eq '3KM001'
           expect(guest2.formatted_bib_number).to eq '3KM002'
+        end
+      end
+
+      context "when multiple generate_bib! concurrently" do
+        let(:line_item) { create(:line_item, order: order, variant: product_with_bib1.variants.first) }
+        let(:guest1) { create(:guest, line_item: line_item, seat_number: 1) }
+        let(:guest2) { create(:guest, line_item: line_item, seat_number: 2) }
+        let(:bib_prefix) { line_item.variant.bib_prefix }
+
+        it 'ensures unique bib_numbers and bib_index for each guest' do
+          threads = []
+          threads << Thread.new { guest1.generate_bib! }
+          threads << Thread.new { guest2.generate_bib! }
+          threads.each(&:join)
+
+          bib_indices = SpreeCmCommissioner::Guest.where(event_id: guest1.event_id, bib_prefix: bib_prefix).pluck(:bib_index)
+          expect(bib_indices.uniq.size).to eq(2)
         end
       end
 
@@ -364,6 +380,7 @@ RSpec.describe SpreeCmCommissioner::Guest, type: :model do
       guest.generate_bib!
 
       variant.update(option_values: [not_display_bib_prefix])
+      guest.reload
 
       expect(guest.formatted_bib_number).to eq "001"
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,4 +23,15 @@ RSpec.configure do |config|
   # https://github.com/channainfo/commissioner/pull/316
   config.order = :random
   Kernel.srand config.seed
+
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+  end
 end


### PR DESCRIPTION
- When payment is `completed`, the order will update the state to `complete` and trigger guest to `generate_bib!` (`SpreeCmCommissioner::OrderBibNumberConcern`)
- The bib_index is validated as unique
- Users may make payments simultaneously that make the guest_bib_index duplicate and raise errors.
- **Continue from enqueue** [PR#2183](https://github.com/channainfo/commissioner/pull/2183) 
- So we apply lock db with `optimistic lock` - Lock with version.