### PR TITLE
Close #2624 implement create ticket service

### DIFF
--- a/app/interactors/spree_cm_commissioner/create_ticket.rb
+++ b/app/interactors/spree_cm_commissioner/create_ticket.rb
@@ -1,0 +1,95 @@
+module SpreeCmCommissioner
+  class CreateTicket
+    include Interactor
+    delegate :params, to: :context
+
+    def call
+      ActiveRecord::Base.transaction do
+        create_ticket
+        set_option_value
+        create_variant
+        create_stock_item
+      end
+    end
+
+    private
+
+    def create_ticket
+      @ticket = Spree::Product.new(ticket_params)
+
+      assign_store
+      assign_event
+      return if @ticket.save
+
+      context.fail!(message: @ticket.errors.full_messages.join(', '))
+    end
+
+    def assign_store
+      @store = Spree::Store.default
+      @ticket.stores << @store
+    end
+
+    def assign_event
+      # Find the event taxon using the event_id from the parameters.
+      # It looks for a taxon with a slug like "events-{event_id}" and picks its first child.
+      @event = Spree::Taxon.find_by(slug: "events-#{params[:event_id]}")&.children&.first
+      if @event
+        @ticket.taxons << @event
+      else
+        context.fail!(message: 'Event not found.')
+      end
+    end
+
+    def set_option_value
+      @option_type = Spree::OptionType.find_or_create_by!(
+        name: 'ticket-type',
+        presentation: 'Ticket Type'
+      )
+
+      @option_value = Spree::OptionValue.find_or_create_by!(
+        name: @ticket.name,
+        presentation: @ticket.name,
+        option_type_id: @option_type.id
+      )
+    end
+
+    def create_variant
+      @variant = @ticket.variants.new(
+        price: @ticket.price,
+        compare_at_price: @ticket.compare_at_price,
+        option_value_ids: [@option_value.id]
+      )
+      return if @variant.save
+
+      context.fail!(message: @variant.errors.full_messages.join(', '))
+    end
+
+    def create_stock_item
+      @stock_item = Spree::StockItem.new(
+        variant_id: @variant.id,
+        stock_location_id: context.params[:stock_location_id],
+        count_on_hand: context.params[:count_on_hand]
+      )
+      return if @stock_item.save
+
+      context.fail!(message: @stock_item.errors.full_messages.join(', '))
+    end
+
+    def ticket_params
+      {
+        name: context.params[:name],
+        price: context.params[:price],
+        compare_at_price: context.params[:compare_at_price],
+        max_order_quantity: context.params[:max_order_quantity],
+        available_on: context.params[:available_on],
+        discontinue_on: context.params[:discontinue_on],
+        description: context.params[:description],
+        product_type: context.params[:product_type],
+        vendor_id: context.params[:vendor_id],
+        status: context.params[:status],
+        shipping_category_id: context.params[:shipping_category_id],
+        option_type_ids: context.params[:option_type_ids]
+      }
+    end
+  end
+end

--- a/db/migrate/20250509075429_add_max_order_quantity_to_spree_product.rb
+++ b/db/migrate/20250509075429_add_max_order_quantity_to_spree_product.rb
@@ -1,0 +1,5 @@
+class AddMaxOrderQuantityToSpreeProduct < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_products, :max_order_quantity, :integer, if_not_exists: true
+  end
+end

--- a/spec/models/spree_cm_commissioner/create_ticket_spec.rb
+++ b/spec/models/spree_cm_commissioner/create_ticket_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::CreateTicket, type: :interactor do
+  let(:taxonomy) { create(:taxonomy, name: 'Events', kind: :event) }
+  let(:event) { create(:taxon, taxonomy: taxonomy, name: 'BunPhum') }
+  let(:section) { create(:taxon, name: 'Ticket Type', taxonomy: taxonomy, parent: event) }
+
+  let!(:store) { create(:store, default: true) }
+  let!(:shipping_category) { create(:shipping_category) }
+  let!(:stock_location) { create(:stock_location) }
+  let!(:vendor) { create(:cm_vendor) }
+
+  let(:base_params) do
+    {
+      name: 'Test Ticket',
+      price: 123,
+      count_on_hand: 500,
+      max_order_quantity: 5,
+      option_type_ids: [],
+      vendor_id: vendor.id,
+      product_type: 'ecommerce',
+      shipping_category_id: shipping_category.id,
+      stock_location_id: stock_location.id,
+      event_id: event.event_slug,
+      action: 'create'
+    }
+  end
+
+  before do
+    event.children = [section]
+    event.save!
+    event.reload
+  end
+
+  describe 'Ticket creation' do
+    it 'creates a ticket with correct attributes' do
+
+      result = described_class.call(params: base_params)
+      ticket = Spree::Product.last
+
+      expect(result).to be_success
+      expect(ticket.name).to eq('Test Ticket')
+      expect(ticket.price.to_f).to eq(123.0)
+      expect(ticket.vendor_id).to eq(vendor.id)
+    end
+  end
+
+  describe 'Store assignment' do
+    it 'assigns the default store to the ticket' do
+
+      described_class.call(params: base_params)
+      ticket = Spree::Product.last
+
+      expect(ticket.stores).to include(store)
+    end
+  end
+
+  describe 'Event assignment' do
+    context 'when event exists' do
+      it 'assigns the section taxon to the ticket' do
+
+        described_class.call(params: base_params)
+        ticket = Spree::Product.last
+
+        expect(ticket.taxons).to include(section)
+      end
+    end
+
+    context 'when event does not exist' do
+      it 'fails with appropriate message' do
+
+        invalid_params = base_params.merge(event_id: 'unknown')
+        result = described_class.call(params: invalid_params)
+
+        expect(result).to be_failure
+        expect(result.message).to eq('Event not found.')
+      end
+    end
+  end
+
+  describe 'Variant creation' do
+    it 'creates a variant for the ticket' do
+      described_class.call(params: base_params)
+      ticket = Spree::Product.last
+      variant = ticket.variants.first
+
+      expect(variant).to be_present
+      expect(variant.price.to_f).to eq(ticket.price.to_f)
+    end
+  end
+
+  describe 'Stock item creation' do
+    it 'creates a stock item for the variant' do
+      described_class.call(params: base_params)
+      variant = Spree::Product.last.variants.first
+      stock_item = variant.stock_items.first
+
+      expect(stock_item).to be_present
+      expect(stock_item.count_on_hand).to eq(500)
+    end
+  end
+end


### PR DESCRIPTION
This PR, we implement a `CreateTicket` service that handles the ticket creation process in one transaction. The process include: 

- Create the ticket

- Link ticket to the event

- Create variant

- Add stock

If any step fails, the whole process is rolled back to prevent data from being saved.