### PR TITLE
close #2236 fix noticed response content cachable

### DIFF
--- a/app/controllers/concerns/spree_cm_commissioner/content_cachable.rb
+++ b/app/controllers/concerns/spree_cm_commissioner/content_cachable.rb
@@ -11,6 +11,9 @@ module SpreeCmCommissioner
     end
 
     def set_cache_control_for_cdn
+      return if response.committed?
+      return if response.status != 200
+
       # max-age: browser cache, s-maxage: server cache
       response.headers['Cache-Control'] = "public, max-age=0, s-maxage=#{max_age}"
       response.headers['Pragma'] = 'no-cache' # For older HTTP/1.0 clients


### PR DESCRIPTION
## This PR is 
Explanation:
This method sets cache control headers for the response.
- `return if response.committed?`: Exits the method if the response is already committed (that is headers have already been sent).
-` return if response.status != 200`: Exits the method if the response status is not 200 (OK).
-  If the response is not committed and the `status is 200`, it sets the following headers:
- `Cache-Control`: Specifies caching directives. public makes the response cacheable by any cache, max-age=0 means the browser cache should not cache the response, and `s-maxage=#{max_age}` sets the server cache duration.
`Pragma`: Sets to no-cache for older HTTP/1.0 clients to prevent caching.
`Expires`: Sets to 0 to indicate that the response is already expired.

## DEMO Postman Headers

https://github.com/user-attachments/assets/25f34804-89ce-4db1-b28f-a007ea7a3c8a

