### PR TITLE
Close #2536 Trip Connection uniqueness on from trip and to trip

### DIFF
--- a/app/models/concerns/spree_cm_commissioner/option_type_attr_type.rb
+++ b/app/models/concerns/spree_cm_commissioner/option_type_attr_type.rb
@@ -20,6 +20,7 @@ module SpreeCmCommissioner
       vehicle_id
       origin
       destination
+      place_id
     ].freeze
 
     RESERVED_OPTIONS = {
@@ -47,8 +48,8 @@ module SpreeCmCommissioner
       'bib-display-prefix' => 'boolean',
       'bib-pre-generation-on-create' => 'boolean',
       'seat-number-positions' => 'array',
-      'origin' => 'origin',
-      'destination' => 'destination',
+      'origin' => 'place_id',
+      'destination' => 'place_id',
       'departure-time' => 'time',
       'vehicle' => 'vehicle_id',
       'allow-seat-selection' => 'boolean'

--- a/app/models/spree_cm_commissioner/trip_connection.rb
+++ b/app/models/spree_cm_commissioner/trip_connection.rb
@@ -5,6 +5,7 @@ module SpreeCmCommissioner
 
     validate :both_trip_cannot_be_the_same
     before_validation :calculate_connection_time_minutes
+    validates :from_trip_id, uniqueness: { scope: :to_trip_id }
 
     private
 

--- a/app/models/spree_cm_commissioner/trip_stop.rb
+++ b/app/models/spree_cm_commissioner/trip_stop.rb
@@ -13,11 +13,11 @@ module SpreeCmCommissioner
     validates :stop_id, uniqueness: { scope: :trip_id }
 
     def set_stop_name
-      self.stop_name = stop.name
+      self.stop_name = stop.name if stop.present?
     end
 
     def create_vendor_stop
-      vendor.vendor_stops.where(stop_id: stop_id, stop_type: stop_type).first_or_create
+      vendor.vendor_stops.where(stop_id: stop_id, stop_type: stop_type).first_or_create if trip.present?
     end
 
     private

--- a/app/models/spree_cm_commissioner/variant_decorator.rb
+++ b/app/models/spree_cm_commissioner/variant_decorator.rb
@@ -24,8 +24,10 @@ module SpreeCmCommissioner
       base.scope :subscribable, -> { active.joins(:product).where(product: { subscribable: true, status: :active }) }
       base.has_one :trip,
                    class_name: 'SpreeCmCommissioner::Trip'
+      base.has_many :trip_stops, class_name: 'SpreeCmCommissioner::TripStop', dependent: :destroy, foreign_key: :trip_id
       base.accepts_nested_attributes_for :option_values
       base.after_commit :sync_trip, if: -> { product.product_type == 'transit' }
+      base.accepts_nested_attributes_for :trip_stops, allow_destroy: true
     end
 
     def delivery_required?

--- a/app/models/spree_cm_commissioner/variant_options.rb
+++ b/app/models/spree_cm_commissioner/variant_options.rb
@@ -166,19 +166,5 @@ module SpreeCmCommissioner
         Time.zone.parse(time) if time.present?
       end
     end
-
-    def arrival_time
-      @arrival_time ||= departure_time + total_duration_in_minutes.minutes
-    end
-
-    def total_duration_in_minutes
-      total_duration_in_minutes = 0
-
-      total_duration_in_minutes += duration_in_hours * 60 if duration_in_hours.present?
-      total_duration_in_minutes += duration_in_minutes if duration_in_minutes.present?
-      total_duration_in_minutes += duration_in_seconds / 60 if duration_in_seconds.present?
-
-      total_duration_in_minutes
-    end
   end
 end


### PR DESCRIPTION
In this PR, I have added a validation check to the instance of `trip_connection` before creation, making sure that it is not a duplicate instance (make sure the link `from_trip` and `to_trip` has not been created before)

```validate :unique_trip_connection, on: %i[create]```

```validates :from_trip_id, uniqueness: { scope: :to_trip_id }```

- update option type origin and destination to use type `place_id`
- add relationship of `variant` with `trip_stops`