### PR TITLE
Close #2589 add idcard tenant guest api

### DIFF
--- a/app/serializers/spree/v2/tenant/guest_serializer.rb
+++ b/app/serializers/spree/v2/tenant/guest_serializer.rb
@@ -13,6 +13,7 @@ module Spree
 
         belongs_to :occupation, serializer: Spree::V2::Tenant::TaxonSerializer
         belongs_to :nationality, serializer: Spree::V2::Tenant::TaxonSerializer
+        has_one :id_card, serializer: Spree::V2::Tenant::IdCardSerializer
 
         # allowed_checkout updates frequently
         cache_options store: nil

--- a/spec/serializers/spree/v2/tenant/guest_serializer_spec.rb
+++ b/spec/serializers/spree/v2/tenant/guest_serializer_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe Spree::V2::Tenant::GuestSerializer, type: :serializer do
     it 'returns exact guest associations' do
       expect(subject[:data][:relationships].keys).to contain_exactly(
         :occupation,
-        :nationality
+        :nationality,
+        :id_card
       )
     end
   end


### PR DESCRIPTION
Added idcard Association field to Guest API 
```json
{
    "data": {
        "id": "3793",
        "type": "guest",
        "attributes": {
            "first_name": null,
            "last_name": null,
            "dob": null,
            "gender": null,
            "kyc_fields": [
                "guest_name",
                "guest_id_card"
            ],
            "other_occupation": null,
            "created_at": "2025-02-27T18:45:16.223+07:00",
            "updated_at": "2025-03-07T16:52:54.703+07:00",
            "qr_data": "00f999cc-467d-4e3e-9ba1-304283690fa4",
            "social_contact_platform": null,
            "social_contact": null,
            "available_social_contact_platforms": [
                "telegram",
                "facebook",
                "wechat",
                "whatsapp",
                "line",
                "viber",
                "other"
            ],
            "age": null,
            "emergency_contact": null,
            "other_organization": null,
            "expectation": null,
            "upload_later": false,
            "address": null,
            "formatted_bib_number": null,
            "phone_number": null,
            "user_id": null,
            "allowed_checkout": false,
            "allowed_upload_later": false,
            "require_kyc_field": true
        },
        "relationships": {
            "occupation": {
                "data": null
            },
            "nationality": {
                "data": null
            },
            "id_card": {
                "data": {
                    "id": "232",
                    "type": "id_card"
                }
            }
        }
    },
    "included": [
        {
            "id": "232",
            "type": "id_card",
            "attributes": {
                "card_type": "passport"
            },
            "relationships": {
                "front_image": {
                    "data": {
                        "id": "1986",
                        "type": "asset"
                    }
                },
                "back_image": {
                    "data": {
                        "id": "1987",
                        "type": "asset"
                    }
                }
            }
        }
    ]
}
```