### PR TITLE
close #2381 ReadMe active-record-multitenant and scope product and homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,3 +385,47 @@ final Map<String, String> cookies;
 ### Adaptive bitrate player
 
 - <https://livepush.io/hls-player/index.html>
+
+## ActiveRecord Multi-Tenant
+
+### Getting the Current Tenant ID
+
+To retrieve the current tenant_id, you can use `MultiTenant.current_tenant_id`.
+
+### Defining Scope with MultiTenant
+
+To ensure queries are scoped by the current tenant, use `MultiTenant.with(@tenant)`:
+
+```ruby
+def scope
+  MultiTenant.with(@tenant) do
+    model_class.where(tenant_id: MultiTenant.current_tenant_id)
+  end
+end
+```
+
+This ensures that queries are filtered based on the current tenant, maintaining proper isolation of data across tenants.
+
+### Example: Getting `@tenant` with `MultiTenant`
+
+```ruby
+@tenant = current_tenant
+MultiTenant.with(@tenant) do
+  # Your tenant-specific code here
+  # Should scope model_class.where(tenant_id: MultiTenant.current_tenant_id)
+  # to make sure our data filter it with current Tenant
+end
+```
+
+### Wrapping Actions Without MultiTenant
+
+Use `around_action` to temporarily disable MultiTenant for specific actions:
+
+```ruby
+around_action :wrap_with_multitenant_without, except: %i[create]
+
+def wrap_with_multitenant_without(&block)
+  MultiTenant.without(&block)
+end
+```
+

--- a/app/controllers/spree/api/v2/tenant/homepage_sections_controller.rb
+++ b/app/controllers/spree/api/v2/tenant/homepage_sections_controller.rb
@@ -11,7 +11,7 @@ module Spree
 
           def scope
             MultiTenant.with(@tenant) do
-              model_class
+              model_class.where(tenant_id: MultiTenant.current_tenant_id)
             end
           end
 

--- a/app/controllers/spree/api/v2/tenant/products_controller.rb
+++ b/app/controllers/spree/api/v2/tenant/products_controller.rb
@@ -21,7 +21,7 @@ module Spree
 
           def scope
             MultiTenant.with(@tenant) do
-              model_class
+              model_class.where(tenant_id: MultiTenant.current_tenant_id)
             end
           end
 


### PR DESCRIPTION
## Fix Product and Homepage Scope
Since we're still facing a scope issue, we can resolve it by wrapping the query with @tenant and adding where(tenant_id: MultiTenant.current_tenant_id).

## Update ReadMe activerecord-multi-tenant:
<img width="1512" alt="Screenshot 2025-02-27 at 10 33 11 in the morning" src="https://github.com/user-attachments/assets/0fa72c19-bbf0-415a-adab-2f86200e11af" />
