### PR TITLE
Close #2574 add slug, description and preferences column to prototype table

### DIFF
--- a/app/controllers/spree/admin/prototypes_controller_decorator.rb
+++ b/app/controllers/spree/admin/prototypes_controller_decorator.rb
@@ -1,0 +1,20 @@
+module Spree
+  module Admin
+    module PrototypesControllerDecorator
+      def self.prepended(base)
+        base.before_action :load_icons
+      end
+
+      # overrided
+      def find_resource
+        Spree::Prototype.friendly.find(params[:id])
+      end
+
+      def load_icons
+        @icons = SpreeCmCommissioner::VectorIcon.all
+      end
+    end
+  end
+end
+
+Spree::Admin::PrototypesController.prepend(Spree::Admin::PrototypesControllerDecorator)

--- a/app/models/spree_cm_commissioner/prototype_decorator.rb
+++ b/app/models/spree_cm_commissioner/prototype_decorator.rb
@@ -1,6 +1,9 @@
 module SpreeCmCommissioner
   module PrototypeDecorator
     def self.prepended(base)
+      base.extend FriendlyId
+      base.friendly_id :name, use: :slugged
+
       base.include SpreeCmCommissioner::ProductType
 
       base.has_many :variant_kind_option_types, -> { where(kind: :variant).order(:position) },
@@ -10,6 +13,12 @@ module SpreeCmCommissioner
                     through: :option_type_prototypes, source: :option_type
 
       base.has_many :option_values, through: :option_types
+
+      base.preference :icon, :string
+
+      def icon
+        preferred_icon
+      end
     end
   end
 end

--- a/app/overrides/spree/admin/prototypes/_form/description.html.erb.deface
+++ b/app/overrides/spree/admin/prototypes/_form/description.html.erb.deface
@@ -1,0 +1,6 @@
+<!-- insert_before "[id=properties]" -->
+
+<div id="description" class="field mb-3">
+  <%= f.label :description, Spree.t(:description) %><br>
+  <%= f.text_area :description, rows: 5, class: 'form-control' %>
+</div>

--- a/app/overrides/spree/admin/prototypes/_form/icon.html.erb.deface
+++ b/app/overrides/spree/admin/prototypes/_form/icon.html.erb.deface
@@ -1,0 +1,8 @@
+<!-- insert_bottom "[data-hook='admin_prototype_form_fields']" -->
+
+<div id='icon'>
+  <%= f.field_container :icon do %>
+    <%= f.label :preferred_icon, Spree.t(:icon_name) %> <%= link_to Spree.t(:icons), spree.admin_vectors_icons_url %>
+    <%= f.select :preferred_icon, @icons.map(&:path), { include_blank: Spree.t(:None) }, { class: "select2" } %>
+  <% end %>
+</div>

--- a/app/overrides/spree/admin/prototypes/_form/product_type.html.erb.deface
+++ b/app/overrides/spree/admin/prototypes/_form/product_type.html.erb.deface
@@ -1,3 +1,3 @@
-<!-- insert_bottom "[data-hook='admin_prototype_form_fields']" -->
+<!-- insert_bottom "#taxons" -->
 
 <%= render 'shared/product_type_field', field: :product_type, f: f %>

--- a/db/migrate/20250425084929_add_description_to_spree_prototypes.rb
+++ b/db/migrate/20250425084929_add_description_to_spree_prototypes.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToSpreePrototypes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_prototypes, :description, :text, if_not_exists: true
+  end
+end

--- a/db/migrate/20250425085938_add_preferences_to_spree_prototypes.rb
+++ b/db/migrate/20250425085938_add_preferences_to_spree_prototypes.rb
@@ -1,0 +1,5 @@
+class AddPreferencesToSpreePrototypes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_prototypes, :preferences, :text, if_not_exists: true
+  end
+end

--- a/db/migrate/20250428025645_add_slug_to_spree_prototypes.rb
+++ b/db/migrate/20250428025645_add_slug_to_spree_prototypes.rb
@@ -1,0 +1,6 @@
+class AddSlugToSpreePrototypes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_prototypes, :slug, :string, if_not_exists: true
+    add_index :spree_prototypes, :slug, unique: true, if_not_exists: true
+  end
+end


### PR DESCRIPTION
In this PR: 

- Add `slug`, `description` and `preferences` columns to `spree_prototypes`.


https://github.com/user-attachments/assets/281ee9de-368f-490a-a423-cb15d9517f70

