### PR TITLE
Close #2431 Refactor cm_place to use nestedset

### DIFF
--- a/.github/workflows/test_and_build_gem.yml
+++ b/.github/workflows/test_and_build_gem.yml
@@ -3,6 +3,11 @@ name: Commissioner Gem
 
 on:
   pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
     branches:
       - develop
   push:
@@ -65,29 +70,48 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const pr = context.payload.pull_request;
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
+            const prNumber = context.payload.pull_request.number;
+            const { owner, repo } = context.repo;
 
-            try {
-              const response = await github.rest.pulls.listReviewComments({
-                owner,
-                repo,
-                pull_number: pr.number,
-                per_page: 100
-              });
-
-              const unresolved = response.data.filter(comment => comment.in_reply_to_id && !comment.resolved);
-
-              if (unresolved.length > 0) {
-                core.setFailed(`There are ${unresolved.length} unresolved review comment(s). Please resolve all threads before merging.`);
-              } else {
-                console.log("All review comments are resolved.");
+            const query = `
+              query($owner: String!, $repo: String!, $prNumber: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $prNumber) {
+                    reviewThreads(first: 100) {
+                      nodes {
+                        isResolved
+                        comments(first: 1) {
+                          nodes {
+                            body
+                            author {
+                              login
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
               }
-            } catch (error) {
-              console.error("Error fetching review comments:", error.message);
-              core.setFailed("Failed to check for unresolved review threads.");
+            `;
+            const variables = { owner, repo, prNumber };
+            const result = await github.graphql(query, variables);
+            const threads = result.repository.pullRequest.reviewThreads.nodes;
+
+            const unresolved = threads.filter(t => !t.isResolved);
+
+            if (unresolved.length > 0) {
+              unresolved.forEach(thread => {
+                const comments = thread.comments.nodes;
+                if (comments.length > 0) {
+                  console.log(`💬 Comment by ${comments[0].author.login}: ${comments[0].body}`);
+                }
+              });
+              core.setFailed(`❌ There are ${unresolved.length} unresolved review thread(s). Please resolve them before merging.`);
+            } else {
+              console.log("✅ All review threads are resolved.");
             }
+
   test_and_build_gem:
     needs: [validate-commits]
     # if: github.head_ref != '2572-enforce-pr-workflow' || github.base_ref != 'develop'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,6 @@
   "files.trimTrailingWhitespace": true,
   "editor.formatOnSave": true,
   "[yaml]": {
-    "editor.defaultFormatter": "aaron-bond.better-comments"
+    "editor.defaultFormatter": "redhat.vscode-yaml"
   },
 }

--- a/app/models/spree_cm_commissioner/place.rb
+++ b/app/models/spree_cm_commissioner/place.rb
@@ -2,6 +2,8 @@ require_dependency 'spree_cm_commissioner'
 
 module SpreeCmCommissioner
   class Place < ApplicationRecord
+    acts_as_nested_set
+
     validates :reference, presence: true, if: :validate_reference?
     validates :lat, presence: true, if: :validate_lat?
     validates :lon, presence: true, if: :validate_lon?
@@ -13,13 +15,20 @@ module SpreeCmCommissioner
 
     has_many :product_places, class_name: 'SpreeCmCommissioner::ProductPlace', dependent: :destroy
     has_many :products, through: :product_places
-    has_many :children, class_name: 'SpreeCmCommissioner::Place', foreign_key: :parent_id, dependent: :destroy
-    belongs_to :parent, class_name: 'SpreeCmCommissioner::Place', optional: true
 
+    has_many :children, -> { order(:lft) }, class_name: 'SpreeCmCommissioner::Place', foreign_key: :parent_id, dependent: :destroy
     has_many :vendor_stops, class_name: 'SpreeCmCommissioner::VendorStop', dependent: :destroy
 
     def self.ransackable_attributes(auth_object = nil)
       super & %w[name code]
+    end
+
+    def full_path_name
+      self_and_ancestors.map(&:name).reverse.join(', ')
+    end
+
+    def path_ids
+      self_and_ancestors.map(&:id)
     end
 
     def validate_reference?

--- a/db/migrate/20250418072528_add_nested_set_columns_to_places.rb
+++ b/db/migrate/20250418072528_add_nested_set_columns_to_places.rb
@@ -1,0 +1,10 @@
+class AddNestedSetColumnsToPlaces < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cm_places, :parent_id, :integer if !column_exists?(:cm_places, :parent_id)
+    add_column :cm_places, :lft,       :integer if !column_exists?(:cm_places, :lft)
+    add_column :cm_places, :rgt,       :integer if !column_exists?(:cm_places, :rgt)
+
+    add_column :cm_places, :depth,          :integer if !column_exists?(:cm_places, :depth)
+    add_column :cm_places, :children_count, :integer if !column_exists?(:cm_places, :children_count)
+  end
+end

--- a/lib/spree_cm_commissioner/test_helper/factories/place_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/place_factory.rb
@@ -10,5 +10,15 @@ FactoryBot.define do
     address_components    { FFaker::Address.street_address }
     lat                   { FFaker::Geolocation.lat }
     lon                   { FFaker::Geolocation.lng }
+    trait :with_parent do
+      association :parent, factory: :cm_place
+    end
+    transient do
+      children_count { 0 }
+    end
+
+    after(:create) do |place, evaluator|
+      create_list(:cm_place, evaluator.children_count, parent: place)
+    end
   end
 end

--- a/lib/tasks/migrate_and_rebuild_place_hierarchy.rake
+++ b/lib/tasks/migrate_and_rebuild_place_hierarchy.rake
@@ -1,0 +1,9 @@
+namespace :spree_cm_commissioner do
+  desc 'Migrate and Rebuild place hierarchy..'
+  task migrate_and_rebuild_place_hierarchy: :environment do
+    puts 'Resetting column information :lft and :rgt columns...'
+    SpreeCmCommissioner::Place.reset_column_information
+    SpreeCmCommissioner::Place.rebuild!
+    puts 'Place hierarchy rebuild completed successfully!'
+  end
+end

--- a/lib/tasks/update_orphan_root_places.rake
+++ b/lib/tasks/update_orphan_root_places.rake
@@ -1,0 +1,7 @@
+namespace :spree_cm_commissioner do
+  desc 'Update orphan root places...'
+  task update_orphan_root_places: :environment do
+    count = SpreeCmCommissioner::Place.where(parent_id: 0).update_all(parent_id: nil) # rubocop:disable Rails/SkipsModelValidations
+    puts "#{count} orphan root places updated."
+  end
+end

--- a/spec/models/spree_cm_commissioner/place_spec.rb
+++ b/spec/models/spree_cm_commissioner/place_spec.rb
@@ -1,19 +1,59 @@
 require 'spec_helper'
 
 RSpec.describe SpreeCmCommissioner::Place, type: :model do
-  describe 'associations' do
-    it { should have_many(:nearby_places).class_name('SpreeCmCommissioner::VendorPlace').dependent(:destroy) }
-    it { should have_many(:vendors).class_name('Spree::Vendor').through(:nearby_places) }
 
-    it { should have_many(:product_places).class_name('SpreeCmCommissioner::ProductPlace').dependent(:destroy) }
-    it { should have_many(:products).through(:product_places) }
-    it { should have_many(:children).class_name('SpreeCmCommissioner::Place').with_foreign_key(:parent_id).dependent(:destroy) }
-    it { should belong_to(:parent).class_name('SpreeCmCommissioner::Place').optional }
+  describe 'nested set behavior' do
+    let!(:root_place)    { create(:cm_place, name: 'Cambodia') }
+    let!(:child_place)   { create(:cm_place, parent: root_place, name: 'Phnom Penh') }
+    let!(:leaf_place)    { create(:cm_place, parent: child_place, name: 'Tuol Tompoung') }
+
+    before do
+      SpreeCmCommissioner::Place.rebuild!
+      root_place.reload
+      child_place.reload
+      leaf_place.reload
+    end
+
+    it 'sets the parent-child relationship correctly' do
+      expect(child_place.parent).to eq(root_place)
+      expect(root_place.children).to include(child_place)
+      expect(child_place.children).to include(leaf_place)
+    end
+
+    it 'can access ancestors and descendants' do
+      expect(leaf_place.ancestors).to match_array([root_place, child_place])
+      expect(root_place.descendants).to match_array([child_place, leaf_place])
+    end
+
+    it 'knows if it is a root or leaf node' do
+      expect(root_place.root?).to be true
+      expect(leaf_place.leaf?).to be true
+    end
+
+    it 'orders children based on lft' do
+      sibling1 = create(:cm_place, name: 'Battambang', parent: root_place)
+      sibling2 = create(:cm_place, name: 'Siem Reap', parent: root_place)
+      expect(root_place.children).to eq([child_place, sibling1, sibling2])
+    end
+
+    it 'builds the nested tree correctly' do
+      expect(root_place.children).to include(child_place)
+      expect(child_place.parent).to eq(root_place)
+      expect(leaf_place.ancestors).to match_array([root_place, child_place])
+    end
+  end
+
+  describe 'associations' do
+    it { is_expected.to have_many(:nearby_places).class_name('SpreeCmCommissioner::VendorPlace').dependent(:destroy) }
+    it { is_expected.to have_many(:vendors).class_name('Spree::Vendor').through(:nearby_places) }
+
+    it { is_expected.to have_many(:product_places).class_name('SpreeCmCommissioner::ProductPlace').dependent(:destroy) }
+    it { is_expected.to have_many(:products).through(:product_places) }
   end
 
   describe 'validation' do
-    it { should validate_presence_of(:reference) }
-    it { should validate_presence_of(:lat) }
-    it { should validate_presence_of(:lon) }
+    it { is_expected.to validate_presence_of(:reference) }
+    it { is_expected.to validate_presence_of(:lat) }
+    it { is_expected.to validate_presence_of(:lon) }
   end
 end


### PR DESCRIPTION
I have refactored the `cm_places` to follow the `nestedset` instead, based on the comment from the previous PR. Ref: https://github.com/channainfo/commissioner/pull/2429#discussion_r1986808799

*Ref about `nestedset`: https://github.com/collectiveidea/awesome_nested_set?tab=readme-ov-file#usage

**PR Changes**: Add nested set functionality to the Place model and update tests
The columns added are: 
- `parent_id` column if it doesn't already exist, and the parent is the `SpreeCmCommissioner::Place`.
- `lft (left)` boundary of a nested set node.
- `rgt (right)` boundary of a nested set node.
- `depth` level column, indicating how deep the node is in the hierarchy (0 = root). (It is useful for displaying indentation)
- `children_count`: Tracks the number of direct children a node has.
