### PR TITLE
WIP #2373 Add slug to event controller

### DIFF
--- a/app/controllers/spree/api/v2/storefront/events_controller.rb
+++ b/app/controllers/spree/api/v2/storefront/events_controller.rb
@@ -18,7 +18,7 @@ module Spree
 
           def events_query
             SpreeCmCommissioner::OrganizerProfileEventQuery.new(
-              vendor_id: params[:vendor_id],
+              vendor_identifier: params[:vendor_id] || params[:slug],
               section: params.fetch(:section, 'upcoming'),
               start_from_date: params[:start_from_date] || nil
             )

--- a/app/serializers/spree/v2/storefront/taxon_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/taxon_serializer_decorator.rb
@@ -15,6 +15,10 @@ module Spree
                           :background_color, :foreground_color, :show_badge_status,
                           :purchasable_on, :vendor_id
 
+          base.attribute :slug do |taxon|
+            taxon.vendor.slug if taxon.vendor.present?
+          end
+
           base.attribute :purchasable_on_app do |taxon|
             taxon.purchasable_on == 'app' || taxon.purchasable_on == 'both'
           end

--- a/config/initializers/spree_permitted_attributes.rb
+++ b/config/initializers/spree_permitted_attributes.rb
@@ -34,6 +34,7 @@ module Spree
       show_badge_status
       purchasable_on
       vendor_id
+      slug
     ]
 
     @@store_attributes += [

--- a/spec/queries/spree_cm_commissioner/organizer_profile_event_query_spec.rb
+++ b/spec/queries/spree_cm_commissioner/organizer_profile_event_query_spec.rb
@@ -2,41 +2,51 @@ require 'spec_helper'
 
 RSpec.describe SpreeCmCommissioner::OrganizerProfileEventQuery do
   let(:vendor) { create(:vendor) }
+  let(:slug) { vendor.slug }
   let(:start_from_date) { Time.zone.now }
-  let!(:upcoming_taxon) { create(:taxon, vendor_id: vendor.id, from_date: 1.day.from_now, to_date: 5.days.from_now) }
-  let!(:previous_taxon) { create(:taxon, vendor_id: vendor.id, from_date: 10.days.ago, to_date: 1.day.ago) }
+  let!(:upcoming_taxon) { create(:taxon, vendor: vendor, from_date: 1.day.from_now, to_date: 5.days.from_now) }
+  let!(:previous_taxon) { create(:taxon, vendor: vendor, from_date: 10.days.ago, to_date: 1.day.ago) }
 
   describe '#events' do
     context 'when section is upcoming' do
-      it 'returns only upcoming events for the vendor' do
-        query = described_class.new(vendor_id: vendor.id, section: 'upcoming', start_from_date: start_from_date)
-        expect(query.events).to contain_exactly(upcoming_taxon)
+      it 'returns only upcoming events for the vendor by vendor_id' do
+        query = described_class.new(vendor_identifier: vendor.id, section: 'upcoming', start_from_date: start_from_date)
+        events = query.events
+        expect(events).to contain_exactly(upcoming_taxon)
+      end
+
+      it 'returns only upcoming events for the vendor by slug' do
+        query = described_class.new(vendor_identifier: slug, section: 'upcoming', start_from_date: start_from_date)
+        events = query.events
+        expect(events).to contain_exactly(upcoming_taxon)
       end
     end
 
     context 'when section is previous' do
-      it 'returns only previous events for the vendor' do
-        query = described_class.new(vendor_id: vendor.id, section: 'previous', start_from_date: start_from_date)
-
-        expect(query.events).to contain_exactly(previous_taxon)
+      it 'returns only previous events for the vendor by vendor_id' do
+        query = described_class.new(vendor_identifier: vendor.id, section: 'previous', start_from_date: start_from_date)
+        events = query.events
+        expect(events).to contain_exactly(previous_taxon)
       end
-    end
 
-    context 'when start_from_date is not provided' do
-      it 'defaults to the current time' do
-        travel_to(Time.zone.now) do
-          query = described_class.new(vendor_id: vendor.id, section: 'upcoming')
-
-          expect(query.start_from_date.to_i).to be_within(1).of(Time.zone.now.to_i)
-        end
+      it 'returns only previous events for the vendor by slug' do
+        query = described_class.new(vendor_identifier: slug, section: 'previous', start_from_date: start_from_date)
+        events = query.events
+        expect(events).to contain_exactly(previous_taxon)
       end
     end
 
     context 'when section is all' do
       it 'returns all events for the vendor, both upcoming and previous' do
-        query = described_class.new(vendor_id: vendor.id, section: 'all', start_from_date: start_from_date)
+        query = described_class.new(vendor_identifier: vendor.id, section: 'all', start_from_date: start_from_date)
+        events = query.events
+        expect(events).to match_array([upcoming_taxon, previous_taxon])
+      end
 
-        expect(query.events).to match_array([upcoming_taxon, previous_taxon])
+      it 'returns all events for the vendor by slug, both upcoming and previous' do
+        query = described_class.new(vendor_identifier: slug, section: 'all', start_from_date: start_from_date)
+        events = query.events
+        expect(events).to match_array([upcoming_taxon, previous_taxon])
       end
     end
   end

--- a/spec/serializers/spree/v2/storefront/taxon_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/taxon_serializer_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe Spree::V2::Storefront::TaxonSerializer, type: :serializer do
         :purchasable_on,
         :purchasable_on_app,
         :purchasable_on_web,
-        :vendor_id
+        :vendor_id,
+        :slug
       )
     end
 


### PR DESCRIPTION
- For the flow, I have set up two ways to fetch event data from the API:
  - Fetching by Vendor ID: can retrieve event data using the vendor's unique numerical ID.
  ```
  GET {{BASE_URL}}/api/v2/storefront/vendors/9/events?section=upcoming
  ```
  - Fetching by Vendor Slug: Instead of using an ID, you can fetch events using the vendor's slug (a human-readable identifier).
  ```
  GET {{BASE_URL}}/api/v2/storefront/vendors/run-with-sai/events?section=upcoming
  ```


``` json
{
    "data": [
        {
            "id": "454",
            "type": "taxon",
            "attributes": {
                "name": "PSK Solo Concert",
                "pretty_name": "Events -> PSK Solo Concert",
                "permalink": "events/psk-solo-concert",
                "seo_title": "PSK Solo Concert",
                "description": "<p>Immerse yourself in an exceptional musical experience at \"PSK Solo Concert\" featuring the acclaimed artist Pich Solika. This exclusive event promises an intimate and memorable performance in the heart of Phnom Penh.</p>\r\n<p><strong>Ticket Options:</strong></p>\r\n<ul>\r\n<li><strong>VIP:</strong> Enjoy unparalleled access with prime seating, entry to a dedicated VIP lounge, and a unique opportunity for a meet-and-greet with Pich Solika.</li>\r\n<li><strong>Premium:</strong> Opt for premium seating with superb views and access to exclusive event amenities.</li>\r\n<li><strong>Standard:</strong> Choose a standard ticket for excellent value and access to general seating.</li>\r\n</ul>\r\n<p>Explore the vibrant cultural scene in Cambodia and be part of this extraordinary evening of live music. Secure your tickets today and join us for a night of unforgettable entertainment.</p>",
                "meta_title": "",
                "meta_description": "Immerse yourself in an exceptional musical experience at \"PSK Solo Concert\" featuring the acclaimed artist Pich Solika. This exclusive event promises an intimate and memorable performance in the heart of Phnom Penh.",
                "meta_keywords": "",
                "left": 162,
                "right": 165,
                "position": 0,
                "depth": 1,
                "updated_at": "2025-02-19T17:51:09.387+07:00",
                "public_metadata": {},
                "is_root": false,
                "is_child": true,
                "is_leaf": false,
                "custom_redirect_url": "bookmeplus://staging-client.contigo.asia/t/events/psk-solo-concert",
                "kind": "event",
                "subtitle": "psk solo concert",
                "from_date": "2025-01-10T17:05:00.000+07:00",
                "to_date": "2025-01-31T12:00:00.000+07:00",
                "background_color": "#FFD1DC",
                "foreground_color": "",
                "show_badge_status": false,
                "purchasable_on": "both",
                "vendor_id": 152,
                "slug": "psk-concert",
                "purchasable_on_app": true,
                "purchasable_on_web": true
            },
            "relationships": {
                "parent": {
                    "data": {
                        "id": "17",
                        "type": "taxon"
                    }
                },
                "taxonomy": {
                    "data": {
                        "id": "5",
                        "type": "taxonomy"
                    }
                },
                "children": {
                    "data": [
                        {
                            "id": "455",
                            "type": "taxon"
                        }
                    ]
                },
                "image": {
                    "data": null
                },
                "vendors": {
                    "data": [
                        {
                            "id": "152",
                            "type": "vendor"
                        }
                    ]
                },
                "visible_products": {
                    "data": []
                },
                "category_icon": {
                    "data": {
                        "id": "1740",
                        "type": "asset"
                    }
                },
                "app_banner": {
                    "data": {
                        "id": "1784",
                        "type": "asset"
                    }
                },
                "web_banner": {
                    "data": {
                        "id": "1741",
                        "type": "asset"
                    }
                },
                "home_banner": {
                    "data": {
                        "id": "1753",
                        "type": "asset"
                    }
                }
            }
        }
    ],
    "meta": {
        "count": 1,
        "total_count": 1,
        "total_pages": 1
    },
    "links": {
        "self": "http://127.0.0.1:4000/api/v2/storefront/vendors/152/events?section=previous",
        "next": "http://127.0.0.1:4000/api/v2/storefront/vendors/152/events?page=1",
        "prev": "http://127.0.0.1:4000/api/v2/storefront/vendors/152/events?page=1",
        "last": "http://127.0.0.1:4000/api/v2/storefront/vendors/152/events?page=1",
        "first": "http://127.0.0.1:4000/api/v2/storefront/vendors/152/events?page=1"
    }
}

```