### PR TITLE
Close #2606 fix not to deduct stock when not track inventory

### DIFF
--- a/.github/workflows/test_and_build_gem.yml
+++ b/.github/workflows/test_and_build_gem.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - develop
+      - milestone-77-scalable-design
   push:
     tags:
       - "*"
@@ -109,6 +110,17 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
+      redis:
+        image: redis
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379 # Maps port 6379 on service container to the host
+
     steps:
       - uses: actions/checkout@v3
 
@@ -144,8 +156,9 @@ jobs:
       - name: Run test
         env:
           DATABASE_URL: postgres://myuser:mypassword@localhost:5432/test_db
+          REDIS_URL: redis://localhost:6379/0
 
-        if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'develop'
+        if: github.event_name == 'pull_request'
         run: |
           bundle exec rake
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'bundler'
 Bundler::GemHelper.install_tasks
 
 require 'rspec/core/rake_task'
-require 'spree/testing_support/extension_rake'
+require 'spree/testing_support/common_rake'
 
 RSpec::Core::RakeTask.new
 
@@ -14,8 +14,37 @@ task :default do
   Rake::Task[:spec].invoke
 end
 
+# Copied from:
+# spree_core:lib/spree/testing_support/common_rake.rb
+# But refactored to skip frontend & backend setup.
 desc 'Generates a dummy app for testing'
-task :test_app do
-  ENV['LIB_NAME'] = 'spree_cm_commissioner'
-  Rake::Task['extension:test_app'].invoke
+task :test_app do |_t, args|
+  require 'spree_cm_commissioner'
+  require "generators/spree_cm_commissioner/install/install_generator"
+
+  Rails.env = ENV['RAILS_ENV'] = 'test'
+
+  Spree::DummyGeneratorHelper.inject_extension_requirements = true
+  Spree::DummyGenerator.start ["--lib_name=spree_cm_commissioner", '--quiet']
+  Spree::InstallGenerator.start [
+    "--lib_name=spree_cm_commissioner",
+    '--auto-accept',
+    '--migrate=false',
+    '--seed=false',
+    '--sample=false',
+    '--quiet',
+    '--copy_storefront=false',
+    "--install_storefront=false",
+    "--install_admin=false",
+    "--user_class=Spree::User"
+  ]
+
+  puts 'Setting up dummy database...'
+  system('bin/rails db:environment:set RAILS_ENV=test')
+  system('bundle exec rake db:drop db:create')
+  Spree::DummyModelGenerator.start
+  system('bundle exec rake db:migrate')
+
+  puts 'Running extension installation generator...'
+  SpreeCmCommissioner::Generators::InstallGenerator.start(['--auto-run-migrations'])
 end

--- a/lib/generators/spree_cm_commissioner/install/install_generator.rb
+++ b/lib/generators/spree_cm_commissioner/install/install_generator.rb
@@ -40,9 +40,17 @@ module SpreeCmCommissioner
                          after: %r{//= require spree/backend}, verbose: true
 
         # For NPM support
-        template 'app/javascript/spree_dashboard/spree_cm_commissioner/utilities.js'
-        inject_into_file 'app/javascript/spree_dashboard/spree-dashboard.js', "\nimport \"./spree_cm_commissioner/utilities.js\"",
-                         after: %r{import "@spree/dashboard"}, verbose: true
+        if File.exist?(File.join(destination_root, 'app/javascript/spree_dashboard'))
+          template 'app/javascript/spree_dashboard/spree_cm_commissioner/utilities.js'
+          inject_into_file 'app/javascript/spree_dashboard/spree-dashboard.js', "\nimport \"./spree_cm_commissioner/utilities.js\"",
+                           after: %r{import "@spree/dashboard"}, verbose: true
+        else
+          Logger.new($stdout).debug <<~MSG
+            SpreeCmCommissioner: JavaScript files for the dashboard are missing.
+            Please move your JavaScript files to the appropriate location in
+            app/javascript/spree_dashboard.
+          MSG
+        end
       end
 
       def install_telegram_web_bot

--- a/spec/models/spree_cm_commissioner/redis_stock/inventory_updater_spec.rb
+++ b/spec/models/spree_cm_commissioner/redis_stock/inventory_updater_spec.rb
@@ -1,199 +1,201 @@
 require 'spec_helper'
 
 RSpec.describe SpreeCmCommissioner::RedisStock::InventoryUpdater do
-  let(:redis) { double('Redis') }
-  let(:redis_pool) { double('RedisPool') }
-  let(:real_redis) { Redis.new(url: ENV['REDIS_URL'] || 'redis://localhost:6379/1') }
-  let(:line_item_ids) { [1, 2] }
-  let(:line_items) do
-    [
-      instance_double(Spree::LineItem, id: 1, variant_id: 101, quantity: 2),
-      instance_double(Spree::LineItem, id: 2, variant_id: 102, quantity: 3)
-    ]
-  end
-  let(:cached_inventory_items) do
-    [
-      instance_double(SpreeCmCommissioner::CachedInventoryItem,
-                      inventory_key: 'inventory:1',
-                      quantity_available: 2,
-                      inventory_item_id: 1,
-                      variant_id: 101),
-      instance_double(SpreeCmCommissioner::CachedInventoryItem,
-                      inventory_key: 'inventory:2',
-                      quantity_available: 3,
-                      inventory_item_id: 2,
-                      variant_id: 102)
-    ]
-  end
-
-  subject { described_class.new(line_item_ids) }
-
-  before do
-    allow(Spree::LineItem).to receive(:where).with(id: line_item_ids).and_return(line_items)
-    allow(SpreeCmCommissioner::RedisStock::LineItemsCachedInventoryItemsBuilder)
-      .to receive(:new).with(line_item_ids: line_item_ids).and_return(double(call: { 1 => cached_inventory_items }))
-    allow(SpreeCmCommissioner).to receive(:redis_pool).and_return(redis_pool)
-    allow(redis_pool).to receive(:with).and_yield(redis)
-  end
-
   describe '#unstock!' do
-    context 'when stock is sufficient' do
-      before do
-        allow(redis).to receive(:eval).and_return(1)
-        allow(SpreeCmCommissioner::InventoryItemSyncerJob).to receive(:perform_later)
-      end
+    let(:line_item1) { Spree::LineItem.new(id: 91, variant_id: 1, quantity: 3) }
+    subject { described_class.new([line_item1.id]) }
 
-      it 'unstocks inventory successfully' do
-        expect(redis).to receive(:eval).with(subject.send(:unstock_redis_script),
-                                            keys: ['inventory:1', 'inventory:2'],
-                                            argv: [2, 3])
-        expect(SpreeCmCommissioner::InventoryItemSyncerJob).to receive(:perform_later).with(
-          inventory_id_and_quantities: [
-            { inventory_id: 1, quantity: -2 },
-            { inventory_id: 2, quantity: -3 }
-          ]
-        )
+    context 'when unstock success' do
+      it 'extract_inventory_data, unstock from redis & schedule_sync_inventory to db' do
+        expect(subject).to receive(:extract_inventory_data).and_return([['inventory:112', 'inventory:113'], [3, 3], [112,113]])
+        expect(subject).to receive(:unstock).and_return(true)
+        expect(subject).to receive(:schedule_sync_inventory).with([{:inventory_id => 112, :quantity => -3}, {:inventory_id => 113, :quantity => -3}])
 
         subject.unstock!
       end
     end
 
-    context 'when stock is insufficient' do
-      before do
-        allow(redis).to receive(:eval).and_return(0)
-      end
+    context 'when failed to unstock' do
+      it 'extract_inventory_data, unstock from redis & throw the error' do
+        expect(subject).to receive(:extract_inventory_data).and_return([['inventory:112', 'inventory:113'], [3, 3], [112,113]])
+        expect(subject).to receive(:unstock).and_return(false)
 
-      it 'raises UnableToUnstock error' do
         expect {
           subject.unstock!
-        }.to raise_error(SpreeCmCommissioner::RedisStock::InventoryUpdater::UnableToUnstock,
-                        Spree.t(:insufficient_stock_lines_present))
+        }.to raise_error(described_class::UnableToUnstock, Spree.t(:insufficient_stock_lines_present))
       end
     end
   end
 
   describe '#restock!' do
-    before do
-      allow(redis).to receive(:eval).and_return(1)
-      allow(SpreeCmCommissioner::InventoryItemSyncerJob).to receive(:perform_later)
-    end
+    let(:line_item1) { Spree::LineItem.new(id: 91, variant_id: 1, quantity: 3) }
+    subject { described_class.new([line_item1.id]) }
 
-    it 'restocks inventory successfully' do
-      expect(redis).to receive(:eval).with(subject.send(:restock_redis_script),
-                                          keys: ['inventory:1', 'inventory:2'],
-                                          argv: [2, 3])
-      expect(SpreeCmCommissioner::InventoryItemSyncerJob).to receive(:perform_later).with(
-        inventory_id_and_quantities: [
-          { inventory_id: 1, quantity: 2 },
-          { inventory_id: 2, quantity: 3 }
-        ]
-      )
+    context 'when restock success' do
+      it 'extract_inventory_data, restock from redis & schedule_sync_inventory to db' do
+        expect(subject).to receive(:extract_inventory_data).and_return([['inventory:112', 'inventory:113'], [3, 3], [112,113]])
+        expect(subject).to receive(:restock).and_return(true)
+        expect(subject).to receive(:schedule_sync_inventory).with([{:inventory_id => 112, :quantity => 3}, {:inventory_id => 113, :quantity => 3}])
 
-      subject.restock!
-    end
-
-    context 'when restock fails' do
-      before do
-        allow(redis).to receive(:eval).and_return(0)
+        subject.restock!
       end
+    end
 
-      it 'raises UnableToRestock error' do
+    context 'when failed to restock' do
+      it 'extract_inventory_data, restock from redis & throw the error' do
+        expect(subject).to receive(:extract_inventory_data).and_return([['inventory:112', 'inventory:113'], [3, 3], [112,113]])
+        expect(subject).to receive(:restock).and_return(false)
+
         expect {
           subject.restock!
-        }.to raise_error(SpreeCmCommissioner::RedisStock::InventoryUpdater::UnableToRestock)
+        }.to raise_error(described_class::UnableToRestock)
       end
     end
   end
 
-  context 'with real Redis' do
-    before do
-      # Set up initial Redis state
-      real_redis.set('inventory:1', 10) # Sufficient stock for quantity 2
-      real_redis.set('inventory:2', 10) # Sufficient stock for quantity 3
+  describe '#extract_inventory_data' do
+    let(:line_item1) { Spree::LineItem.new(id: 91, variant_id: 1, quantity: 3) }
+    let(:line_item2) { Spree::LineItem.new(id: 92, variant_id: 2, quantity: 3) }
 
-      # Override redis_pool to yield real_redis
-      allow(redis_pool).to receive(:with).and_yield(real_redis)
-      allow(SpreeCmCommissioner::InventoryItemSyncerJob).to receive(:perform_later)
+    let(:line_item_ids) { [line_item1.id, line_item2.id] }
+
+    subject { described_class.new(line_item_ids) }
+
+    # no db needed, it do entirely in class object level.
+    it 'construct inventory_data from cached_inventory_items & quantity from line_items' do
+      expect(subject).to receive(:cached_inventory_items).and_return([
+        SpreeCmCommissioner::CachedInventoryItem.new(
+          inventory_key: 'inventory:112',
+          active: true,
+          quantity_available: 3,
+          inventory_item_id: 112,
+          variant_id: 1,
+        ),
+        SpreeCmCommissioner::CachedInventoryItem.new(
+          inventory_key: 'inventory:113',
+          active: true,
+          quantity_available: 3,
+          inventory_item_id: 113,
+          variant_id: 2,
+        ),
+      ])
+
+      expect(subject).to receive(:line_items).twice.and_return([
+        line_item1,
+        line_item2
+      ])
+
+      expect(subject.send(:extract_inventory_data)).to eq [["inventory:112", "inventory:113"], [3, 3], [112, 113]]
+    end
+  end
+
+
+  describe '#cached_inventory_items' do
+    let(:line_item1) { Spree::LineItem.new(id: 91, variant_id: 1, quantity: 3) }
+    let(:line_item2) { Spree::LineItem.new(id: 92, variant_id: 2, quantity: 3) }
+
+    let(:line_item_ids) { [line_item1.id, line_item2.id] }
+
+    subject { described_class.new(line_item_ids) }
+
+    it 'call SpreeCmCommissioner::RedisStock::LineItemsCachedInventoryItemsBuilder with only line item return from line_items method' do
+      expect(subject).to receive(:line_items).once.and_return([line_item1])
+
+      # even there are 2 line items passed, if line_items return 1, it will recieve one
+      expect(SpreeCmCommissioner::RedisStock::LineItemsCachedInventoryItemsBuilder).to receive(:new).with(line_item_ids: [line_item1.id]).and_call_original
+      expect_any_instance_of(SpreeCmCommissioner::RedisStock::LineItemsCachedInventoryItemsBuilder).to receive(:call).and_return({})
+
+      subject.send(:cached_inventory_items)
+    end
+  end
+
+  # we want to unstock variant that aren't meet these condition
+  # so line item method should only return line items that ready.
+  describe '#line_items' do
+    context 'when line items is not_track_inventory, backorderable, or need_confirmation' do
+      let(:not_available_variant) { double(:variant, id: 33, available?: false) }
+      let(:not_track_inventory_variant) { double(:variant, id: 33, available?: true, should_track_inventory?: false) }
+      let(:backorderable_variant) { double(:variant, id: 34, available?: true, should_track_inventory?: true, backorderable?: true) }
+      let(:need_confirmation_variant) { double(:variant, id: 35, available?: true, should_track_inventory?: true, backorderable?: false, need_confirmation?: true) }
+      let(:eligible_variant) { double(:variant, id: 36, available?: true, should_track_inventory?: true, backorderable?: false, need_confirmation?: false) }
+
+      let(:not_available_line_item) { double(:line_item, id: 93, quantity: 3, variant: not_available_variant) }
+      let(:not_track_inventory_line_item) { double(:line_item, id: 93, quantity: 3, variant: not_track_inventory_variant) }
+      let(:backorderable_line_item) { double(:line_item, id: 91, quantity: 3, variant: backorderable_variant) }
+      let(:need_confirmation_line_item) { double(:line_item, id: 92, quantity: 3, variant: need_confirmation_variant) }
+      let(:eligible_line_item) { double(:line_item, id: 94, quantity: 3, variant: eligible_variant) }
+
+      let(:line_items) { [ not_available_line_item, not_track_inventory_line_item, backorderable_line_item, need_confirmation_line_item, eligible_line_item ] }
+      let(:line_item_ids) { line_items.map(&:id) }
+
+      subject { described_class.new(line_item_ids) }
+
+      it 'filtered & return only 1 line item which track inventory, not backorderable & not need confirmation' do
+        expect(Spree::LineItem).to receive(:where).with(id: line_item_ids).and_return(line_items)
+        expect(line_items).to receive(:includes).with(variant: :stock_items).and_return(line_items)
+
+        expect(subject.send(:line_items)).to eq([eligible_line_item])
+      end
+    end
+  end
+
+  context 'unstock/restock with real redis' do
+    subject { described_class.new([]) }
+
+    before do
+      SpreeCmCommissioner.redis_pool.with do |redis|
+        redis.set('inventory:1', 5)
+        redis.set('inventory:2', 5)
+      end
     end
 
+    # Clean up Redis keys
     after do
-      # Clean up Redis keys
-      real_redis.del('inventory:1', 'inventory:2')
+      SpreeCmCommissioner.redis_pool.with do |redis|
+        redis.del('inventory:1', 'inventory:2')
+      end
     end
 
-    describe '#unstock!' do
-      it 'unstocks inventory and updates Redis' do
-        expect {
-          subject.unstock!
-        }.to change {
-          [real_redis.get('inventory:1').to_i, real_redis.get('inventory:2').to_i]
-        }.from([10, 10]).to([8, 7])
+    # unstock with real redis
+    describe '#unstock' do
+      context 'when final stock >= 0' do
+        it 'subtract the quantity from redis & return TRUE' do
+          keys = ['inventory:1', 'inventory:2']
+          quantities = [3, 5]
 
-        expect(SpreeCmCommissioner::InventoryItemSyncerJob).to have_received(:perform_later).with(
-          inventory_id_and_quantities: [
-            { inventory_id: 1, quantity: -2 },
-            { inventory_id: 2, quantity: -3 }
-          ]
-        )
-      end
+          success = subject.send(:unstock, keys, quantities)
+          result = SpreeCmCommissioner.redis_pool.with { |redis| redis.mget(keys) }
 
-      context 'when stock is insufficient' do
-        before do
-          real_redis.set('inventory:1', 1) # Insufficient for quantity 2
-        end
-
-        it 'raises UnableToUnstock error' do
-          expect {
-            subject.unstock!
-          }.to raise_error(SpreeCmCommissioner::RedisStock::InventoryUpdater::UnableToUnstock,
-                          Spree.t(:insufficient_stock_lines_present))
+          expect(result).to eq(["2", "0"])
+          expect(success).to be true
         end
       end
-    end
 
-    describe '#restock!' do
-      it 'restocks inventory and updates Redis' do
-        expect {
-          subject.restock!
-        }.to change {
-          [real_redis.get('inventory:1').to_i, real_redis.get('inventory:2').to_i]
-        }.from([10, 10]).to([12, 13])
+      context 'when final stock < 0' do
+        it 'keep original redis quantity & return FALSE' do
+          keys = ['inventory:1', 'inventory:2']
+          quantities = [3, 6]
 
-        expect(SpreeCmCommissioner::InventoryItemSyncerJob).to have_received(:perform_later).with(
-          inventory_id_and_quantities: [
-            { inventory_id: 1, quantity: 2 },
-            { inventory_id: 2, quantity: 3 }
-          ]
-        )
-      end
-    end
-  end
+          success = subject.send(:unstock, keys, quantities)
+          result = SpreeCmCommissioner.redis_pool.with { |redis| redis.mget(keys) }
 
-  describe 'private methods' do
-    describe '#unstock_redis_script' do
-      it 'returns correct Lua script' do
-        script = subject.send(:unstock_redis_script)
-        expect(script).to include('local keys = KEYS')
-        expect(script).to include('local quantities = ARGV')
-        expect(script).to include("redis.call('DECRBY', key, tonumber(quantities[i]))")
+          expect(result).to eq(["5", "5"])
+          expect(success).to be false
+        end
       end
     end
 
-    describe '#restock_redis_script' do
-      it 'returns correct Lua script' do
-        script = subject.send(:restock_redis_script)
-        expect(script).to include('local keys = KEYS')
-        expect(script).to include('local quantities = ARGV')
-        expect(script).to include("redis.call('INCRBY', key, tonumber(quantities[i]))")
-      end
-    end
+    # restock with real redis
+    describe '#restock' do
+      it 'add the quantity to redis & return true' do
+        keys = ['inventory:1', 'inventory:2']
+        quantities = [3, 6]
 
-    describe '#extract_inventory_data' do
-      it 'returns keys, quantities, and inventory_ids' do
-        keys, quantities, inventory_ids = subject.send(:extract_inventory_data)
-        expect(keys).to eq(['inventory:1', 'inventory:2'])
-        expect(quantities).to eq([2, 3])
-        expect(inventory_ids).to eq([1, 2])
+        success = subject.send(:restock, keys, quantities)
+        result = SpreeCmCommissioner.redis_pool.with { |redis| redis.mget(keys) }
+
+        expect(result).to eq(["8", "11"])
+        expect(success).to be true
       end
     end
   end

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -1,0 +1,37 @@
+# spec/redis_spec.rb
+require 'spec_helper'
+require 'redis'
+
+describe 'Redis Connection and Functionality' do
+  let(:redis) { Redis.new(url: ENV['REDIS_URL'] || 'redis://localhost:6379/0') }
+
+  before do
+    # Ensure Redis is flushed before each test to avoid interference
+    redis.flushdb
+  end
+
+  after do
+    # Clean up Redis after each test
+    redis.flushdb
+    redis.quit
+  end
+
+  describe 'Redis connection' do
+    it 'successfully connects to Redis' do
+      expect { redis.ping }.not_to raise_error
+      expect(redis.ping).to eq('PONG')
+    end
+  end
+
+  describe 'Basic Redis functionality' do
+    it 'sets and retrieves a key-value pair' do
+      # Set a key-value pair
+      redis.set('test_key', 'test_value')
+
+      # Retrieve the value
+      value = redis.get('test_key')
+
+      expect(value).to eq('test_value')
+    end
+  end
+end


### PR DESCRIPTION
## Why not to deduct?
In Spree, shipment doesn’t deduct stock for line items that don’t track inventory or backorderable, need confirmation, or unavailable, currently we don't do the same when restock/unstock from redis. We should follow Spree’s behavior.

This PR skips restock/unstock for those line items.