### PR TITLE
Close #2559 create organizer url method

### DIFF
--- a/app/models/spree_cm_commissioner/vendor_decorator.rb
+++ b/app/models/spree_cm_commissioner/vendor_decorator.rb
@@ -177,6 +177,10 @@ module SpreeCmCommissioner
     def generate_code
       self.code = (code.presence || name[0, 3].upcase)
     end
+
+    def organizer_url
+      "#{Spree::Store.default.formatted_url}/organizers/#{slug}"
+    end
   end
 end
 


### PR DESCRIPTION
We use this method to generate a URL for an organizer's profile with the vendor slug. This URL is used to view the organizer's profile or share organizer's profile  on social media platforms like Facebook, LinkedIn, Email, and Telegram.