### PR TITLE
Close #2247: stop retry fcm queue when missing notification record

### DIFF
--- a/app/jobs/spree_cm_commissioner/application_job_decorator.rb
+++ b/app/jobs/spree_cm_commissioner/application_job_decorator.rb
@@ -1,0 +1,18 @@
+module SpreeCmCommissioner
+  module ApplicationJobDecorator
+    def self.prepended(base)
+      base.discard_on ActiveJob::DeserializationError do |job, error|
+        handle_deserialization_error(job, error)
+      end
+
+      def self.handle_deserialization_error(job, error)
+        label = "#{job.class}: #{error.message}"
+        data = job.as_json
+
+        CmAppLogger.log(label:, data:)
+      end
+    end
+  end
+end
+
+ApplicationJob.prepend(SpreeCmCommissioner::ApplicationJobDecorator)

--- a/lib/cm_app_logger.rb
+++ b/lib/cm_app_logger.rb
@@ -1,0 +1,11 @@
+# lib/cm_app_logger.rb
+module CmAppLogger
+  def self.log(label:, data: nil)
+    message = {
+      label: label,
+      data: data
+    }
+
+    Rails.logger.info(message.to_json)
+  end
+end

--- a/lib/spree_cm_commissioner.rb
+++ b/lib/spree_cm_commissioner.rb
@@ -35,5 +35,6 @@ require 'dry-validation'
 require 'font-awesome-sass'
 require 'rqrcode'
 require 'premailer/rails'
+require 'cm_app_logger'
 
 require 'byebug' if Rails.env.development? || Rails.env.test?

--- a/spec/jobs/spree_cm_commissioner/application_job_decorator_spec.rb
+++ b/spec/jobs/spree_cm_commissioner/application_job_decorator_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::ApplicationJobDecorator do
+  class TestJob < ::ApplicationJob
+    def perform
+    end
+  end
+
+  describe 'discard_on ActiveJob::DeserializationError' do
+    let(:order) { create(:completed_order_with_pending_payment) }
+
+    before do
+      ActiveJob::Base.queue_adapter = :test
+      ActiveJob::Base.queue_adapter.performed_jobs.clear
+      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
+      ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = true
+      order.destroy
+    end
+
+    it 'verifies that the exception does not propagate' do
+      expect {
+        Noticed::DeliveryMethods::Fcm.perform_later(order)
+      }.not_to raise_error
+    end
+
+    it 'calls handle_deserialization_error' do
+      allow(SpreeCmCommissioner::ApplicationJobDecorator).to receive(:handle_deserialization_error)
+      job = Noticed::DeliveryMethods::Fcm.perform_later(order)
+
+      expect(SpreeCmCommissioner::ApplicationJobDecorator).to have_received(:handle_deserialization_error).with(an_instance_of(Noticed::DeliveryMethods::Fcm), an_instance_of(ActiveJob::DeserializationError))
+    end
+  end
+
+  describe '.handle_deserialization_error' do
+    let(:job) { instance_double('TestJob', class: 'TestJob', as_json: { 'id' => 123, 'arguments' => [] }) }
+    let(:error) { StandardError.new(message: 'Error while trying to deserialize arguments', backtrace: []) }
+
+    before do
+      allow(CmAppLogger).to receive(:log)
+      described_class.handle_deserialization_error(job, error)
+    end
+
+    it 'logs the error with the job details' do
+      expect(CmAppLogger).to have_received(:log).with(
+        label: "TestJob: {:message=>\"Error while trying to deserialize arguments\", :backtrace=>[]}",
+        data: {'id'=>123, 'arguments'=>[]}
+      )
+    end
+  end
+end

--- a/spec/lib/cm_app_logger_spec.rb
+++ b/spec/lib/cm_app_logger_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe CmAppLogger do
+  describe '.log' do
+    let(:label) { 'Log Label' }
+    let(:data) { { key: 'value' } }
+    let(:expected_message) { { label: label, data: data }.to_json }
+
+    it 'logs the message with the correct format' do
+      expect(Rails.logger).to receive(:info).with(expected_message)
+      CmAppLogger.log(label: label, data: data)
+    end
+
+    it 'logs the message without data' do
+      expected_message_without_data = { label: label, data: nil }.to_json
+      expect(Rails.logger).to receive(:info).with(expected_message_without_data)
+      CmAppLogger.log(label: label)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ RSpec.configure do |config|
   config.include DoorkeeperAuthHelper
   config.include ActiveSupport::Testing::TimeHelpers
   config.extend Spree::TestingSupport::AuthorizationHelpers::Request, type: :request
-
+  config.include ActiveJob::TestHelper
   # https://github.com/channainfo/commissioner/pull/316
   config.order = :random
   Kernel.srand config.seed


### PR DESCRIPTION
- Added `DeliveryMethods::FcmDecorator` to enhance the functionality of FCM delivery.
- Implemented a discard job mechanism to handle scenarios where a notification record is missing, ensuring that unnecessary processing is avoided.