### PR TITLE
Close #2219 Organizer fetch ticket api

### DIFF
--- a/app/controllers/spree/api/v2/organizer/base_controller.rb
+++ b/app/controllers/spree/api/v2/organizer/base_controller.rb
@@ -1,0 +1,15 @@
+module Spree
+  module Api
+    module V2
+      module Organizer
+        class BaseController < ::Spree::Api::V2::BaseController
+          include Spree::Api::V2::CollectionOptionsHelpers
+
+          def render_serialized_payload(status = 200)
+            render json: yield, status: status, content_type: content_type
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/spree/api/v2/organizer/tickets_controller.rb
+++ b/app/controllers/spree/api/v2/organizer/tickets_controller.rb
@@ -1,0 +1,34 @@
+module Spree
+  module Api
+    module V2
+      module Organizer
+        class TicketsController < ::Spree::Api::V2::Organizer::BaseController
+          def index
+            event = Spree::Taxon.find(params[:event_id])
+
+            resource = event.products.page(params[:page]).per(params[:per_page])
+
+            render_serialized_payload do
+              collection_serializer.new(
+                resource,
+                collection_options(resource)
+              ).serializable_hash
+            end
+          end
+
+          def show
+            resource = Spree::Product.find(params[:id])
+
+            render_serialized_payload do
+              Spree::V2::Organizer::TicketSerializer.new(resource).serializable_hash
+            end
+          end
+
+          def collection_serializer
+            ::Spree::V2::Organizer::TicketSerializer
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/spree/v2/organizer/base_serializer.rb
+++ b/app/serializers/spree/v2/organizer/base_serializer.rb
@@ -1,0 +1,9 @@
+module Spree
+  module V2
+    module Organizer
+      class BaseSerializer
+        include JSONAPI::Serializer
+      end
+    end
+  end
+end

--- a/app/serializers/spree/v2/organizer/ticket_serializer.rb
+++ b/app/serializers/spree/v2/organizer/ticket_serializer.rb
@@ -1,0 +1,10 @@
+module Spree
+  module V2
+    module Organizer
+      class TicketSerializer < BaseSerializer
+        set_type :ticket
+        attributes :name, :price, :compare_at_price, :available_on, :kyc, :description, :shipping_category_id, :product_type, :status
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -384,6 +384,10 @@ Spree::Core::Engine.add_routes do
         resources :places
       end
 
+      namespace :organizer do
+        resources :tickets
+      end
+
       namespace :storefront do
         resources :waiting_room_sessions, only: :create
 


### PR DESCRIPTION
### Get Ticket API by event ID under organizer namespace
URL: {{BASE_URL}}/api/v2/organizer/tickets?event_id=415

````
{
"data": [
  {
    "id": "240",
    "type": "ticket",
    "attributes": {
      "name": "5KM Race",
      "price": "10.99",
      "compare_at_price": "0.0",
      "available_on": null,
      "kyc": 0,
      "description": "",
      "shipping_category_id": 5,
      "product_type": "ecommerce",
      "status": "active"
      }
    }
  ],
  "meta": {
    "count": 1,
    "total_count": 1,
    "total_pages": 1
  },
  "links": {
    "self": "http://127.0.0.1:4000/api/v2/organizer/tickets?event_id=415",
    "next": "http://127.0.0.1:4000/api/v2/organizer/tickets?page=1",
    "prev": "http://127.0.0.1:4000/api/v2/organizer/tickets?page=1",
    "last": "http://127.0.0.1:4000/api/v2/organizer/tickets?page=1",
    "first": "http://127.0.0.1:4000/api/v2/organizer/tickets?page=1"
  }
}

