### PR TITLE
close #2353 Build API tenant Booking cart flow

### DIFF
--- a/app/controllers/spree/api/v2/tenant/base_controller.rb
+++ b/app/controllers/spree/api/v2/tenant/base_controller.rb
@@ -7,7 +7,6 @@ module Spree
 
           set_current_tenant_through_filter
           before_action :require_tenant
-          around_action :set_tenant_context
 
           def require_tenant
             raise Doorkeeper::Errors::DoorkeeperError if doorkeeper_token&.application.nil?
@@ -19,14 +18,6 @@ module Spree
 
           def render_serialized_payload(status = 200)
             render json: yield, status: status, content_type: content_type
-          end
-
-          private
-
-          def set_tenant_context
-            MultiTenant.with(@tenant) do # rubocop:disable Style/ExplicitBlockArgument
-              yield
-            end
           end
 
           # override

--- a/app/controllers/spree/api/v2/tenant/cart_controller.rb
+++ b/app/controllers/spree/api/v2/tenant/cart_controller.rb
@@ -1,0 +1,110 @@
+module Spree
+  module Api
+    module V2
+      module Tenant
+        class CartController < BaseController
+          include Spree::Api::V2::Storefront::OrderConcern
+          include Spree::Api::V2::CouponCodesHelper
+          include Spree::Api::V2::Storefront::MetadataControllerConcern
+
+          before_action :ensure_valid_metadata, only: %i[create]
+          before_action :ensure_order, except: %i[create]
+          around_action :wrap_with_multitenant_without, except: %i[create]
+
+          def show
+            spree_authorize! :show, spree_current_order, order_token
+
+            render_serialized_payload { serialized_current_order }
+          end
+
+          def create
+            spree_authorize! :create, Spree::Order
+
+            create_cart_params = {
+              user: spree_current_user,
+              store: current_store,
+              currency: current_currency,
+              public_metadata: add_item_params[:public_metadata],
+              private_metadata: add_item_params[:private_metadata]
+            }
+
+            order = spree_current_order if spree_current_order.present?
+            order ||= create_service.call(create_cart_params).value
+
+            render_serialized_payload(201) { serialize_resource(order) }
+          end
+
+          def destroy
+            spree_authorize! :update, spree_current_order, order_token
+
+            result = destroy_cart_service.call(order: spree_current_order)
+
+            if result.success?
+              head :no_content
+            else
+              render_error_payload(result.error)
+            end
+          end
+
+          def set_quantity
+            return render_error_item_quantity unless params[:quantity].to_i.positive?
+
+            spree_authorize! :update, spree_current_order, order_token
+
+            result = set_item_quantity_service.call(order: spree_current_order,
+                                                    line_item: line_item,
+                                                    quantity: params[:quantity]
+                                                   )
+
+            render_order(result)
+          end
+
+          private
+
+          def wrap_with_multitenant_without(&block)
+            MultiTenant.without(&block)
+          end
+
+          def resource_serializer
+            Spree::Api::Dependencies.storefront_cart_serializer.constantize
+          end
+
+          def create_service
+            Spree::Api::Dependencies.storefront_cart_create_service.constantize
+          end
+
+          def destroy_cart_service
+            Spree::Api::Dependencies.storefront_cart_destroy_service.constantize
+          end
+
+          def set_item_quantity_service
+            Spree::Api::Dependencies.storefront_cart_set_item_quantity_service.constantize
+          end
+
+          def line_item
+            @line_item ||= spree_current_order.line_items.find(params[:line_item_id])
+          end
+
+          def load_variant
+            @variant = current_store.variants.find(add_item_params[:variant_id])
+          end
+
+          def render_error_item_quantity
+            render json: { error: I18n.t(:wrong_quantity, scope: 'spree.api.v2.cart') }, status: :unprocessable_entity
+          end
+
+          def serialize_estimated_shipping_rates(shipping_rates)
+            estimate_shipping_rates_serializer.new(
+              shipping_rates,
+              params: serializer_params
+            ).serializable_hash
+          end
+
+          def add_item_params
+            params.permit(:quantity, :variant_id, public_metadata: {}, private_metadata: {}, options: {})
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/spree/api/v2/tenant/cart_guests_controller.rb
+++ b/app/controllers/spree/api/v2/tenant/cart_guests_controller.rb
@@ -1,0 +1,42 @@
+module Spree
+  module Api
+    module V2
+      module Tenant
+        class CartGuestsController < CartController
+          around_action :wrap_with_multitenant_without
+
+          # :line_item_id
+          def create
+            spree_authorize! :update, spree_current_order, order_token
+
+            result = SpreeCmCommissioner::Cart::AddGuest.call(
+              order: spree_current_order,
+              line_item: line_item
+            )
+
+            render_order(result)
+          end
+
+          # :line_item_id, :guest_id
+          def destroy
+            spree_authorize! :update, spree_current_order, order_token
+
+            result = SpreeCmCommissioner::Cart::RemoveGuest.call(
+              order: spree_current_order,
+              line_item: line_item,
+              guest_id: params[:guest_id]
+            )
+
+            render_order(result)
+          end
+
+          private
+
+          def wrap_with_multitenant_without(&block)
+            MultiTenant.without(&block)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/spree/api/v2/tenant/homepage_sections_controller.rb
+++ b/app/controllers/spree/api/v2/tenant/homepage_sections_controller.rb
@@ -10,7 +10,9 @@ module Spree
           end
 
           def scope
-            model_class.where(tenant_id: MultiTenant.current_tenant_id)
+            MultiTenant.with(@tenant) do
+              model_class
+            end
           end
 
           def model_class

--- a/app/controllers/spree/api/v2/tenant/products_controller.rb
+++ b/app/controllers/spree/api/v2/tenant/products_controller.rb
@@ -20,7 +20,9 @@ module Spree
           end
 
           def scope
-            model_class.where(tenant_id: MultiTenant.current_tenant_id)
+            MultiTenant.with(@tenant) do
+              model_class
+            end
           end
 
           def collection_sorter

--- a/app/controllers/spree/api/v2/tenant/vendors_controller.rb
+++ b/app/controllers/spree/api/v2/tenant/vendors_controller.rb
@@ -21,7 +21,9 @@ module Spree
           end
 
           def scope
-            ::Spree::Vendor.active
+            MultiTenant.with(@tenant) do
+              ::Spree::Vendor.active
+            end
           end
 
           def resource_serializer

--- a/app/models/spree_cm_commissioner/order_decorator.rb
+++ b/app/models/spree_cm_commissioner/order_decorator.rb
@@ -52,6 +52,9 @@ module SpreeCmCommissioner
 
         find_by!(token: token)
       end
+
+      base.belongs_to :tenant, class_name: 'SpreeCmCommissioner::Tenant'
+      base.before_create :set_tenant_id
     end
 
     def ticket_seller_user?
@@ -259,6 +262,10 @@ module SpreeCmCommissioner
       return if allowed_prefixes.any? { |prefix| channel&.start_with?(prefix) }
 
       errors.add(:channel, "must start with one of the following: #{allowed_prefixes.join(', ')}")
+    end
+
+    def set_tenant_id
+      self.tenant_id = MultiTenant.current_tenant_id
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -460,6 +460,11 @@ Spree::Core::Engine.add_routes do
         resource :account, controller: :account, only: %i[show update]
         resource :account_deletions, only: %i[destroy]
         resource :account_recovers, only: [:update]
+
+        resource :cart, controller: :cart, only: %i[show create destroy] do
+          patch  :set_quantity
+        end
+        resource :cart_guests, only: %i[create destroy]
       end
 
       namespace :storefront do


### PR DESCRIPTION
This PR Included:
- [x] Fetch Current OrderCart
- [x] CreateEmptyOrder
- [x] DeleteOrder
- [x] Set Quantity to Order LineItem
- [x] CreateEmptyGuest to Order LineItem
- [x] DestroyGuest from Order LineItem

## Why this Needed?
```
MultiTenant.without(&block)
```
Multitenancy Scoping Issue: In a multi-tenant setup, each query may be scoped to a specific tenant (e.g., based on current_tenant). If certain queries in this controller need to bypass that scope (e.g., retrieving order association like line_items, variant... that might not belong to the current tenant), this wrapper allows those queries to be executed without tenant restrictions.

## DEMO 1: Create, GET, Delete and Set Quantity To LineItem API
https://github.com/user-attachments/assets/4ae66fae-c37b-46f6-a273-ce8e01f7327b

## DEMO 2: Add EmptyGuest to LineItem API
https://github.com/user-attachments/assets/ac58b7ee-715a-4a59-8985-62e86445cab6


