### PR TITLE
close #2196 prevent assigning random address to user

### DIFF
--- a/app/models/spree_cm_commissioner/order/address_book_decorator.rb
+++ b/app/models/spree_cm_commissioner/order/address_book_decorator.rb
@@ -1,0 +1,39 @@
+# Override to reject setting billing/shipping addresses for guest orders if no basic information is provided.
+#
+# Without this safeguard, Spree may associate the order with a random existing address using the following default behavior:
+# ::Spree::Address.find_or_create_by(attributes.except(:id, :updated_at, :created_at))
+module SpreeCmCommissioner
+  module Order
+    module AddressBookDecorator
+      def guest_order? = user.blank?
+
+      # override
+      def bill_address_attributes=(attributes)
+        attributes[:id] = bill_address&.id if attributes[:id].blank?
+        return if guest_order? && !basic_info_included?(attributes)
+
+        super
+      end
+
+      # override
+      def ship_address_attributes=(attributes)
+        attributes[:id] = bill_address&.id if attributes[:id].blank?
+        return if guest_order? && !basic_info_included?(attributes)
+
+        super
+      end
+
+      private
+
+      def basic_info_included?(attributes)
+        return true if attributes[:id].present?
+
+        %i[firstname lastname phone].all? { |key| attributes[key].present? }
+      end
+    end
+  end
+end
+
+unless Spree::Order::AddressBook.included_modules.include?(SpreeCmCommissioner::Order::AddressBookDecorator)
+  Spree::Order::AddressBook.prepend(SpreeCmCommissioner::Order::AddressBookDecorator)
+end

--- a/spec/models/spree_cm_commissioner/order/address_book_decorator_spec.rb
+++ b/spec/models/spree_cm_commissioner/order/address_book_decorator_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::Order::AddressBookDecorator, type: :model do
+  describe '#bill_address_attributes=' do
+    let!(:existing_address) { create(:address, first_name: "Panha", last_name: "Chom", city: "Poi Pet") }
+
+    context 'when it is guest order' do
+      context 'when no existing billing address' do
+        let!(:order1) { create(:order, billing_address: nil, user_id: nil) }
+        let(:address_attributes) do
+          { city: "Phnom Penh", address1: "Lovely Street", state_id: existing_address.state_id, country_id: existing_address.country_id, zipcode: existing_address.zipcode }
+        end
+
+        it 'reject bill address when basic info is not provided' do
+          order1.bill_address_attributes = address_attributes
+
+          expect(order1.save).to be true
+          expect(order1.bill_address.nil?).to be true
+        end
+
+        it 'saved new bill address when basic info is provided' do
+          order1.bill_address_attributes = address_attributes.merge({ firstname: "Thea", lastname: "Choem", phone: "012345678" })
+
+          expect(order1.save).to be true
+          expect(order1.bill_address.id).to be_present
+        end
+      end
+
+      context 'when is existing billing address' do
+        let!(:order1) { create(:order, billing_address: existing_address, user_id: nil) }
+
+        it 'just save bill address (bill_address.id is all it need)' do
+          order1.bill_address_attributes = { city: "New Phnom Penh", address1: "New Address Right Here" }
+
+          expect(order1.save).to be true
+          expect(order1.bill_address.city).to eq "New Phnom Penh"
+          expect(order1.bill_address.address1).to eq "New Address Right Here"
+          expect(order1.bill_address.id).to eq existing_address.id
+        end
+      end
+    end
+  end
+
+  describe '#ship_address_attributes=' do
+    let!(:existing_address) { create(:address, first_name: "Panha", last_name: "Chom", city: "Poi Pet") }
+
+    context 'when it is guest order' do
+      context 'when no existing billing address' do
+        let!(:order1) { create(:order, billing_address: nil, ship_address: nil, user_id: nil) }
+        let(:address_attributes) do
+          { city: "Phnom Penh", address1: "Lovely Street", state_id: existing_address.state_id, country_id: existing_address.country_id, zipcode: existing_address.zipcode }
+        end
+
+        it 'reject shipping address when basic info is not provided' do
+          order1.ship_address_attributes = address_attributes
+
+          expect(order1.save).to be true
+          expect(order1.ship_address.nil?).to be true
+        end
+
+        it 'saved new shipping address when basic info is provided' do
+          order1.ship_address_attributes = address_attributes.merge({ firstname: "Thea", lastname: "Choem", phone: "012345678" })
+
+          expect(order1.save).to be true
+          expect(order1.ship_address.id).to be_present
+        end
+      end
+
+      context 'when is existing billing address' do
+        let!(:order1) { create(:order, billing_address: existing_address, ship_address: existing_address, user_id: nil) }
+
+        it 'just save shipping address (shipping_address.id is all it need)' do
+          order1.ship_address_attributes = { city: "New Phnom Penh", address1: "New Address Right Here" }
+
+          expect(order1.save).to be true
+          expect(order1.ship_address.city).to eq "New Phnom Penh"
+          expect(order1.ship_address.address1).to eq "New Address Right Here"
+          expect(order1.ship_address.id).to eq existing_address.id
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Issue

It only happens for guest orders (no user). This 1-minute video describes the issue:

https://github.com/user-attachments/assets/a55089ab-33fa-4837-8264-bbab2f28cc13


## Fixed & tested on staging

It no longer set random address.

<img width="574" alt="image" src="https://github.com/user-attachments/assets/ed8242fe-734b-4d44-8149-28f79b8e649e" />
