### PR TITLE
close #2198 fix could not create new promotion

### DIFF
--- a/app/models/spree_cm_commissioner/promotion_decorator.rb
+++ b/app/models/spree_cm_commissioner/promotion_decorator.rb
@@ -14,7 +14,11 @@ module SpreeCmCommissioner
     end
 
     def auto_apply?
-      auto_apply.in?([true, 'true', '1'])
+      if auto_apply.present?
+        auto_apply.in?([true, 'true', '1'])
+      else
+        code.nil? && path.nil?
+      end
     end
 
     def date_eligible?(date)

--- a/app/overrides/spree/admin/promotions/_form/auto_apply_field.html.erb.deface
+++ b/app/overrides/spree/admin/promotions/_form/auto_apply_field.html.erb.deface
@@ -2,7 +2,7 @@
 
 <%= f.field_container :auto_apply, class: ['checkbox'] do %>
   <%= f.label :auto_apply do %>
-    <%= f.check_box :auto_apply, checked: f.object.code.nil? && f.object.path.nil? %>
+    <%= f.check_box :auto_apply, checked: f.object&.auto_apply? %>
     <%= Spree.t(:auto_apply) %>
     <small class="form-text text-muted">
       <%= raw Spree.t('auto_apply_info') %>


### PR DESCRIPTION
```
Application spree_starter


⚠️ Error occurred in production ⚠️
An *ActionView::Template::Error* occurred in *promotions#new*.


Exception:
undefined method 'code' for nil:NilClass
```

<img width="1090" alt="image" src="https://github.com/user-attachments/assets/373f841f-2f86-4572-9ec7-d6f10c5e1ee8" />
