### PR TITLE
Close #2338 Enhancement image resolution

### DIFF
--- a/app/models/spree_cm_commissioner/image_decorator.rb
+++ b/app/models/spree_cm_commissioner/image_decorator.rb
@@ -1,0 +1,23 @@
+module SpreeCmCommissioner
+  module ImageDecorator
+    # override
+    def styles
+      size = '1200x1200'
+      width, height = size.split('x')
+
+      [
+        {
+          url: cdn_image_url(attachment.variant(resize_to_limit: [width.to_i, height.to_i])),
+          width: width,
+          height: height
+        }
+      ]
+    end
+
+    def asset_styles
+      self.class.styles.merge({ product_zoomed: '1200x1200>' })
+    end
+  end
+end
+
+Spree::Image.prepend(SpreeCmCommissioner::ImageDecorator) unless Spree::Image.included_modules.include?(SpreeCmCommissioner::ImageDecorator)

--- a/spec/models/spree/image_spec.rb
+++ b/spec/models/spree/image_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Image, type: :model do
+  let(:image) { create(:image) }
+
+  describe "#asset_styles" do
+    it "merges old styles with product_zoomed style" do
+      expected_styles = Spree::Image.styles.merge({ product_zoomed: "1200x1200>" })
+
+      expect(image.asset_styles).to eq(expected_styles)
+    end
+  end
+
+  describe "#styles" do
+    it "returns only the 1200x1200 variant" do
+      expected_url = image.cdn_image_url(image.attachment.variant(resize_to_limit: [1200, 1200]))
+      expect(image.styles).to eq([{ url: expected_url, width: '1200', height: '1200' }])
+    end
+  end
+end


### PR DESCRIPTION
- We're adding a new size called product_zoomed to enhance the resolution of event gallery images:
product_zoomed => "1200x1200>"

<img width="828" alt="Screenshot 2025-02-12 at 5 10 28 in the afternoon" src="https://github.com/user-attachments/assets/8b7a83f3-8031-4997-a59a-5f4ea21bebb5" />


``` json
{"host":"Deths-MacBook-Pro.local","application":"cm","environment":"development","timestamp":"2025-02-12T09:59:04.921207Z","level":"info","level_index":2,"pid":65758,"thread":"puma srv tp 003","file":"/Users/sreyleak/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/activesupport-7.0.8/lib/active_support/subscriber.rb","line":149,"duration_ms":8.030999999493361,"duration":"8.031ms","named_tags":{"request_id":"76695c9b-29d6-48b8-b173-5dd7981c6502","ip":"127.0.0.1"},"name":"ActionView","message":"Rendered","payload":{"partial":"/Users/sreyleak/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/spree_backend-4.5.1/app/views/spree/admin/shared/_sidebar.html.erb","allocations":6864}}
{"host":"Deths-MacBook-Pro.local","application":"cm","environment":"development","timestamp":"2025-02-12T09:59:04.921811Z","level":"info","level_index":2,"pid":65758,"thread":"puma srv tp 003","file":"/Users/sreyleak/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/activesupport-7.0.8/lib/active_support/subscriber.rb","line":149,"duration_ms":1587.434000000358,"duration":"1.587s","named_tags":{"request_id":"76695c9b-29d6-48b8-b173-5dd7981c6502","ip":"127.0.0.1"},"name":"Spree::Admin::ImagesController","message":"Completed #index","payload":{"controller":"Spree::Admin::ImagesController","action":"index","params":{"product_id":"psk-vip-pass"},"format":"TURBO_STREAM","method":"GET","path":"/admin/products/psk-vip-pass/images","status":200,"view_runtime":1546.19,"searchkick_runtime":0.0,"db_runtime":28.56,"allocations":1180453,"status_message":"OK"}}
{"host":"Deths-MacBook-Pro.local","application":"cm","environment":"development","timestamp":"2025-02-12T09:59:04.922630Z","level":"warn","level_index":3,"pid":65758,"thread":"puma srv tp 003","file":"/Users/sreyleak/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/uniform_notifier-1.16.0/lib/uniform_notifier/rails_logger.rb","line":15,"named_tags":{"request_id":"76695c9b-29d6-48b8-b173-5dd7981c6502","ip":"127.0.0.1"},"name":"Rails","message":"user: sreyleak\nGET /admin/products/psk-vip-pass/images\nUSE eager loading detected\n  Spree::Image =\u003e [:viewable]\n  Add to your query: .includes([:viewable])\nCall stack"}
{"host":"Deths-MacBook-Pro.local","application":"cm","environment":"development","timestamp":"2025-02-12T09:59:04.930200Z","level":"info","level_index":2,"pid":65758,"thread":"worker-1","file":"/Users/sreyleak/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/sentry-ruby-5.11.0/lib/sentry/utils/logging_helper.rb","line":15,"name":"Rails","message":"sentry -- [Transport] Sending envelope with items [transaction, profile] 551c7688169447018a9bc942a8f11541 to Sentry"}
[65758] 127.0.0.1 - - [12/Feb/2025:16:59:04 +0700] "GET /admin/products/psk-vip-pass/images HTTP/1.1" 200 115704 1.6905
[65757] 127.0.0.1 - - [12/Feb/2025:16:59:04 +0700] "POST /mini-profiler-resources/results HTTP/1.1" 200 - 0.0019
[65758] 127.0.0.1 - - [12/Feb/2025:16:59:04 +0700] "POST /mini-profiler-resources/results HTTP/1.1" 200 - 0.0029
[65758] 127.0.0.1 - - [12/Feb/2025:16:59:04 +0700] "GET /favicon.ico HTTP/1.1" 200 - 0.0017

```

