### PR TITLE
close #2347 create and delete tenant user device_token API

### DIFF
--- a/app/controllers/spree/api/v2/tenant/base_controller.rb
+++ b/app/controllers/spree/api/v2/tenant/base_controller.rb
@@ -2,7 +2,7 @@ module Spree
   module Api
     module V2
       module Tenant
-        class BaseController < ::Spree::Api::V2::BaseController
+        class BaseController < ::Spree::Api::V2::ResourceController
           include Spree::Api::V2::CollectionOptionsHelpers
 
           set_current_tenant_through_filter

--- a/app/controllers/spree/api/v2/tenant/user_device_tokens_controller.rb
+++ b/app/controllers/spree/api/v2/tenant/user_device_tokens_controller.rb
@@ -1,0 +1,50 @@
+module Spree
+  module Api
+    module V2
+      module Tenant
+        class UserDeviceTokensController < BaseController
+          before_action :require_spree_current_user
+
+          def create
+            options = filter_params.merge(user: spree_current_user)
+            context = SpreeCmCommissioner::UserDeviceTokenRegister.call(options)
+
+            if context.success?
+              render_serialized_payload { serialize_resource(context.device_token) }
+            else
+              render_error_payload(context.message)
+            end
+          end
+
+          def destroy
+            options = {
+              user: spree_current_user,
+              registration_token: params[:id]
+            }
+
+            context = SpreeCmCommissioner::UserDeviceTokenDeregister.call(options)
+
+            if context.success?
+              render json: { message: 'Device token deleted successfully' }, status: :ok
+            else
+              render_error_payload(context.error)
+            end
+          end
+
+          def resource_serializer
+            Spree::V2::Tenant::UserDeviceTokenSerializer
+          end
+
+          def filter_params
+            {
+              registration_token: params[:registration_token],
+              device_type: params[:device_type],
+              client_version: app_version,
+              client_name: app_name
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -403,6 +403,7 @@ Spree::Core::Engine.add_routes do
         resource :user_registration_with_pin_codes, only: [:create]
         resources :pin_code_generators, only: [:create]
         resource :account, controller: :account, only: %i[show update]
+        resources :user_device_tokens, only: %i[create destroy]
 
         resources :homepage, only: [] do
           resources :homepage_sections, only: [:index]


### PR DESCRIPTION
In this PR:
- We create new endpoint of tenant user device token registration and and deletion API
- Reuse Existing Interactor Logic

# DEMO 

https://github.com/user-attachments/assets/d4303edc-416e-4010-84e8-6d805eb87325


