### PR TITLE
close #2307 Tenant Account Delete and Recover API

### DIFF
--- a/app/controllers/spree/api/v2/tenant/account_deletions_controller.rb
+++ b/app/controllers/spree/api/v2/tenant/account_deletions_controller.rb
@@ -1,0 +1,40 @@
+module Spree
+  module Api
+    module V2
+      module Tenant
+        class AccountDeletionsController < BaseController
+          before_action :validate_params, only: [:destroy]
+          before_action :load_user, only: [:destroy]
+          before_action :validate_user, only: [:destroy]
+
+          def destroy
+            context = SpreeCmCommissioner::AccountDeletion.call(
+              user: @user,
+              is_from_backend: false,
+              user_deletion_reason_id: params[:user_deletion_reason_id],
+              optional_reason: params[:optional_reason]
+            )
+
+            return render_error_payload(context.message) unless context.success?
+
+            render json: { message: 'Account deleted successfully' }, status: :ok
+          end
+
+          private
+
+          def validate_params
+            params.require(:user_deletion_reason_id)
+          end
+
+          def load_user
+            @user = spree_current_user
+          end
+
+          def validate_user
+            raise CanCan::AccessDenied unless @user.normal_user?
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/spree/api/v2/tenant/account_recovers_controller.rb
+++ b/app/controllers/spree/api/v2/tenant/account_recovers_controller.rb
@@ -1,0 +1,24 @@
+module Spree
+  module Api
+    module V2
+      module Tenant
+        class AccountRecoversController < BaseController
+          def update
+            context = SpreeCmCommissioner::AccountRecover.call(**filter_params.slice(:id_token, :login, :password))
+            if context.success?
+              render json: { message: 'Account Recovered successfully' }, status: :ok
+            else
+              render_error_payload(context.message)
+            end
+          end
+
+          private
+
+          def filter_params
+            params.permit(:id_token, :login, :password)
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -402,12 +402,15 @@ Spree::Core::Engine.add_routes do
         resource :pin_code_checkers, only: [:update]
         resource :user_registration_with_pin_codes, only: [:create]
         resources :pin_code_generators, only: [:create]
-        resource :account, controller: :account, only: %i[show update]
         resources :user_device_tokens, only: %i[create destroy]
 
         resources :homepage, only: [] do
           resources :homepage_sections, only: [:index]
         end
+
+        resource :account, controller: :account, only: %i[show update]
+        resource :account_deletions, only: %i[destroy]
+        resource :account_recovers, only: [:update]
       end
 
       namespace :storefront do


### PR DESCRIPTION
- User Can Delete their Account with reason 
- User Can recover their Account Back
- Can only Delete Normal User that spree_roles.empty?

# DEMO

https://github.com/user-attachments/assets/2ec83db4-50b7-4abb-a105-dc8947400be3

