### PR TITLE
close #2552 sync inventory_item on update stock item

### DIFF
--- a/app/controllers/spree/admin/stock_managements_controller.rb
+++ b/app/controllers/spree/admin/stock_managements_controller.rb
@@ -12,9 +12,25 @@ module Spree
       def index
         @variants = @product.variants.includes(:images, stock_items: :stock_location, option_values: :option_type)
         @variants = [@product.master] if @variants.empty?
-
         @stock_locations = (@variants.flat_map(&:stock_locations) + @product.vendor.stock_locations).uniq
 
+        load_inventories unless @product.permanent_stock?
+      end
+
+      def calendar
+        @year = params[:year].present? ? params[:year].to_i : Time.zone.today.year
+
+        from_date = Date.new(@year, 1, 1).beginning_of_year
+        to_date = Date.new(@year, 1, 1).end_of_year
+
+        @inventory_items = @product.inventory_items.includes(:variant).where(inventory_date: from_date..to_date).to_a
+        @events = SpreeCmCommissioner::CalendarEvent.from_inventory_items(@inventory_items)
+      end
+
+      private
+
+      def load_inventories
+        @inventory_items = @product.inventory_items.group_by { |item| item.variant.id }
         @reserved_stocks = Spree::LineItem
                            .complete
                            .where(variant_id: @variants.pluck(:id))

--- a/app/models/concerns/spree_cm_commissioner/product_type.rb
+++ b/app/models/concerns/spree_cm_commissioner/product_type.rb
@@ -5,11 +5,16 @@ module SpreeCmCommissioner
   module ProductType
     extend ActiveSupport::Concern
 
-    PRODUCT_TYPES = %i[accommodation service ecommerce transit event bus].freeze
+    PRODUCT_TYPES = %i[accommodation service ecommerce transit].freeze
+    PERMANENT_STOCK_PRODUCT_TYPES = %w[accommodation service transit].freeze
 
     included do
       enum product_type: PRODUCT_TYPES if table_exists? && column_names.include?('product_type')
       enum primary_product_type: PRODUCT_TYPES if table_exists? && column_names.include?('primary_product_type')
+    end
+
+    def permanent_stock?
+      PERMANENT_STOCK_PRODUCT_TYPES.include?(product_type)
     end
   end
 end

--- a/app/models/spree_cm_commissioner/inventory_item.rb
+++ b/app/models/spree_cm_commissioner/inventory_item.rb
@@ -1,6 +1,8 @@
 module SpreeCmCommissioner
   class InventoryItem < ApplicationRecord
-    # Constant
+    include SpreeCmCommissioner::ProductType
+
+    # Constant (deprecated -> we should use [ProductType] instead)
     PRODUCT_TYPE_ACCOMMODATION = 'accommodation'.freeze
     PRODUCT_TYPE_EVENT = 'event'.freeze
     PRODUCT_TYPE_BUS = 'bus'.freeze
@@ -16,10 +18,20 @@ module SpreeCmCommissioner
     # Validation
     validates :quantity_available, numericality: { greater_than_or_equal_to: 0 }
     validates :max_capacity, numericality: { greater_than_or_equal_to: 0 } # Originally inventory of each variant.
-    validates :inventory_date, presence: true, unless: -> { product_type == PRODUCT_TYPE_EVENT }
-    validates :variant_id, uniqueness: { scope: :inventory_date, message: ->(object, data) { "The variant is taken on #{object.inventory_date}" } }
+    validates :inventory_date, presence: true, if: -> { permanent_stock? }
+    validates :variant_id, uniqueness: { scope: :inventory_date, message: -> (object, _data) { "The variant is taken on #{object.inventory_date}" } }
 
     # Scope
     scope :for_product, -> (type) { where(product_type: type) }
+    scope :active, -> { where(inventory_date: nil).or(where('inventory_date >= ?', Time.zone.today)) }
+
+    def adjust_quantity!(quantity)
+      with_lock do
+        self.max_capacity = max_capacity + quantity
+        self.quantity_available = quantity_available + quantity
+
+        save!
+      end
+    end
   end
 end

--- a/app/models/spree_cm_commissioner/product_decorator.rb
+++ b/app/models/spree_cm_commissioner/product_decorator.rb
@@ -33,6 +33,7 @@ module SpreeCmCommissioner
       base.has_one :google_wallet, class_name: 'SpreeCmCommissioner::GoogleWallet', dependent: :destroy
 
       base.has_many :complete_line_items, through: :classifications, source: :line_items
+      base.has_many :inventory_items, through: :variants
 
       base.has_many :product_places, class_name: 'SpreeCmCommissioner::ProductPlace', dependent: :destroy
       base.has_many :places, through: :product_places

--- a/app/models/spree_cm_commissioner/stock_movement_decorator.rb
+++ b/app/models/spree_cm_commissioner/stock_movement_decorator.rb
@@ -1,0 +1,34 @@
+module SpreeCmCommissioner
+  module StockMovementDecorator
+    def self.prepended(base)
+      base.after_create :adjust_inventory_items, if: -> { stock_item.should_track_inventory? }
+    end
+
+    def adjust_inventory_items
+      if !variant.permanent_stock? && !variant.default_inventory_item_exist?
+        variant.create_default_non_permanent_inventory_item!
+      else
+        adjust_existing_inventory_items!
+      end
+    end
+
+    private
+
+    def should_create_default_non_permanent_inventory_item?
+      return false if variant.permanent_stock?
+      return false if variant.inventory_items.exists?(inventory_date: nil)
+
+      true
+    end
+
+    def adjust_existing_inventory_items!
+      variant.inventory_items.active.find_each(batch_size: 100) do |inventory_item|
+        inventory_item.adjust_quantity!(quantity)
+      end
+    end
+  end
+end
+
+unless Spree::StockMovement.included_modules.include?(SpreeCmCommissioner::StockMovementDecorator)
+  Spree::StockMovement.prepend(SpreeCmCommissioner::StockMovementDecorator)
+end

--- a/app/views/spree/admin/stock_managements/_events_popover.html.erb
+++ b/app/views/spree/admin/stock_managements/_events_popover.html.erb
@@ -1,0 +1,17 @@
+<div>
+  <% events.each do |event| %>
+    <div>
+      <h6><%= event.options[:inventory_item].variant.options_text %></h6>
+      <ul class="list-group mt-1">
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          Max capacity
+          <span class="badge badge-primary badge-pill"><%= event.options[:inventory_item].max_capacity %></span>
+        </li>
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          Quantity available
+          <span class="badge badge-primary badge-pill"><%= event.options[:inventory_item].quantity_available %></span>
+        </li>
+      </ul>
+    </div>
+  <% end %>
+</div>

--- a/app/views/spree/admin/stock_managements/calendar.html.erb
+++ b/app/views/spree/admin/stock_managements/calendar.html.erb
@@ -1,0 +1,32 @@
+<%= turbo_frame_tag "calendar" do %>
+  <%= form_with url: admin_product_stock_managements_path, method: :get, class: "mt-4" do %>
+    <%= select_year(params[:year]&.to_i || @year, { start_year: 2025, end_year: @year + 3 }, { name: "year", onchange: "this.form.submit()" }) %>
+  <% end %>
+
+  <div class="c-annual-calendar-container mt-2">
+    <div class="c-annual-calendar">
+      <% (1..12).each do |month| %>
+        <%= month_calendar(start_date: Date.new(@year, month, 1), attribute: :from_date, end_attribute: :to_date, events: @events) do |date, events| %>
+          <div class="c-annual-day"
+            data-date="<%= date.strftime '%Y-%m-%d' %>"
+            type="button"
+            tabindex="0"
+            data-toggle="popover"
+            data-trigger="hover"
+            data-placement="right"
+            data-html="true"
+            data-content="<%= raw render_escape_html partial: "events_popover", locals: { events: events } if events.any? %>">
+            <%= date.day %>
+            <ul class="p-0 m-0 list-unstyled">
+              <% events.each do |event| %>
+              <li class="badge badge-warning">
+                <%= event.options[:inventory_item].quantity_available %>
+              </li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/spree/admin/stock_managements/index.html.erb
+++ b/app/views/spree/admin/stock_managements/index.html.erb
@@ -19,10 +19,7 @@
       <% @variants.each do |variant| %>
         <tr id="<%= spree_dom_id variant %>" data-hook="admin_product_stock_management_index_rows">
           <td class="image text-center">
-              <%= small_image(variant) %>
-              <div class="mt-4">
-                Reserved Stock: <%= @reserved_stocks[variant.id] || 0 %></strong>
-              </div>
+            <%= small_image(variant) %>
           </td>
           <td>
             <%= variant.sku_and_options_text %>
@@ -35,13 +32,36 @@
                 <% end %>
               </div>
             <% end if can?(:update, @product) && can?(:update, variant) %>
+
+            <% if defined?(@reserved_stocks) %>
+              <div>
+                <span type="button" data-toggle="popover" data-trigger="hover" data-placement="right" data-content="This product stock will renew every day">
+                  <%= svg_icon name: "cart-check.svg", width: '14', height: '14' %>
+                </span>
+                <%= label_tag "reserved_stock#{variant.id}", "Reserved Stock: #{@reserved_stocks[variant.id] || 0}", class: "m-0" %>
+              </div>
+            <% end %>
+
             <% if variant.permanent_stock? %>
               <div>
                 <span type="button" data-toggle="popover" data-trigger="hover" data-placement="right" data-content="This product stock will renew every day">
                     <%= svg_icon name: "info-circle-fill.svg", width: '14', height: '14' %>
                 </span>
-                <%= label_tag "permanent_stock_#{ variant.id }", Spree.t(:permanent_stock) %>
+                <%= label_tag "permanent_stock_#{ variant.id }", Spree.t(:permanent_stock), class: "m-0" %>
               </div>
+            <% end %>
+
+            <% if defined?(@inventory_items) %>
+              <% @inventory_items[variant.id]&.each do |inventory_item| %>
+                <div>
+                  <%= svg_icon name: "handbag.svg", width: '14', height: '14' %>
+                  <%= label_tag "max_capacity_#{ inventory_item.id }", "Max capacity: #{inventory_item.max_capacity}", class: "m-0" %>
+                </div>
+                <div>
+                  <%= svg_icon name: "approve.svg", width: '14', height: '14' %>
+                  <%= label_tag "quantity_available_#{ inventory_item.id }", "Quantity available: #{inventory_item.quantity_available}", class: "m-0" %>
+                </div>
+              <% end %>
             <% end %>
           </td>
 
@@ -53,3 +73,9 @@
     </tbody>
   </table>
 </div>
+
+<%= turbo_frame_tag "calendar", src: calendar_admin_product_stock_managements_path(year: params[:year]) do %>
+  <div class="spinner-border mt-2" role="status">
+    <span class="sr-only">Loading...</span>
+  </div>
+<% end if @product.permanent_stock? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,7 +137,11 @@ Spree::Core::Engine.add_routes do
         end
       end
 
-      resources :stock_managements
+      resources :stock_managements do
+        collection do
+          get :calendar
+        end
+      end
 
       resources :product_completion_steps do
         collection do

--- a/db/migrate/20250304293518_create_cm_inventory_items.rb
+++ b/db/migrate/20250304293518_create_cm_inventory_items.rb
@@ -2,17 +2,17 @@ class CreateCmInventoryItems < ActiveRecord::Migration[7.0]
   def up
     create_table :cm_inventory_items, if_not_exists: true do |t|
       t.integer :variant_id
-      t.date    :inventory_date
-      t.integer :max_capacity, default: 0
-      t.integer :quantity_available, default: 0
-      t.string  :product_type #-- 'event', 'bus', 'accommodation'
+      t.date :inventory_date
+      t.integer :max_capacity, default: 0, null: false
+      t.integer :quantity_available, default: 0, null: false
+      t.integer :product_type, default: 0, null: false
 
       t.timestamps
     end
 
-    add_index :cm_inventory_items, :variant_id
-    add_index :cm_inventory_items, :inventory_date
-    add_index :cm_inventory_items, [:variant_id, :inventory_date], unique: true
+    add_index :cm_inventory_items, :variant_id, if_not_exists: true
+    add_index :cm_inventory_items, :inventory_date, if_not_exists: true
+    add_index :cm_inventory_items, [:variant_id, :inventory_date], unique: true, if_not_exists: true
   end
 
   def down

--- a/lib/generators/spree_cm_commissioner/install/install_generator.rb
+++ b/lib/generators/spree_cm_commissioner/install/install_generator.rb
@@ -40,8 +40,8 @@ module SpreeCmCommissioner
                          after: %r{//= require spree/backend}, verbose: true
 
         # For NPM support
-        template 'app/javascript/spree_cm_commissioner/utilities.js'
-        inject_into_file 'app/javascript/spree-dashboard.js', "\nimport \"./spree_cm_commissioner/utilities.js\"",
+        template 'app/javascript/spree_dashboard/spree_cm_commissioner/utilities.js'
+        inject_into_file 'app/javascript/spree_dashboard/spree-dashboard.js', "\nimport \"./spree_cm_commissioner/utilities.js\"",
                          after: %r{import "@spree/dashboard"}, verbose: true
       end
 

--- a/lib/generators/spree_cm_commissioner/install/templates/app/javascript/spree_dashboard/spree_cm_commissioner/utilities.js
+++ b/lib/generators/spree_cm_commissioner/install/templates/app/javascript/spree_dashboard/spree_cm_commissioner/utilities.js
@@ -6,3 +6,7 @@ const $ = jquery;
 document.addEventListener("spree:load", function () {
   $('[data-toggle="popover"]').popover();
 });
+
+document.documentElement.addEventListener("turbo:frame-load", (event) => {
+  $('[data-toggle="popover"]').popover();
+});

--- a/lib/spree_cm_commissioner/calendar_event.rb
+++ b/lib/spree_cm_commissioner/calendar_event.rb
@@ -2,7 +2,7 @@ module SpreeCmCommissioner
   class CalendarEvent
     attr_reader :from_date, :to_date, :title, :options
 
-    def initialize(from_date:, to_date:, title:, options:)
+    def initialize(from_date:, to_date:, title: nil, options: nil)
       @from_date = from_date
       @to_date = to_date
       @title = title
@@ -20,6 +20,16 @@ module SpreeCmCommissioner
             classes: ['bg-primary'],
             order: order
           }
+        )
+      end
+    end
+
+    def self.from_inventory_items(inventory_items)
+      inventory_items.map do |item|
+        CalendarEvent.new(
+          from_date: item.inventory_date,
+          to_date: item.inventory_date,
+          options: { inventory_item: item }
         )
       end
     end

--- a/lib/tasks/create_default_non_permanent_inventory_items.rake
+++ b/lib/tasks/create_default_non_permanent_inventory_items.rake
@@ -1,0 +1,16 @@
+# recommend to be used in schedule.yml & manually access in /sidekiq/cron
+namespace :spree_cm_commissioner do
+  desc 'Create default inventory items for non-permanent stock products'
+  task create_default_non_permanent_inventory_items: :environment do
+    Spree::Variant.active.with_non_permanent_stock.find_each do |variant|
+      total_purchases = variant.complete_line_items.sum(:quantity).to_i || 0
+      max_capacity = variant.total_on_hand || 0
+      quantity_available = [max_capacity - total_purchases, 0].max
+
+      variant.create_default_non_permanent_inventory_item!(
+        max_capacity: max_capacity,
+        quantity_available: quantity_available
+      )
+    end
+  end
+end

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Spree::Product, type: :model do
     it { should have_many(:variant_kind_option_types).through(:product_option_types) }
     it { should have_many(:product_kind_option_types).through(:product_option_types) }
     it { should have_many(:promoted_option_types).through(:product_option_types) }
+    it { should have_many(:inventory_items).through(:variants) }
   end
 
   describe 'attributes' do

--- a/spec/models/spree/stock_movement_spec.rb
+++ b/spec/models/spree/stock_movement_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+RSpec.describe Spree::StockMovement, type: :model do
+  let(:variant) { create(:variant) }
+  let(:stock_item) { create(:stock_item, variant: variant) }
+  let(:stock_movement) { build(:stock_movement, stock_item: stock_item, quantity: 5) }
+
+  before do
+    allow(stock_movement).to receive(:stock_item).and_return(stock_item)
+    allow(stock_movement).to receive(:variant).and_return(variant)
+  end
+
+  describe 'after_create :adjust_inventory_items' do
+    it 'calls adjust_inventory_items if should_track_inventory? is true' do
+      allow(stock_item).to receive(:should_track_inventory?).and_return(true)
+
+      expect(stock_movement).to receive(:adjust_inventory_items)
+      stock_movement.run_callbacks(:create)
+    end
+
+    it 'does not call adjust_inventory_items if should_track_inventory? is false' do
+      allow(stock_item).to receive(:should_track_inventory?).and_return(false)
+
+      expect(stock_movement).not_to receive(:adjust_inventory_items)
+      stock_movement.run_callbacks(:create)
+    end
+  end
+
+  describe '#adjust_inventory_items' do
+    context 'when variant is not permanent stock and no default inventory item exists' do
+      it 'creates default non-permanent inventory item' do
+        allow(variant).to receive(:permanent_stock?).and_return(false)
+        allow(variant).to receive(:default_inventory_item_exist?).and_return(false)
+
+        expect(variant).to receive(:create_default_non_permanent_inventory_item!)
+        stock_movement.send(:adjust_inventory_items)
+      end
+    end
+
+    context 'when variant is permanent stock or default inventory item exists' do
+      it 'adjusts existing inventory items' do
+        allow(variant).to receive(:permanent_stock?).and_return(false)
+        allow(variant).to receive(:default_inventory_item_exist?).and_return(true)
+
+        expect(stock_movement).to receive(:adjust_existing_inventory_items!)
+        stock_movement.send(:adjust_inventory_items)
+      end
+    end
+  end
+
+  describe '#adjust_existing_inventory_items!' do
+    it 'adjusts quantity on each active inventory item' do
+      inventory_item1 = instance_double('InventoryItem')
+      inventory_item2 = instance_double('InventoryItem')
+
+      allow(variant).to receive_message_chain(:inventory_items, :active, :find_each)
+        .and_yield(inventory_item1).and_yield(inventory_item2)
+
+      expect(inventory_item1).to receive(:adjust_quantity!).with(stock_movement.quantity)
+      expect(inventory_item2).to receive(:adjust_quantity!).with(stock_movement.quantity)
+
+      stock_movement.send(:adjust_existing_inventory_items!)
+    end
+  end
+end


### PR DESCRIPTION
# What is in this PR?
- Sync new stock item data to all inventory_items on update
- Show all inventory items in calendar UI

| |
| - |
| 1. Permanent stock |
| <img width="1728" alt="image" src="https://github.com/user-attachments/assets/f52583e8-e3d6-48bb-aa03-cc9f5ed3a948" /> |
| 2. Non-permanent stock |
| <img width="1728" alt="image" src="https://github.com/user-attachments/assets/b1ccd57f-7653-42f8-b763-7a9d4debccbb" /> |
