### PR TITLE
Close #2369 reserved stock method

### DIFF
--- a/app/models/spree_cm_commissioner/product_decorator.rb
+++ b/app/models/spree_cm_commissioner/product_decorator.rb
@@ -75,6 +75,10 @@ module SpreeCmCommissioner
       taxons.event.first&.parent
     end
 
+    def total_reserved_stock
+      line_items.complete.where(variant_id: variants.pluck(:id)).sum(:quantity)
+    end
+
     private
 
     def set_tenant


### PR DESCRIPTION
In this PR, we create total_reserved_stock method to count total reserved stock of a product.