### PR TITLE
close #2390 create event slug method

### DIFF
--- a/app/models/spree_cm_commissioner/taxon_decorator.rb
+++ b/app/models/spree_cm_commissioner/taxon_decorator.rb
@@ -67,6 +67,10 @@ module SpreeCmCommissioner
       self.slug = permalink&.parameterize
     end
 
+    def event_slug
+      slug.sub(/^events-/, '')
+    end
+
     def products_option_type_names
       Spree::OptionType.joins(products: :taxons)
                        .where(spree_taxons: { id: child_ids })


### PR DESCRIPTION
Since our event model is level 2 taxon so the slug will is in fomat 
```
http://127.0.0.1:4000/organizer/events/events-walk-with-phan
```
we create this method to remove "events-" from slug this is new format 

```
http://127.0.0.1:4000/organizer/events/walk-with-phan
```