### PR TITLE
Close #2604 add migration for taxon_option_type and taxon_option_value

### DIFF
--- a/app/interactors/spree_cm_commissioner/create_event.rb
+++ b/app/interactors/spree_cm_commissioner/create_event.rb
@@ -10,6 +10,8 @@ module SpreeCmCommissioner
         assign_prototype
         create_child_taxon
         build_home_banner
+        assign_option_types
+        assign_option_values
       end
     end
 
@@ -60,6 +62,27 @@ module SpreeCmCommissioner
       )
 
       context.fail!(message: 'Home banner upload failed') unless banner.persisted?
+    end
+
+    def assign_options(model_class, param_key, foreign_key)
+      return unless params[param_key]
+
+      params[param_key].each do |id|
+        record = model_class.new(
+          taxon_id: @parent_taxon.id,
+          foreign_key => id
+        )
+
+        context.fail!(message: record.errors.full_messages.join(', ')) unless record.save
+      end
+    end
+
+    def assign_option_types
+      assign_options(SpreeCmCommissioner::TaxonOptionType, :option_type_id, :option_type_id)
+    end
+
+    def assign_option_values
+      assign_options(SpreeCmCommissioner::TaxonOptionValue, :option_value_id, :option_value_id)
     end
   end
 end

--- a/app/models/spree_cm_commissioner/taxon_decorator.rb
+++ b/app/models/spree_cm_commissioner/taxon_decorator.rb
@@ -57,6 +57,9 @@ module SpreeCmCommissioner
       base.has_many :event_blazer_queries, class_name: 'SpreeCmCommissioner::TaxonBlazerQuery'
       base.has_many :blazer_queries, through: :event_blazer_queries, class_name: 'Blazer::Query'
 
+      base.has_many :taxon_option_types, class_name: 'SpreeCmCommissioner::TaxonOptionType'
+      base.has_many :taxon_option_values, class_name: 'SpreeCmCommissioner::TaxonOptionValue'
+
       def base.active_homepage_events
         joins(:homepage_section_relatables)
           .joins("INNER JOIN spree_taxons taxon ON taxon.id = cm_homepage_section_relatables.relatable_id
@@ -94,6 +97,14 @@ module SpreeCmCommissioner
                        .where(spree_taxons: { id: child_ids })
                        .pluck('spree_option_types.name')
                        .uniq
+    end
+
+    def selected_option_types
+      taxon_option_types.pluck(:option_type_id)
+    end
+
+    def selected_option_values
+      taxon_option_values.pluck(:option_value_id)
     end
 
     def event_url

--- a/app/models/spree_cm_commissioner/taxon_option_type.rb
+++ b/app/models/spree_cm_commissioner/taxon_option_type.rb
@@ -1,0 +1,8 @@
+require_dependency 'spree_cm_commissioner'
+
+module SpreeCmCommissioner
+  class TaxonOptionType < ApplicationRecord
+    belongs_to :taxon, class_name: 'Spree::Taxon', dependent: :destroy
+    belongs_to :option_type, class_name: 'Spree::OptionType', dependent: :destroy
+  end
+end

--- a/app/models/spree_cm_commissioner/taxon_option_value.rb
+++ b/app/models/spree_cm_commissioner/taxon_option_value.rb
@@ -1,0 +1,8 @@
+require_dependency 'spree_cm_commissioner'
+
+module SpreeCmCommissioner
+  class TaxonOptionValue < ApplicationRecord
+    belongs_to :taxon, class_name: 'Spree::Taxon', dependent: :destroy
+    belongs_to :option_value, class_name: 'Spree::OptionValue', dependent: :destroy
+  end
+end

--- a/db/migrate/20250430091742_create_cm_taxon_option_types.rb
+++ b/db/migrate/20250430091742_create_cm_taxon_option_types.rb
@@ -1,0 +1,9 @@
+class CreateCmTaxonOptionTypes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cm_taxon_option_types do |t|
+      t.references :taxon, null: false, if_not_exists: true
+      t.references :option_type, null: false, if_not_exists: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250430092928_create_cm_taxon_option_values.rb
+++ b/db/migrate/20250430092928_create_cm_taxon_option_values.rb
@@ -1,0 +1,9 @@
+class CreateCmTaxonOptionValues < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cm_taxon_option_values do |t|
+      t.references :taxon, null: false, if_not_exists: true
+      t.references :option_value, null: false, if_not_exists: true
+      t.timestamps
+    end
+  end
+end

--- a/spec/models/spree_cm_commissioner/taxon_option_value_spec.rb
+++ b/spec/models/spree_cm_commissioner/taxon_option_value_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::TaxonOptionValue, type: :model do
+  describe 'associations' do
+    it { should belong_to(:taxon).class_name('Spree::Taxon').dependent(:destroy) }
+    it { should belong_to(:option_value).class_name('Spree::OptionValue').dependent(:destroy)}
+  end
+end


### PR DESCRIPTION
The purpose of this PR is to migrates `taxon-option-types` and `taxon-option-values` so that each event can have its own `taxon-option-types (example: rules)` without depending on `vendor (vendor_option_types)`