### PR TITLE
close #2252 remove passed events from homepage section in app

### DIFF
--- a/app/controllers/spree/admin/homepage_section_relatable_controller.rb
+++ b/app/controllers/spree/admin/homepage_section_relatable_controller.rb
@@ -25,7 +25,7 @@ module Spree
       end
 
       def permitted_resource_params
-        params.require(object_name).permit(:homepage_section_id, :relatable_id, :relatable_type, :active)
+        params.require(object_name).permit(:homepage_section_id, :relatable_id, :relatable_type, :available_on, :discontinue_on)
       end
     end
   end

--- a/app/models/spree_cm_commissioner/homepage_section_relatable.rb
+++ b/app/models/spree_cm_commissioner/homepage_section_relatable.rb
@@ -6,7 +6,17 @@ module SpreeCmCommissioner
     belongs_to :homepage_section, counter_cache: true, optional: false, inverse_of: :homepage_section_relatables
     belongs_to :relatable, polymorphic: true, optional: false, inverse_of: :homepage_section_relatables
 
-    scope :active, -> { where(active: true).order(:position) }
+    scope :active, lambda {
+      where('available_on IS NULL OR available_on <= ?', Time.zone.now)
+        .where('discontinue_on IS NULL OR discontinue_on >= ?', Time.zone.now)
+        .order(:position)
+    }
+
+    def active?
+      current_time = Time.zone.now
+      (available_on.nil? || available_on <= current_time) &&
+        (discontinue_on.nil? || discontinue_on >= current_time)
+    end
 
     private
 

--- a/app/views/spree/admin/homepage_section_relatable/_form.html.erb
+++ b/app/views/spree/admin/homepage_section_relatable/_form.html.erb
@@ -8,7 +8,6 @@
           <%= f.label :relatable_type %>
           <%= f.select :relatable_type, [['Vendor', 'Spree::Vendor'], ['Taxon', 'Spree::Taxon'], ['Product', 'Spree::Product']], {}, :class => "fullwidth select2" %>
         <% end %>
-
         <%= f.field_container :relatable_id do %>
           <%= f.label :relatable_id %>
           <%= f.select :relatable_id,
@@ -20,16 +19,40 @@
                       autocomplete_min_input_value: 1,
                       autocomplete_additional_url_params_value: "model_class=#{f.object.relatable_type}" } %>
         <% end %>
-
-        <%= f.field_container :active do %>
-          <%= f.label :active %>
-          <%= f.check_box :active %>
-        <% end %>
+        <div class="date-range-filter row">
+          <div class="col-12 col-md-6 mb-3 mb-md-0">
+            <%= label_tag nil, Spree.t(:available_on) %>
+            <div class="input-group datePickerFrom"
+                    data-wrap="true"
+                    data-alt-input="true"
+                     data-max-date="<%= @object.discontinue_on %>"
+                    data-enable-time="true">
+              <%= f.text_field :available_on,
+                                  placeholder: Spree.t(:select_a_date),
+                                  class: 'form-control shadow-none',
+                                  'data-input':'' %>
+              <%= render partial: 'spree/admin/shared/cal_close' %>
+            </div>
+          </div>
+          <div class="col-12 col-md-6 mt-3 mt-md-0">
+            <%= label_tag nil, Spree.t(:discontinue_on) %>
+            <div class="input-group datePickerTo"
+                    data-wrap="true"
+                    data-alt-input="true"
+                    data-min-date="<%= @object.available_on %>"
+                    data-enable-time="true">
+              <%= f.text_field :discontinue_on,
+                                  placeholder: Spree.t(:select_a_date),
+                                  class: 'form-control shadow-none',
+                                  'data-input':'' %>
+              <%= render partial: 'spree/admin/shared/cal_close' %>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
 </div>
-
 <script>
   $(document).ready(function () {
     const relatableTypeSelector = "#spree_cm_commissioner_homepage_section_relatable_relatable_type"

--- a/db/migrate/20250116081414_remove_active_from_homepage_sections_relatables.rb
+++ b/db/migrate/20250116081414_remove_active_from_homepage_sections_relatables.rb
@@ -1,0 +1,5 @@
+class RemoveActiveFromHomepageSectionsRelatables < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :cm_homepage_section_relatables, :active, :boolean, if_exists: true
+  end
+end

--- a/db/migrate/20250117092553_add_available_on_and_discontinue_on_to_homepage_section_relatables.rb
+++ b/db/migrate/20250117092553_add_available_on_and_discontinue_on_to_homepage_section_relatables.rb
@@ -1,0 +1,6 @@
+class AddAvailableOnAndDiscontinueOnToHomepageSectionRelatables < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cm_homepage_section_relatables, :available_on, :datetime, if_not_exists: true
+    add_column :cm_homepage_section_relatables, :discontinue_on, :datetime, if_not_exists: true
+  end
+end

--- a/lib/spree_cm_commissioner/test_helper/factories/homepage_section_relatable_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/homepage_section_relatable_factory.rb
@@ -2,9 +2,10 @@ FactoryBot.define do
   factory :cm_homepage_section_relatable, class: SpreeCmCommissioner::HomepageSectionRelatable do
     homepage_section { create(:cm_homepage_section) }
     relatable { create(:taxon) }
-    active { true }
+    available_on { nil }
+    discontinue_on { nil }
 
-    # position is defaultly set by act_as_list
+   # position is defaultly set by act_as_list
     transient do
       position { nil }
     end

--- a/spec/models/spree_cm_commissioner/homepage_section_relatable_spec.rb
+++ b/spec/models/spree_cm_commissioner/homepage_section_relatable_spec.rb
@@ -1,27 +1,24 @@
 require 'spec_helper'
 
 RSpec.describe SpreeCmCommissioner::HomepageSectionRelatable, type: :model do
-  describe '#active' do
+  describe '.active' do
     let(:section) { create(:cm_homepage_section) }
 
-    it 'should return active sections order by position' do
-      position_1 = create(:cm_homepage_section_relatable, homepage_section: section, position: 1, active: false)
-      position_3 = create(:cm_homepage_section_relatable, homepage_section: section, position: 3, active: true)
-      position_2 = create(:cm_homepage_section_relatable, homepage_section: section, position: 2, active: true)
-      position_4 = create(:cm_homepage_section_relatable, homepage_section: section, position: 4, active: true)
-
-      expect(described_class.active.to_a).to eq [position_2, position_3, position_4]
+    it 'should return active relatables ordered by position' do
+      position_1 = create(:cm_homepage_section_relatable, homepage_section: section, position: 1, available_on: nil, discontinue_on: nil)
+      position_3 = create(:cm_homepage_section_relatable, homepage_section: section, position: 3, available_on: 1.day.ago, discontinue_on: 1.day.from_now)
+      position_2 = create(:cm_homepage_section_relatable, homepage_section: section, position: 2, available_on: 1.day.ago, discontinue_on: nil)
+      position_4 = create(:cm_homepage_section_relatable, homepage_section: section, position: 4, available_on: 2.days.ago, discontinue_on: 1.day.ago)
+      expect(described_class.active.to_a).to eq [position_1, position_2, position_3]
     end
   end
 
   describe '#update_homepage_section' do
     it 'should update the homepage_section updated_at when relatable is updated' do
       homepage_section = create(:cm_homepage_section)
-      relatable = create(:cm_homepage_section_relatable, homepage_section: homepage_section, active: true)
-
-      relatable.update(active: false)
-
-      expect(homepage_section.updated_at.to_i).to eq relatable.updated_at.to_i
+      relatable = create(:cm_homepage_section_relatable, homepage_section: homepage_section, available_on: nil, discontinue_on: nil)
+      relatable.update(available_on: 1.day.from_now)
+      expect(homepage_section.reload.updated_at.to_i).to eq relatable.updated_at.to_i
     end
   end
 end


### PR DESCRIPTION
| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/a38c156d-896d-4ccd-a588-05b2ed21f683) | ![image](https://github.com/user-attachments/assets/23637954-c598-4e3a-b4e7-7237ce904bac)|


[Screencast from 2025-01-21 10-02-00.webm](https://github.com/user-attachments/assets/e65fc817-cd5e-4fec-a760-14a37405c1b2)




Description :
- In this PR , we create an automatic event  available_on  and discontinue_on base on the date that the user input 
- The event will automatic show and hide on the homepage section base on the date that have been set,
- if the user that does not set available_on and discontinue_on dates ,  the event will always active on the homepage section