### PR TITLE
close #2311 fix homepage section scope

### DIFF
--- a/app/models/spree_cm_commissioner/homepage_section.rb
+++ b/app/models/spree_cm_commissioner/homepage_section.rb
@@ -9,10 +9,9 @@ module SpreeCmCommissioner
     has_many :homepage_section_relatables, -> { active }, inverse_of: :homepage_section, dependent: :destroy
 
     scope :active, lambda {
-      joins(:homepage_section_relatables)
-        .where(active: true)
-        .group('cm_homepage_sections.id')
-        .having('COUNT(cm_homepage_section_relatables.id) > 0')
+      where(active: true)
+        .joins(:homepage_section_relatables)
+        .distinct
         .order(:position)
     }
 


### PR DESCRIPTION
In this previous PR : https://github.com/channainfo/commissioner/pull/2292  ,  the scope return hash which lead the error in the app that expected integer 

```
  (byebug) described_class.active.count
  {4=>1, 5=>1}
  (byebug) described_class.active.size
  {4=>1, 5=>1}
```

After changed , we return integer as expected :

```
  (byebug) described_class.active.count
  2
  (byebug) described_class.active.size
  2
```

Before change :

[Screencast from 2025-01-31 10-28-45.webm](https://github.com/user-attachments/assets/ef8fc8b3-e67b-42c8-b202-974efd583f9e)

After Change : 

  
[Screencast from 2025-01-31 10-31-38.webm](https://github.com/user-attachments/assets/8a44d01e-5455-4732-82c5-5993262d89b5)


 