### PR TITLE
close #2289 implement muilti_tenantcy ERD and migration

### DIFF
--- a/app/models/spree_cm_commissioner/tenant.rb
+++ b/app/models/spree_cm_commissioner/tenant.rb
@@ -1,0 +1,5 @@
+module SpreeCmCommissioner
+  class Tenant < SpreeCmCommissioner::Base
+    has_many :vendors, class_name: 'Spree::Vendor'
+  end
+end

--- a/db/migrate/20250122083010_create_cm_tenants.rb
+++ b/db/migrate/20250122083010_create_cm_tenants.rb
@@ -1,0 +1,8 @@
+class CreateCmTenants < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cm_tenants, if_not_exists: true do |t|
+      t.string :name
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250122084511_add_tenant_id_to_spree_vendors.rb
+++ b/db/migrate/20250122084511_add_tenant_id_to_spree_vendors.rb
@@ -1,0 +1,6 @@
+class AddTenantIdToSpreeVendors < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_vendors, :tenant_id, :integer, if_not_exists: true
+    add_index :spree_vendors, :tenant_id, if_not_exists: true
+  end
+end

--- a/db/migrate/20250124033405_add_tenant_id_to_spree_users.rb
+++ b/db/migrate/20250124033405_add_tenant_id_to_spree_users.rb
@@ -1,0 +1,6 @@
+class AddTenantIdToSpreeUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_users, :tenant_id, :integer, if_not_exists: true
+    add_index :spree_users, :tenant_id, if_not_exists: true
+  end
+end

--- a/db/migrate/20250124034040_add_tenant_id_to_cm_notifications.rb
+++ b/db/migrate/20250124034040_add_tenant_id_to_cm_notifications.rb
@@ -1,0 +1,6 @@
+class AddTenantIdToCmNotifications < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cm_notifications, :tenant_id, :integer, if_not_exists: true
+    add_index :cm_notifications, :tenant_id, if_not_exists: true
+  end
+end

--- a/db/migrate/20250124034128_add_tenant_id_to_spree_orders.rb
+++ b/db/migrate/20250124034128_add_tenant_id_to_spree_orders.rb
@@ -1,0 +1,6 @@
+class AddTenantIdToSpreeOrders < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_orders, :tenant_id, :integer, if_not_exists: true
+    add_index :spree_orders, :tenant_id, if_not_exists: true
+  end
+end

--- a/db/migrate/20250124034153_add_tenant_id_to_spree_products.rb
+++ b/db/migrate/20250124034153_add_tenant_id_to_spree_products.rb
@@ -1,0 +1,6 @@
+class AddTenantIdToSpreeProducts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_products, :tenant_id, :integer, if_not_exists: true
+    add_index :spree_products, :tenant_id, if_not_exists: true
+  end
+end

--- a/spree_cm_commissioner.gemspec
+++ b/spree_cm_commissioner.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_multi_vendor', '>= 2.4.1'
   s.add_dependency 'spree_extension'
 
+  s.add_dependency 'activerecord-multi-tenant'
   s.add_dependency 'phonelib'
   s.add_dependency 'aws-sdk-ecs'
   s.add_dependency 'google-cloud-firestore'


### PR DESCRIPTION
# Note:
### Ensure that [PR #2294](https://github.com/channainfo/commissioner/pull/2294) is merged into this PR before merging this PR into the develop branch.

## ERD

<img width="1070" alt="Image" src="https://github.com/user-attachments/assets/06edd846-e5f4-4151-aadb-c85e23d7c80f" />

# How the ERD Affects Multitenancy

## 1. Tenancy Segregation (`cm_tenants`)
- `cm_tenants` defines each tenant with a unique `id`.
- Other tables reference `tenant_id` to enforce data isolation.

---

## 2. Vendor Isolation (`spree_vendors`)
- Vendors are linked to tenants using `tenant_id`.
- Ensures vendors and their data are isolated by tenant.

---

## 3. User Isolation (`spree_users`)
- Users are scoped to a single tenant via `tenant_id`.
- Users can only access data within their tenant's context.

---

## 4. Order Isolation (`spree_orders`)
- Orders reference both `user_id` and `tenant_id`.
- Each order is tied exclusively to a tenant and its users.

---

## 5. Product Isolation (`spree_products`)
- Products link to both `vendor_id` and `tenant_id`.
- Products are managed and displayed within the tenant ecosystem.

---

## 6. Notification Isolation (`cm_notifications`)
- Notifications are scoped to `tenant_id`, `recipient_id`, and `notificable_id`.
- Ensures notifications are specific to users and events in the tenant.

---

## Key Impacts of the ERD
- **Data Isolation**: Each table includes `tenant_id`, ensuring strict separation.
- **Scalability**: Supports multiple tenants and vendors without interference.
- **Security**: Prevents cross-tenant data access with tenant-based queries.
- **Flexibility**: Handles multi-vendor and multi-user systems within tenants.
