### PR TITLE
Close #2577 add log to critical logic code

### DIFF
--- a/app/jobs/spree_cm_commissioner/application_job.rb
+++ b/app/jobs/spree_cm_commissioner/application_job.rb
@@ -1,5 +1,25 @@
 module SpreeCmCommissioner
   class ApplicationJob < ::ApplicationJob
     queue_as :default
+
+    around_perform :log_exceptions
+
+    private
+
+    def log_exceptions
+      yield
+    rescue StandardError => e
+      CmAppLogger.log(
+        label: "#{self.class.name} failed",
+        data: {
+          error_class: e.class.name,
+          error_message: e.message,
+          arguments: arguments.inspect,
+          backtrace: e.backtrace&.first(5)&.join("\n")
+        }
+      )
+
+      raise # Re-raise the exception to let Sidekiq handle retries or failure
+    end
   end
 end

--- a/app/jobs/spree_cm_commissioner/application_unique_job.rb
+++ b/app/jobs/spree_cm_commissioner/application_unique_job.rb
@@ -2,5 +2,25 @@
 module SpreeCmCommissioner
   class ApplicationUniqueJob < ::ApplicationUniqueJob
     queue_as :default
+
+    around_perform :log_exceptions
+
+    private
+
+    def log_exceptions
+      yield
+    rescue StandardError => e
+      CmAppLogger.log(
+        label: "#{self.class.name} failed",
+        data: {
+          error_class: e.class.name,
+          error_message: e.message,
+          arguments: arguments.inspect,
+          backtrace: e.backtrace&.first(5)&.join("\n")
+        }
+      )
+
+      raise # Re-raise the exception to let Sidekiq handle retries or failure
+    end
   end
 end

--- a/app/models/concerns/spree_cm_commissioner/order_state_machine.rb
+++ b/app/models/concerns/spree_cm_commissioner/order_state_machine.rb
@@ -78,16 +78,16 @@ module SpreeCmCommissioner
         # and neither the `finalize!` method nor any notifications will be triggered.
         # The payment will be reversed in vPago gem, and `Spree::Checkout::Complete` will be called, which checks `order.reload.complete?`.
         # This is critical because if the order state is complete, the payment will be marked as paid.
-        CmAppLogger.log(label: 'order_state_machine_before_unstock', data: { order_id: id, state: state })
-        unstock_inventory_in_redis!
+        CmAppLogger.log(label: 'order_state_machine_unstock', data: { order_id: id, state: state }) do
+          unstock_inventory_in_redis!
+        end
         # We rollback only order state, and we keep payment state as it is.
         # We implement payment in vPago gem, and it will be reversed in the gem.
         # Some bank has api for refund, but some don't have the api to refund yet. So we keep the payment state as it is and refund manually.
-        CmAppLogger.log(label: 'order_state_machine_after_unstock', data: { order_id: id, state: state })
       end
     rescue StandardError => e
       CmAppLogger.log(label: 'order_state_machine',
-                      data: { order_id: id, error: e.message, type: e.class.name, backtrace: e.backtrace.first(5).join("\n") }
+                      data: { order_id: id, error: e.message, type: e.class.name, backtrace: e.backtrace&.first(5)&.join("\n") }
                      )
       raise e
     end

--- a/app/models/spree_cm_commissioner/order_decorator.rb
+++ b/app/models/spree_cm_commissioner/order_decorator.rb
@@ -202,11 +202,15 @@ module SpreeCmCommissioner
     private
 
     def unstock_inventory_in_redis!
-      SpreeCmCommissioner::RedisStock::InventoryUpdater.new(line_item_ids).unstock!
+      CmAppLogger.log(label: "#{self.class.name}#unstock_inventory_in_redis", data: { order_id: id }) do
+        SpreeCmCommissioner::RedisStock::InventoryUpdater.new(line_item_ids).unstock!
+      end
     end
 
     def restock_inventory_in_redis!
-      SpreeCmCommissioner::RedisStock::InventoryUpdater.new(line_item_ids).restock!
+      CmAppLogger.log(label: "#{self.class.name}restock_inventory_in_redis", data: { order_id: id }) do
+        SpreeCmCommissioner::RedisStock::InventoryUpdater.new(line_item_ids).restock!
+      end
     end
 
     # override :spree_api

--- a/app/models/spree_cm_commissioner/stock_item_decorator.rb
+++ b/app/models/spree_cm_commissioner/stock_item_decorator.rb
@@ -20,7 +20,10 @@ module SpreeCmCommissioner
 
     # When admin delete stock item, it will deduct stock from inventory item
     def adjust_inventory_items_async
-      SpreeCmCommissioner::Stock::InventoryItemsAdjusterJob.perform_later(variant_id: variant_id, quantity: -count_on_hand)
+      params = { variant_id: variant.id, quantity: -count_on_hand }
+      CmAppLogger.log(label: "#{self.class.name}:after_destroy#adjust_inventory_items_async", data: params) do
+        SpreeCmCommissioner::Stock::InventoryItemsAdjusterJob.perform_later(**params)
+      end
     end
   end
 end

--- a/lib/cm_app_logger.rb
+++ b/lib/cm_app_logger.rb
@@ -1,11 +1,18 @@
 # lib/cm_app_logger.rb
 module CmAppLogger
   def self.log(label:, data: nil)
-    message = {
-      label: label,
-      data: data
-    }
-
+    message = { label: label, data: data }
+    start_time = Time.current
     Rails.logger.info(message.to_json)
+
+    return unless block_given?
+
+    # Capture the block’s return value and return it to preserve existing behavior for callers expecting that value.
+    block_result = yield
+
+    message[:start_time] = start_time
+    message[:duration_ms] = (Time.current - start_time) * 1000
+    Rails.logger.info(message.to_json)
+    block_result
   end
 end

--- a/spec/jobs/spree_cm_commissioner/application_job_spec.rb
+++ b/spec/jobs/spree_cm_commissioner/application_job_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::ApplicationJob, type: :job do
+  include ActiveJob::TestHelper
+
+  # Sample job class for testing
+  class TestApplicationJob < described_class
+    def perform(*args)
+      raise "Test error" if args.first == :raise_error
+      # Simulate successful job execution
+      true
+    end
+  end
+
+  let(:job_arguments) { [123, "update"] }
+  let(:error) { StandardError.new("Test error") }
+
+  before do
+    ActiveJob::Base.queue_adapter = :test
+    ActiveJob::Base.queue_adapter.performed_jobs.clear
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
+    ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = true
+
+    # Stub CmAppLogger to avoid actual logging and capture the call
+    allow(CmAppLogger).to receive(:log)
+  end
+
+  describe "#log_exceptions" do
+    context "when an exception is raised" do
+      it "logs the error details and re-raises the exception" do
+        expect(CmAppLogger).to receive(:log)
+
+        # Expect the exception to be re-raised
+        expect {
+          TestApplicationJob.perform_later(:raise_error, "update")
+        }.to raise_error(StandardError, "Test error")
+      end
+    end
+
+    context "when no exception is raised" do
+      it "does not log anything and completes the job" do
+        expect(CmAppLogger).not_to receive(:log)
+
+        perform_enqueued_jobs do
+          TestApplicationJob.perform_later(*job_arguments)
+        end
+
+        # Verify the job was executed without errors
+        expect(TestApplicationJob).to have_been_performed.with(*job_arguments)
+      end
+    end
+  end
+end

--- a/spec/jobs/spree_cm_commissioner/application_unique_job_spec.rb
+++ b/spec/jobs/spree_cm_commissioner/application_unique_job_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::ApplicationUniqueJob, type: :job do
+  include ActiveJob::TestHelper
+
+  # Sample job class for testing
+  class TestUniqueJob < described_class
+    def perform(*args)
+      raise "Test error" if args.first == :raise_error
+      # Simulate successful job execution
+      true
+    end
+  end
+
+  let(:job_arguments) { [123, "update"] }
+  let(:error) { StandardError.new("Test error") }
+
+  before do
+    ActiveJob::Base.queue_adapter = :test
+    ActiveJob::Base.queue_adapter.performed_jobs.clear
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
+    ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = true
+
+    # Stub CmAppLogger to avoid actual logging and capture the call
+    allow(CmAppLogger).to receive(:log)
+  end
+
+  describe "#log_exceptions" do
+    context "when an exception is raised" do
+      it "logs the error details and re-raises the exception" do
+        expect(CmAppLogger).to receive(:log)
+
+        # Expect the exception to be re-raised
+        expect {
+          TestUniqueJob.perform_later(:raise_error, "update")
+        }.to raise_error(StandardError, "Test error")
+
+      end
+    end
+
+    context "when no exception is raised" do
+      it "does not log anything and completes the job" do
+        expect(CmAppLogger).not_to receive(:log)
+
+        perform_enqueued_jobs do
+          TestUniqueJob.perform_later(*job_arguments)
+        end
+
+        # Verify the job was executed without errors
+        expect(TestUniqueJob).to have_been_performed.with(*job_arguments)
+      end
+    end
+  end
+end

--- a/spec/lib/cm_app_logger_spec.rb
+++ b/spec/lib/cm_app_logger_spec.rb
@@ -2,19 +2,65 @@ require 'spec_helper'
 
 RSpec.describe CmAppLogger do
   describe '.log' do
-    let(:label) { 'Log Label' }
+    let(:label) { 'test_event' }
     let(:data) { { key: 'value' } }
-    let(:expected_message) { { label: label, data: data }.to_json }
+    let(:message) { { label: label, data: data } }
+    let(:current_time) { Time.current }
 
-    it 'logs the message with the correct format' do
-      expect(Rails.logger).to receive(:info).with(expected_message)
-      CmAppLogger.log(label: label, data: data)
+    before do
+      # Mock Rails.logger
+      allow(Rails.logger).to receive(:info)
+      # Freeze time for consistent duration calculations
+      allow(Time).to receive(:current).and_return(current_time)
     end
 
-    it 'logs the message without data' do
-      expected_message_without_data = { label: label, data: nil }.to_json
-      expect(Rails.logger).to receive(:info).with(expected_message_without_data)
-      CmAppLogger.log(label: label)
+    context 'without a block' do
+      it 'logs a message with label and data' do
+        expect(Rails.logger).to receive(:info).with(message.to_json)
+        CmAppLogger.log(label: label, data: data)
+      end
+
+      it 'logs a message with label only when data is nil' do
+        message = { label: label, data: nil }
+        expect(Rails.logger).to receive(:info).with(message.to_json)
+        CmAppLogger.log(label: label)
+      end
+
+      it 'does not yield or log a second message' do
+        expect(Rails.logger).to receive(:info).once.with({ label: label, data: nil }.to_json)
+        CmAppLogger.log(label: label)
+      end
+    end
+
+    context 'with a block' do
+      it 'logs the initial message, yields, and logs the message with duration' do
+        # Simulate time passing (100ms)
+        allow(Time).to receive(:current).and_return(current_time, current_time + 0.1)
+        message_with_duration = message.merge(start_time: current_time, duration_ms: 100.0)
+
+        expect(Rails.logger).to receive(:info).with(message.to_json).ordered
+        expect(Rails.logger).to receive(:info).with(message_with_duration.to_json).ordered
+        expect { |b| CmAppLogger.log(label: label, data: data, &b) }.to yield_control
+
+        CmAppLogger.log(label: label, data: data) { :do_something }
+      end
+
+      it 'yields to the provided block' do
+        block_called = false
+        CmAppLogger.log(label: label) { block_called = true }
+        expect(block_called).to be true
+      end
+
+      it 'calculates duration_ms correctly' do
+        # Simulate 50ms passing
+        allow(Time).to receive(:current).and_return(current_time, current_time + 0.05)
+        message_with_duration = { label: label, data: nil, start_time: current_time, duration_ms: 50.0 }
+
+        expect(Rails.logger).to receive(:info).with({ label: label, data: nil }.to_json).ordered
+        expect(Rails.logger).to receive(:info).with(message_with_duration.to_json).ordered
+
+        CmAppLogger.log(label: label) { :do_something }
+      end
     end
   end
 end


### PR DESCRIPTION
## What does this PR do?
Applies logging to critical logic code for improved tracking and debugging.
- Adds logging for unstock operations
- Adds logging for restock operations
- Adds logging for stock adjustments
- Add a log when running jobs and raise an exception 

**Screenshot**
<img width="1511" alt="Screenshot 2025-05-22 at 4 20 28 PM" src="https://github.com/user-attachments/assets/b0635c3d-50f0-428f-a37d-6f37bc8ac8a3" />
