### PR TITLE
close #2271 pre create bib prefix on create guest (no need to wait order complete)

### DIFF
--- a/app/models/concerns/spree_cm_commissioner/option_type_attr_type.rb
+++ b/app/models/concerns/spree_cm_commissioner/option_type_attr_type.rb
@@ -39,6 +39,7 @@ module SpreeCmCommissioner
       'bib-prefix' => 'string',
       'bib-zerofill' => 'integer',
       'bib-display-prefix' => 'boolean',
+      'bib-pre-generation-on-create' => 'boolean',
       'seat-number-positions' => 'array'
     }.freeze
 

--- a/app/models/concerns/spree_cm_commissioner/variant_options_concern.rb
+++ b/app/models/concerns/spree_cm_commissioner/variant_options_concern.rb
@@ -24,6 +24,7 @@ module SpreeCmCommissioner
                :bib_prefix,
                :bib_zerofill,
                :bib_display_prefix?,
+               :bib_pre_generation_on_create?,
                :seat_number_positions,
                :seat_number_layouts,
                to: :options

--- a/app/models/spree_cm_commissioner/guest.rb
+++ b/app/models/spree_cm_commissioner/guest.rb
@@ -40,6 +40,8 @@ module SpreeCmCommissioner
     before_validation :set_event_id
     before_validation :assign_seat_number, if: -> { bib_number.present? }
 
+    before_create :generate_bib, if: -> { variant.bib_pre_generation_on_create? }
+
     validates :seat_number, uniqueness: { scope: :event_id }, allow_nil: true, if: -> { event_id.present? }
     validates :bib_index, uniqueness: true, allow_nil: true
 

--- a/app/models/spree_cm_commissioner/variant_options.rb
+++ b/app/models/spree_cm_commissioner/variant_options.rb
@@ -126,6 +126,11 @@ module SpreeCmCommissioner
       @bib_display_prefix == 1
     end
 
+    def bib_pre_generation_on_create?
+      @bib_pre_generation_on_create ||= option_value_name_for(option_type_name: 'bib-pre-generation-on-create')&.to_i || 0
+      @bib_pre_generation_on_create == 1
+    end
+
     def seat_number_positions
       @seat_number_positions ||= option_value_name_for(option_type_name: 'seat-number-positions')&.split(',')
     end

--- a/lib/spree_cm_commissioner/test_helper/factories/option_type_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/option_type_factory.rb
@@ -135,6 +135,12 @@ FactoryBot.define do
       presentation { 'Should display bib prefix?' }
     end
 
+    trait :bib_pre_generation_on_create do
+      attr_type { :boolean }
+      name { 'bib-pre-generation-on-create' }
+      presentation { 'Should pre generate bib on create' }
+    end
+
     trait :seat_number_positions do
       attr_type { :array }
       name { 'seat-number-positions' }

--- a/lib/spree_cm_commissioner/test_helper/factories/product_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/product_factory.rb
@@ -90,18 +90,31 @@ FactoryBot.define do
       transient do
         variant1_bib_prefix { '3KM' }
         variant2_bib_prefix { '5KM' }
+        bib_pre_generation_on_create { false }
+      end
+
+      before(:create) do |product, evaluator|
+        if evaluator.bib_pre_generation_on_create
+          product.option_types << create(:cm_option_type, :bib_pre_generation_on_create)
+        end
       end
 
       after(:create) do |product, evaluator|
         option_value1 = create(:cm_option_value, presentation: evaluator.variant1_bib_prefix, name: evaluator.variant1_bib_prefix, option_type: product.option_types[0])
         option_value2 = create(:cm_option_value, presentation: evaluator.variant2_bib_prefix, name: evaluator.variant2_bib_prefix, option_type: product.option_types[0])
 
+        bib_pre_generation_option_value = if evaluator.bib_pre_generation_on_create
+          create(:cm_option_value, presentation: 'Yes', name: '1', option_type: product.option_types.find_by(name: 'bib-pre-generation-on-create'))
+        end
+
         variant1 = create(:variant, price: product.price, product: product)
         variant1.option_values = [option_value1]
+        variant1.option_values << bib_pre_generation_option_value if evaluator.bib_pre_generation_on_create
         variant1.save!
 
         variant2 = create(:variant, price: product.price, product: product)
         variant2.option_values = [option_value2]
+        variant2.option_values << bib_pre_generation_option_value if evaluator.bib_pre_generation_on_create
         variant2.save!
       end
     end


### PR DESCRIPTION
Generate bib when create guest instead of when order is completing. This will prevent bib to be duplicate.

> This feature is disabled by default, for event that has many users ordering at the same time, we can enable by set `bib-pre-generation-on-create` option to variant to 'Yes' (true)