### PR TITLE
Close #2519 run redis in spec

### DIFF
--- a/.github/workflows/test_and_build_gem.yml
+++ b/.github/workflows/test_and_build_gem.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - develop
+      - milestone-77-scalable-design
   push:
     tags:
       - "*"
@@ -109,6 +110,17 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
+      redis:
+        image: redis
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379 # Maps port 6379 on service container to the host
+
     steps:
       - uses: actions/checkout@v3
 
@@ -144,8 +156,9 @@ jobs:
       - name: Run test
         env:
           DATABASE_URL: postgres://myuser:mypassword@localhost:5432/test_db
+          REDIS_URL: redis://localhost:6379/0
 
-        if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'develop'
+        if: github.event_name == 'pull_request'
         run: |
           bundle exec rake
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'bundler'
 Bundler::GemHelper.install_tasks
 
 require 'rspec/core/rake_task'
-require 'spree/testing_support/extension_rake'
+require 'spree/testing_support/common_rake'
 
 RSpec::Core::RakeTask.new
 
@@ -14,8 +14,37 @@ task :default do
   Rake::Task[:spec].invoke
 end
 
+# Copied from:
+# spree_core:lib/spree/testing_support/common_rake.rb
+# But refactored to skip frontend & backend setup.
 desc 'Generates a dummy app for testing'
-task :test_app do
-  ENV['LIB_NAME'] = 'spree_cm_commissioner'
-  Rake::Task['extension:test_app'].invoke
+task :test_app do |_t, args|
+  require 'spree_cm_commissioner'
+  require "generators/spree_cm_commissioner/install/install_generator"
+
+  Rails.env = ENV['RAILS_ENV'] = 'test'
+
+  Spree::DummyGeneratorHelper.inject_extension_requirements = true
+  Spree::DummyGenerator.start ["--lib_name=spree_cm_commissioner", '--quiet']
+  Spree::InstallGenerator.start [
+    "--lib_name=spree_cm_commissioner",
+    '--auto-accept',
+    '--migrate=false',
+    '--seed=false',
+    '--sample=false',
+    '--quiet',
+    '--copy_storefront=false',
+    "--install_storefront=false",
+    "--install_admin=false",
+    "--user_class=Spree::User"
+  ]
+
+  puts 'Setting up dummy database...'
+  system('bin/rails db:environment:set RAILS_ENV=test')
+  system('bundle exec rake db:drop db:create')
+  Spree::DummyModelGenerator.start
+  system('bundle exec rake db:migrate')
+
+  puts 'Running extension installation generator...'
+  SpreeCmCommissioner::Generators::InstallGenerator.start(['--auto-run-migrations'])
 end

--- a/lib/generators/spree_cm_commissioner/install/install_generator.rb
+++ b/lib/generators/spree_cm_commissioner/install/install_generator.rb
@@ -40,9 +40,17 @@ module SpreeCmCommissioner
                          after: %r{//= require spree/backend}, verbose: true
 
         # For NPM support
-        template 'app/javascript/spree_dashboard/spree_cm_commissioner/utilities.js'
-        inject_into_file 'app/javascript/spree_dashboard/spree-dashboard.js', "\nimport \"./spree_cm_commissioner/utilities.js\"",
-                         after: %r{import "@spree/dashboard"}, verbose: true
+        if File.exist?(File.join(destination_root, 'app/javascript/spree_dashboard'))
+          template 'app/javascript/spree_dashboard/spree_cm_commissioner/utilities.js'
+          inject_into_file 'app/javascript/spree_dashboard/spree-dashboard.js', "\nimport \"./spree_cm_commissioner/utilities.js\"",
+                           after: %r{import "@spree/dashboard"}, verbose: true
+        else
+          Logger.new($stdout).debug <<~MSG
+            SpreeCmCommissioner: JavaScript files for the dashboard are missing.
+            Please move your JavaScript files to the appropriate location in
+            app/javascript/spree_dashboard.
+          MSG
+        end
       end
 
       def install_telegram_web_bot

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -1,0 +1,37 @@
+# spec/redis_spec.rb
+require 'spec_helper'
+require 'redis'
+
+describe 'Redis Connection and Functionality' do
+  let(:redis) { Redis.new(url: ENV['REDIS_URL'] || 'redis://localhost:6379/0') }
+
+  before do
+    # Ensure Redis is flushed before each test to avoid interference
+    redis.flushdb
+  end
+
+  after do
+    # Clean up Redis after each test
+    redis.flushdb
+    redis.quit
+  end
+
+  describe 'Redis connection' do
+    it 'successfully connects to Redis' do
+      expect { redis.ping }.not_to raise_error
+      expect(redis.ping).to eq('PONG')
+    end
+  end
+
+  describe 'Basic Redis functionality' do
+    it 'sets and retrieves a key-value pair' do
+      # Set a key-value pair
+      redis.set('test_key', 'test_value')
+
+      # Retrieve the value
+      value = redis.get('test_key')
+
+      expect(value).to eq('test_value')
+    end
+  end
+end


### PR DESCRIPTION
- Setup Redis for github action
- Use custom generate test_app instead of using default spree
  - Why? to skip installing spree_frontend & spree_backend which minimize spec running spec time.
  - Total github check time (previously ~13-15mn):
    1. 8m 47s (6m 24s for generate app & run spec)
    2. 8m 37s (6m 14s for generate app & run spec)
    3. 9m 3s (6m 32s for generate app & run spec)
    4. 8m 44s (6m 14s for generate app & run spec)