### PR TITLE
Revert "close #2479 add reports preference to spree taxon"

### DIFF
--- a/app/models/spree_cm_commissioner/taxon_decorator.rb
+++ b/app/models/spree_cm_commissioner/taxon_decorator.rb
@@ -7,7 +7,6 @@ module SpreeCmCommissioner
 
       base.preference :background_color, :string
       base.preference :foreground_color, :string
-      base.preference :reports, :array, default: []
 
       base.has_many :taxon_vendors, class_name: 'SpreeCmCommissioner::TaxonVendor'
       base.has_many :vendors, through: :taxon_vendors


### PR DESCRIPTION
Reverts channainfo/commissioner#2480

Application spree_starter


⚠️ Error occurred in production ⚠️
A *RuntimeError* occurred in *taxons#create*.


Exception:
Locking a record with unpersisted changes is not supported. Use `save` to persist the changes, or `reload` to discard them explicitly.


Set by controller:
{:user=>"25839"}


Request:
```
* url : https://api-production.bookme.plus/admin/taxonomies/3/taxons
* http_method : POST
* ip_address : 43.230.192.190
* parameters : {"authenticity_token"=>"[FILTERED]", "taxon"=>{"name"=>"Sokleng Solo Concert", "hide_video_banner"=>"0", "hide_from_nav"=>"0", "available_on"=>"", "purchasable_on"=>"both", "show_badge_status"=>"false", "parent_id"=>"9"}, "controller"=>"spree/admin/taxons", "action"=>"create", "taxonomy_id"=>"3"}
* timestamp : 2025-04-21 11:58:21 +0700
```

## Description :
.  Error occurs when accessing or modifying preferences (preferred_reports) on an unsaved record.