### PR TITLE
close #2291 Remove homepage section when events are inactive

### DIFF
--- a/app/models/spree_cm_commissioner/homepage_section.rb
+++ b/app/models/spree_cm_commissioner/homepage_section.rb
@@ -8,7 +8,13 @@ module SpreeCmCommissioner
 
     has_many :homepage_section_relatables, -> { active }, inverse_of: :homepage_section, dependent: :destroy
 
-    scope :active, -> { where(active: true).order(:position) }
+    scope :active, lambda {
+      joins(:homepage_section_relatables)
+        .where(active: true)
+        .group('cm_homepage_sections.id')
+        .having('COUNT(cm_homepage_section_relatables.id) > 0')
+        .order(:position)
+    }
 
     scope :filter_by_segment, -> (segment) { where('segment & ? > 0', BIT_SEGMENT[segment.to_sym]) }
   end

--- a/spec/models/spree_cm_commissioner/homepage_section_spec.rb
+++ b/spec/models/spree_cm_commissioner/homepage_section_spec.rb
@@ -6,13 +6,16 @@ RSpec.describe SpreeCmCommissioner::HomepageSection, type: :model do
   end
 
   describe '#active' do
-    it 'should return active sections order by position' do
-      position_1 = create(:cm_homepage_section, position: 1, active: false)
-      position_3 = create(:cm_homepage_section, position: 3, active: true)
-      position_2 = create(:cm_homepage_section, position: 2, active: true)
-      position_4 = create(:cm_homepage_section, position: 4, active: true)
+    it 'should return active sections ordered by position if they have active relatables' do
 
-      expect(described_class.active.to_a).to eq [position_2, position_3, position_4]
+      position_1 = create(:cm_homepage_section, position: 1, active: true)
+      position_2 = create(:cm_homepage_section, position: 2, active: true)
+      position_3 = create(:cm_homepage_section, position: 3, active: true)
+
+      create(:cm_homepage_section_relatable, homepage_section: position_2, available_on: 1.day.ago, discontinue_on: 1.day.from_now)
+      create(:cm_homepage_section_relatable, homepage_section: position_3, available_on: nil, discontinue_on: nil)
+
+      expect(described_class.active.to_a).to eq [position_2, position_3]
     end
   end
 


### PR DESCRIPTION

# Demo :

[Screencast from 2025-01-30 15-44-18.webm](https://github.com/user-attachments/assets/dfed2656-640c-4e99-8b7e-1b87037d5449)

In this PR :
- Return only homepage sections that are active and have at least one homepage section  relatable is active .