### PR TITLE
Close #2506 Order transition to complete, update stock in redis

### DIFF
--- a/app/interactors/spree_cm_commissioner/inventory_item_syncer.rb
+++ b/app/interactors/spree_cm_commissioner/inventory_item_syncer.rb
@@ -1,0 +1,25 @@
+module SpreeCmCommissioner
+  class InventoryItemSyncer < BaseInteractor
+    # inventory_id_and_quantities = [{ inventory_id: inventory_item1.id, quantity: 5 } ]
+    delegate :inventory_id_and_quantities, to: :context
+
+    def call
+      ActiveRecord::Base.transaction do
+        inventory_items.each do |inventory_item|
+          quantity = inventory_id_and_quantities.find { |item| item[:inventory_id] == inventory_item.id }&.dig(:quantity) || 0
+          adjust_quantity_available(inventory_item, quantity)
+        end
+      end
+    end
+
+    private
+
+    def adjust_quantity_available(inventory_item, quantity)
+      inventory_item.update!(quantity_available: inventory_item.quantity_available + quantity)
+    end
+
+    def inventory_items
+      @inventory_items ||= InventoryItem.where(id: inventory_id_and_quantities.pluck(:inventory_id))
+    end
+  end
+end

--- a/app/jobs/spree_cm_commissioner/inventory_item_syncer_job.rb
+++ b/app/jobs/spree_cm_commissioner/inventory_item_syncer_job.rb
@@ -1,0 +1,7 @@
+module SpreeCmCommissioner
+  class InventoryItemSyncerJob < ApplicationUniqueJob
+    def perform(inventory_id_and_quantities:)
+      InventoryItemSyncer.call(inventory_id_and_quantities:)
+    end
+  end
+end

--- a/app/models/concerns/spree_cm_commissioner/order_state_machine.rb
+++ b/app/models/concerns/spree_cm_commissioner/order_state_machine.rb
@@ -13,10 +13,13 @@ module SpreeCmCommissioner
       state_machine.after_transition to: :complete, do: :notify_order_complete_telegram_notification_to_user, unless: :subscription?
       state_machine.after_transition to: :complete, do: :send_order_complete_telegram_alert_to_vendors, unless: :need_confirmation?
       state_machine.after_transition to: :complete, do: :send_order_complete_telegram_alert_to_store, unless: :need_confirmation?
+      state_machine.around_transition to: :complete, do: :handle_unstock_in_redis
 
       state_machine.after_transition to: :resumed, do: :precalculate_conversion
+      state_machine.around_transition to: :resumed, do: :handle_unstock_in_redis
 
       state_machine.after_transition to: :canceled, do: :precalculate_conversion
+      state_machine.after_transition to: :canceled, do: :restock_inventory_in_redis!
 
       scope :accepted, -> { where(request_state: 'accepted') }
 
@@ -64,6 +67,27 @@ module SpreeCmCommissioner
       line_items.each do |item|
         SpreeCmCommissioner::ConversionPreCalculatorJob.perform_later(item.product_id)
       end
+    end
+
+    def handle_unstock_in_redis
+      ActiveRecord::Base.transaction do
+        yield # Equal to block.call
+
+        # After the transition is complete, the following code will execute first before proceeding to other `after_transition` callbacks.
+        # This ensures that if `unstock_inventory_in_redis!` fails, the state will be rolled back,
+        # and neither the `finalize!` method nor any notifications will be triggered.
+        # The payment will be reversed in vPago gem, and `Spree::Checkout::Complete` will be called, which checks `order.reload.complete?`.
+        # This is critical because if the order state is complete, the payment will be marked as paid.
+        CmAppLogger.log(label: 'order_state_machine_before_unstock', data: { order_id: id, state: state })
+        unstock_inventory_in_redis!
+        # We rollback only order state, and we keep payment state as it is.
+        # We implement payment in vPago gem, and it will be reversed in the gem.
+        # Some bank has api for refund, but some don't have the api to refund yet. So we keep the payment state as it is and refund manually.
+        CmAppLogger.log(label: 'order_state_machine_after_unstock', data: { order_id: id, state: state })
+      end
+    rescue StandardError => e
+      CmAppLogger.log(label: 'order_state_machine', data: { order_id: id, error: e.message, type: e.class.name, backtrace: e.backtrace.first(5).join("\n") })
+      raise e
     end
 
     def generate_bib_number

--- a/app/models/spree_cm_commissioner/order_decorator.rb
+++ b/app/models/spree_cm_commissioner/order_decorator.rb
@@ -201,6 +201,14 @@ module SpreeCmCommissioner
 
     private
 
+    def unstock_inventory_in_redis!
+      SpreeCmCommissioner::RedisStock::InventoryUpdater.new(line_item_ids).unstock!
+    end
+
+    def restock_inventory_in_redis!
+      SpreeCmCommissioner::RedisStock::InventoryUpdater.new(line_item_ids).restock!
+    end
+
     # override :spree_api
     def webhook_payload_body
       resource_serializer.new(

--- a/app/models/spree_cm_commissioner/redis_stock/inventory_updater.rb
+++ b/app/models/spree_cm_commissioner/redis_stock/inventory_updater.rb
@@ -1,0 +1,113 @@
+module SpreeCmCommissioner
+  module RedisStock
+    class InventoryUpdater
+      class UnableToRestock < StandardError; end
+      class UnableToUnstock < StandardError; end
+
+      def initialize(line_item_ids)
+        @line_item_ids = line_item_ids
+      end
+
+      def unstock!
+        keys, quantities, inventory_ids = extract_inventory_data
+
+        raise UnableToUnstock, Spree.t(:insufficient_stock_lines_present) unless unstock(keys, quantities)
+
+        inventory_id_and_quantities = inventory_ids.map.with_index do |inventory_id, i|
+          { inventory_id: inventory_id, quantity: -quantities[i] }
+        end
+
+        schedule_sync_inventory(inventory_id_and_quantities)
+      end
+
+      def restock!
+        keys, quantities, inventory_ids = extract_inventory_data
+
+        raise UnableToRestock unless restock(keys, quantities)
+
+        inventory_id_and_quantities = inventory_ids.map.with_index do |inventory_id, i|
+          { inventory_id: inventory_id, quantity: quantities[i] }
+        end
+
+        schedule_sync_inventory(inventory_id_and_quantities)
+      end
+
+      private
+
+      def line_items
+        @line_items ||= Spree::LineItem.where(id: @line_item_ids)
+      end
+
+      def unstock(keys, quantities)
+        SpreeCmCommissioner.redis_pool.with do |redis|
+          redis.eval(unstock_redis_script, keys: keys, argv: quantities)
+        end.positive?
+      end
+
+      def restock(keys, quantities)
+        SpreeCmCommissioner.redis_pool.with do |redis|
+          redis.eval(restock_redis_script, keys: keys, argv: quantities)
+        end.positive?
+      end
+
+      # Return: [CachedInventoryItem(...), CachedInventoryItem(...)]
+      def cached_inventory_items
+        @cached_inventory_items ||= SpreeCmCommissioner::RedisStock::LineItemsCachedInventoryItemsBuilder.new(line_item_ids: @line_item_ids).call.values.flatten
+      end
+
+      def extract_inventory_data
+        keys = []
+        quantities = []
+        inventory_ids = []
+
+        cached_inventory_items.each do |cached_inventory_item|
+          keys << cached_inventory_item.inventory_key
+          quantities << line_items.find { |item| item.variant_id == cached_inventory_item.variant_id }.quantity
+          inventory_ids << cached_inventory_item.inventory_item_id
+        end
+
+        [keys, quantities, inventory_ids]
+      end
+
+      def unstock_redis_script
+        <<~LUA
+          local keys = KEYS
+          local quantities = ARGV
+
+          -- Check availability first
+          for i, key in ipairs(keys) do
+            local current = tonumber(redis.call('GET', key) or 0)
+            if current - tonumber(quantities[i]) < 0 then
+              return 0
+            end
+          end
+
+          -- Apply updates
+          for i, key in ipairs(keys) do
+            redis.call('DECRBY', key, tonumber(quantities[i]))
+          end
+
+          return 1
+        LUA
+      end
+
+      def restock_redis_script
+        <<~LUA
+          local keys = KEYS
+          local quantities = ARGV
+
+          -- Apply restock updates
+          for i, key in ipairs(keys) do
+            redis.call('INCRBY', key, tonumber(quantities[i]))
+          end
+
+          return 1
+        LUA
+      end
+
+      def schedule_sync_inventory(inventory_id_and_quantities)
+        SpreeCmCommissioner::InventoryItemSyncerJob.perform_later(inventory_id_and_quantities:)
+      end
+    end
+  end
+end

--- a/db/migrate/20250429094228_add_lock_version_to_cm_inventory_items.rb
+++ b/db/migrate/20250429094228_add_lock_version_to_cm_inventory_items.rb
@@ -1,0 +1,5 @@
+class AddLockVersionToCmInventoryItems < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cm_inventory_items, :lock_version, :integer, default: 0, null: false
+  end
+end

--- a/spec/interactors/spree_cm_commissioner/inventory_item_syncer_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/inventory_item_syncer_spec.rb
@@ -1,0 +1,85 @@
+# spec/spree_cm_commissioner/inventory_item_syncer_spec.rb
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::InventoryItemSyncer, type: :interactor do
+  describe '.call' do
+    let(:inventory_item1) { create(:cm_inventory_item, quantity_available: 10) }
+    let(:inventory_item2) { create(:cm_inventory_item, quantity_available: 20) }
+    let(:inventory_id_and_quantities) do
+      [
+        { inventory_id: inventory_item1.id, quantity: 5 },
+        { inventory_id: inventory_item2.id, quantity: -3 }
+      ]
+    end
+    let(:context) { Interactor::Context.new(inventory_id_and_quantities: inventory_id_and_quantities) }
+
+    subject(:result) { described_class.call(context) }
+
+    it 'updates the quantity_available for each inventory item based on provided quantities' do
+      expect { result }.to change { inventory_item1.reload.quantity_available }.from(10).to(15)
+                        .and change { inventory_item2.reload.quantity_available }.from(20).to(17)
+    end
+
+    context 'when inventory_id_and_quantities contains fewer entries than inventory items' do
+      let(:inventory_id_and_quantities) do
+        [{ inventory_id: inventory_item1.id, quantity: 5 }]
+      end
+
+      it 'only processes inventory items with matching quantities' do
+        expect { result }.to change { inventory_item1.reload.quantity_available }.from(10).to(15)
+      end
+    end
+
+    context 'when an inventory_id is not found' do
+      let(:inventory_id_and_quantities) do
+        [
+          { inventory_id: inventory_item1.id, quantity: 5 },
+          { inventory_id: 999, quantity: 10 }
+        ]
+      end
+
+      it 'skips the missing inventory item and processes valid ones' do
+        expect { result }.to change { inventory_item1.reload.quantity_available }.from(10).to(15)
+      end
+    end
+  end
+
+  describe '#adjust_quantity_available' do
+    let(:inventory_item) { create(:cm_inventory_item, quantity_available: 10) }
+    let(:syncer) { described_class.new }
+
+    it 'increments quantity_available by the provided quantity' do
+      expect {
+        syncer.send(:adjust_quantity_available, inventory_item, 5)
+      }.to change { inventory_item.reload.quantity_available }.from(10).to(15)
+    end
+
+    it 'decrements quantity_available when a negative quantity is provided' do
+      expect {
+        syncer.send(:adjust_quantity_available, inventory_item, -3)
+      }.to change { inventory_item.reload.quantity_available }.from(10).to(7)
+    end
+  end
+
+  describe '#inventory_items' do
+    let(:inventory_item) { create(:cm_inventory_item) }
+    let(:syncer) { described_class.new }
+    let(:inventory_id_and_quantities) do
+      [{ inventory_id: inventory_item.id, quantity: 5 }]
+    end
+    let(:context) { Interactor::Context.new(inventory_id_and_quantities: inventory_id_and_quantities) }
+
+    before do
+      syncer.instance_variable_set(:@context, context)
+    end
+
+    it 'returns InventoryItem records matching the provided inventory_ids' do
+      expect(syncer.send(:inventory_items)).to eq([inventory_item])
+    end
+
+    it 'returns an empty relation when inventory_id_and_quantities is empty' do
+      allow(context).to receive(:inventory_id_and_quantities).and_return([])
+      expect(syncer.send(:inventory_items)).to be_empty
+    end
+  end
+end

--- a/spec/jobs/spree_cm_commissioner/inventory_item_syncer_job_spec.rb
+++ b/spec/jobs/spree_cm_commissioner/inventory_item_syncer_job_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::InventoryItemSyncerJob, type: :job do
+  let(:inventory_id_and_quantities) { [{inventory_id: 1, quantity: 2}, {inventory_id: 2, quantity: 1}] }
+
+  describe '#perform' do
+    let(:syncer_class) { SpreeCmCommissioner::InventoryItemSyncer }
+
+    subject { described_class.new.perform(inventory_id_and_quantities:) }
+
+    it 'calls InventoryItemSyncer with correct parameters' do
+      expect(syncer_class).to receive(:call).with(
+        inventory_id_and_quantities: inventory_id_and_quantities
+      )
+      subject
+    end
+  end
+
+  describe 'queue behavior' do
+    it 'enqueues the job' do
+      expect {
+        described_class.perform_later(inventory_id_and_quantities:)
+      }.to have_enqueued_job(described_class).with(inventory_id_and_quantities:)
+    end
+  end
+end

--- a/spec/models/spree_cm_commissioner/order_decorator_spec.rb
+++ b/spec/models/spree_cm_commissioner/order_decorator_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::OrderDecorator, type: :model do
+  let(:order) { create(:order_with_line_items, line_items_count: 2) }
+  let(:line_items) { order.line_items }
+  let(:line_item_ids) { line_items.map(&:id) }
+  let(:inventory_updater) { instance_double(SpreeCmCommissioner::RedisStock::InventoryUpdater) }
+
+  describe '#unstock_inventory_in_redis!' do
+    before do
+      allow(SpreeCmCommissioner::RedisStock::InventoryUpdater).to receive(:new).with(line_item_ids).and_return(inventory_updater)
+    end
+
+    it 'calls InventoryUpdater#unstock!' do
+      expect(inventory_updater).to receive(:unstock!)
+      order.send(:unstock_inventory_in_redis!)
+    end
+  end
+
+  describe '#restock_inventory_in_redis!' do
+    before do
+      allow(SpreeCmCommissioner::RedisStock::InventoryUpdater).to receive(:new).with(line_item_ids).and_return(inventory_updater)
+    end
+
+    it 'calls InventoryUpdater#restock!' do
+      expect(inventory_updater).to receive(:restock!)
+      order.send(:restock_inventory_in_redis!)
+    end
+  end
+end

--- a/spec/models/spree_cm_commissioner/redis_stock/inventory_updater_spec.rb
+++ b/spec/models/spree_cm_commissioner/redis_stock/inventory_updater_spec.rb
@@ -1,0 +1,200 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::RedisStock::InventoryUpdater do
+  let(:redis) { double('Redis') }
+  let(:redis_pool) { double('RedisPool') }
+  let(:real_redis) { Redis.new(url: ENV['REDIS_URL'] || 'redis://localhost:6379/1') }
+  let(:line_item_ids) { [1, 2] }
+  let(:line_items) do
+    [
+      instance_double(Spree::LineItem, id: 1, variant_id: 101, quantity: 2),
+      instance_double(Spree::LineItem, id: 2, variant_id: 102, quantity: 3)
+    ]
+  end
+  let(:cached_inventory_items) do
+    [
+      instance_double(SpreeCmCommissioner::CachedInventoryItem,
+                      inventory_key: 'inventory:1',
+                      quantity_available: 2,
+                      inventory_item_id: 1,
+                      variant_id: 101),
+      instance_double(SpreeCmCommissioner::CachedInventoryItem,
+                      inventory_key: 'inventory:2',
+                      quantity_available: 3,
+                      inventory_item_id: 2,
+                      variant_id: 102)
+    ]
+  end
+
+  subject { described_class.new(line_item_ids) }
+
+  before do
+    allow(Spree::LineItem).to receive(:where).with(id: line_item_ids).and_return(line_items)
+    allow(SpreeCmCommissioner::RedisStock::LineItemsCachedInventoryItemsBuilder)
+      .to receive(:new).with(line_item_ids).and_return(double(call: { 1 => cached_inventory_items }))
+    allow(SpreeCmCommissioner).to receive(:redis_pool).and_return(redis_pool)
+    allow(redis_pool).to receive(:with).and_yield(redis)
+  end
+
+  describe '#unstock!' do
+    context 'when stock is sufficient' do
+      before do
+        allow(redis).to receive(:eval).and_return(1)
+        allow(SpreeCmCommissioner::InventoryItemSyncerJob).to receive(:perform_later)
+      end
+
+      it 'unstocks inventory successfully' do
+        expect(redis).to receive(:eval).with(subject.send(:unstock_redis_script),
+                                            keys: ['inventory:1', 'inventory:2'],
+                                            argv: [2, 3])
+        expect(SpreeCmCommissioner::InventoryItemSyncerJob).to receive(:perform_later).with(
+          inventory_id_and_quantities: [
+            { inventory_id: 1, quantity: -2 },
+            { inventory_id: 2, quantity: -3 }
+          ]
+        )
+
+        subject.unstock!
+      end
+    end
+
+    context 'when stock is insufficient' do
+      before do
+        allow(redis).to receive(:eval).and_return(0)
+      end
+
+      it 'raises UnableToUnstock error' do
+        expect {
+          subject.unstock!
+        }.to raise_error(SpreeCmCommissioner::RedisStock::InventoryUpdater::UnableToUnstock,
+                        Spree.t(:insufficient_stock_lines_present))
+      end
+    end
+  end
+
+  describe '#restock!' do
+    before do
+      allow(redis).to receive(:eval).and_return(1)
+      allow(SpreeCmCommissioner::InventoryItemSyncerJob).to receive(:perform_later)
+    end
+
+    it 'restocks inventory successfully' do
+      expect(redis).to receive(:eval).with(subject.send(:restock_redis_script),
+                                          keys: ['inventory:1', 'inventory:2'],
+                                          argv: [2, 3])
+      expect(SpreeCmCommissioner::InventoryItemSyncerJob).to receive(:perform_later).with(
+        inventory_id_and_quantities: [
+          { inventory_id: 1, quantity: 2 },
+          { inventory_id: 2, quantity: 3 }
+        ]
+      )
+
+      subject.restock!
+    end
+
+    context 'when restock fails' do
+      before do
+        allow(redis).to receive(:eval).and_return(0)
+      end
+
+      it 'raises UnableToRestock error' do
+        expect {
+          subject.restock!
+        }.to raise_error(SpreeCmCommissioner::RedisStock::InventoryUpdater::UnableToRestock)
+      end
+    end
+  end
+
+  context 'with real Redis' do
+    before do
+      # Set up initial Redis state
+      real_redis.set('inventory:1', 10) # Sufficient stock for quantity 2
+      real_redis.set('inventory:2', 10) # Sufficient stock for quantity 3
+
+      # Override redis_pool to yield real_redis
+      allow(redis_pool).to receive(:with).and_yield(real_redis)
+      allow(SpreeCmCommissioner::InventoryItemSyncerJob).to receive(:perform_later)
+    end
+
+    after do
+      # Clean up Redis keys
+      real_redis.del('inventory:1', 'inventory:2')
+    end
+
+    describe '#unstock!' do
+      it 'unstocks inventory and updates Redis' do
+        expect {
+          subject.unstock!
+        }.to change {
+          [real_redis.get('inventory:1').to_i, real_redis.get('inventory:2').to_i]
+        }.from([10, 10]).to([8, 7])
+
+        expect(SpreeCmCommissioner::InventoryItemSyncerJob).to have_received(:perform_later).with(
+          inventory_id_and_quantities: [
+            { inventory_id: 1, quantity: -2 },
+            { inventory_id: 2, quantity: -3 }
+          ]
+        )
+      end
+
+      context 'when stock is insufficient' do
+        before do
+          real_redis.set('inventory:1', 1) # Insufficient for quantity 2
+        end
+
+        it 'raises UnableToUnstock error' do
+          expect {
+            subject.unstock!
+          }.to raise_error(SpreeCmCommissioner::RedisStock::InventoryUpdater::UnableToUnstock,
+                          Spree.t(:insufficient_stock_lines_present))
+        end
+      end
+    end
+
+    describe '#restock!' do
+      it 'restocks inventory and updates Redis' do
+        expect {
+          subject.restock!
+        }.to change {
+          [real_redis.get('inventory:1').to_i, real_redis.get('inventory:2').to_i]
+        }.from([10, 10]).to([12, 13])
+
+        expect(SpreeCmCommissioner::InventoryItemSyncerJob).to have_received(:perform_later).with(
+          inventory_id_and_quantities: [
+            { inventory_id: 1, quantity: 2 },
+            { inventory_id: 2, quantity: 3 }
+          ]
+        )
+      end
+    end
+  end
+
+  describe 'private methods' do
+    describe '#unstock_redis_script' do
+      it 'returns correct Lua script' do
+        script = subject.send(:unstock_redis_script)
+        expect(script).to include('local keys = KEYS')
+        expect(script).to include('local quantities = ARGV')
+        expect(script).to include("redis.call('DECRBY', key, tonumber(quantities[i]))")
+      end
+    end
+
+    describe '#restock_redis_script' do
+      it 'returns correct Lua script' do
+        script = subject.send(:restock_redis_script)
+        expect(script).to include('local keys = KEYS')
+        expect(script).to include('local quantities = ARGV')
+        expect(script).to include("redis.call('INCRBY', key, tonumber(quantities[i]))")
+      end
+    end
+
+    describe '#extract_inventory_data' do
+      it 'returns keys, quantities, and inventory_ids' do
+        keys, quantities, inventory_ids = subject.send(:extract_inventory_data)
+        expect(keys).to eq(['inventory:1', 'inventory:2'])
+        expect(quantities).to eq([2, 3])
+        expect(inventory_ids).to eq([1, 2])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What does th PR do?
**Redis Integration for Inventory Management**
- Modified stock checking to read from Redis for improved performance.
- Updated order completion to deduct stock from Redis. 
```   
# After the transition to complete, it deducts stock from redis before proceeding to other `after_transition` callbacks.
# Ensures that if `unstock_inventory_in_redis!` fails, the state will be rolled back,
# and neither the `finalize!` method nor any notifications will be triggered.
# This is critical because if the order state is complete, the payment will be marked as paid.
# We roll back only the order state, and we keep the payment state as it is.
# We implement payment in the vPago gem, and it will be reversed in the gem.
# Some banks has api for refunds, but some don't have the api to refund yet. So we keep the payment state as it is and refund manually.
```
- Added `stock deduction from Redis` when `resuming` a cancelled order. and implement a transaction like above
- Implemented `restocking` to Redis when `cancelling` a completed order.
- Sync inventory item after stock is cut from the redis


