### PR TITLE
close #2379 fix guest card cannot set back to none

### DIFF
--- a/app/controllers/spree/admin/variant_guest_card_classes_controller.rb
+++ b/app/controllers/spree/admin/variant_guest_card_classes_controller.rb
@@ -11,7 +11,11 @@ module Spree
         @product.variants.each do |variant|
           guest_card_class_id = variant_params[variant.id.to_s]
 
-          next if guest_card_class_id.blank?
+          if guest_card_class_id.blank?
+            variant_guest_card_class = model_class.find_by(variant_id: variant.id)
+            variant_guest_card_class&.destroy
+            next
+          end
 
           variant_guest_card_class = model_class.find_or_initialize_by(variant_id: variant.id)
           variant_guest_card_class.guest_card_class_id = guest_card_class_id

--- a/app/views/spree/admin/variant_guest_card_classes/index.html.erb
+++ b/app/views/spree/admin/variant_guest_card_classes/index.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :page_actions do %>
   <%= yield :page_actions %>
-  <% if @taxonomy&.present? && @taxon&.present? %>
+  <% if @taxonomy&.present? && @taxon&.present? && @taxon&.parent.present? %>
     <%= button_link_to Spree.t('Edit Event'), spree.admin_taxonomy_taxon_guest_card_classes_url(@taxonomy.id, @taxon.id), icon: 'edit.svg', class: 'btn-light' %>
   <% end %>
   <%= external_page_preview_link(@product) %>


### PR DESCRIPTION
## Before :

[Screencast from 2025-02-21 17-12-34.webm](https://github.com/user-attachments/assets/970026f0-f41e-41ce-b830-1a27b69a0a63)

## After :

[Screencast from 2025-02-21 17-22-04.webm](https://github.com/user-attachments/assets/eedb710b-e94d-45a0-9a7d-9ae940ba9d19)

Descripition : 
. We make guest card to be able to set back to none.
. Also , we check the edit event button to only show if the taxons have parent

