### PR TITLE
close #2330 self check in without location

### DIFF
--- a/app/controllers/spree/api/v2/storefront/self_check_in_controller.rb
+++ b/app/controllers/spree/api/v2/storefront/self_check_in_controller.rb
@@ -86,8 +86,10 @@ module Spree
           def within_allowed_distance(lat, lon, line_item_id)
             line_item = Spree::LineItem.find(line_item_id)
             place = line_item.product.venue.place
-            allowed_distance = line_item.product.venue.checkinable_distance
 
+            return true unless line_item.product.required_self_check_in_location
+
+            allowed_distance = line_item.product.venue.checkinable_distance
             user_location_km = Geocoder::Calculations.distance_between([lat, lon], [place.lat, place.lon], units: :km)
             user_location_meters = user_location_km * 1000
 

--- a/app/models/concerns/spree_cm_commissioner/product_delegation.rb
+++ b/app/models/concerns/spree_cm_commissioner/product_delegation.rb
@@ -12,6 +12,8 @@ module SpreeCmCommissioner
                :associated_event,
                :allow_self_check_in,
                :allow_self_check_in?,
+               :required_self_check_in_location,
+               :required_self_check_in_location?,
                to: :product
     end
   end

--- a/app/models/spree_cm_commissioner/line_item_decorator.rb
+++ b/app/models/spree_cm_commissioner/line_item_decorator.rb
@@ -83,6 +83,10 @@ module SpreeCmCommissioner
       allow_self_check_in?
     end
 
+    def required_self_check_in_location?
+      required_self_check_in_location
+    end
+
     def amount_per_guest
       amount / quantity
     end

--- a/app/overrides/spree/admin/products/_form/required_self_check_in_location.html.erb.deface
+++ b/app/overrides/spree/admin/products/_form/required_self_check_in_location.html.erb.deface
@@ -1,0 +1,9 @@
+<!-- insert_after "[data-hook='admin_product_form_promotionable']" -->
+
+<div data-hook="admin_product_form_required_self_check_in_location">
+  <%= f.field_container :required_self_check_in_location do %>
+    <%= f.check_box :required_self_check_in_location %>
+    <%= f.label :required_self_check_in_location, Spree.t(:required_self_check_in_location) %>
+    <%= f.error_message_on :required_self_check_in_location %>
+  <% end %>
+</div>

--- a/app/serializers/spree/v2/storefront/line_item_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/line_item_serializer_decorator.rb
@@ -9,6 +9,7 @@ module Spree
                           :completion_steps, :available_social_contact_platforms, :allow_anonymous_booking, :discontinue_on,
                           :high_demand, :jwt_token
 
+          base.attribute :required_self_check_in_location, &:required_self_check_in_location?
           base.attribute :allowed_self_check_in, &:allowed_self_check_in?
           base.attribute :allowed_upload_later, &:allowed_upload_later?
           base.attribute :delivery_required, &:delivery_required?

--- a/db/migrate/20250214025007_add_required_self_check_in_location_to_spree_products.rb
+++ b/db/migrate/20250214025007_add_required_self_check_in_location_to_spree_products.rb
@@ -1,0 +1,5 @@
+class AddRequiredSelfCheckInLocationToSpreeProducts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_products , :required_self_check_in_location, :boolean, default: false, if_not_exists: true
+  end
+end

--- a/spec/serializers/spree/v2/storefront/line_item_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/line_item_serializer_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe Spree::V2::Storefront::LineItemSerializer, type: :serializer do
         :number_of_guests,
         :completion_steps,
         :delivery_required,
+        :required_self_check_in_location,
         :allowed_self_check_in,
         :available_social_contact_platforms,
         :allowed_upload_later,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/473d6243-4943-4639-b8c1-905b86da54a3)

Description : 
- In this PR , we add new column " required_self_check_in_location"
- So , if  we want the product to be self check in with location ,  we need to check this column
- Else , if we  want the product to be self check in but without location , we can check the "  allow self check in "columns