### PR TITLE
Close #2632 Tenant CmsPages API

### DIFF
--- a/app/controllers/spree/admin/cms_pages_controller_decorator.rb
+++ b/app/controllers/spree/admin/cms_pages_controller_decorator.rb
@@ -1,0 +1,32 @@
+module Spree
+  module Admin
+    module CmsPagesControllerDecorator
+      def scope
+        return Spree::CmsPage.none unless current_store&.cms_pages
+
+        scope = current_store.cms_pages
+
+        case params[:tab]
+        when 'default'
+          scope = scope.where(tenant_id: nil)
+        when 'tenants'
+          scope = if params[:tenant_id].present?
+                    scope.where(tenant_id: params[:tenant_id])
+                  else
+                    scope.where.not(tenant_id: nil)
+                  end
+        end
+
+        scope
+      end
+
+      def permitted_resource_params
+        super.merge(tenant_id: params[:cms_page][:tenant_id])
+      end
+    end
+  end
+end
+
+unless Spree::Admin::CmsPagesController.included_modules.include?(Spree::Admin::CmsPagesControllerDecorator)
+  Spree::Admin::CmsPagesController.prepend(Spree::Admin::CmsPagesControllerDecorator)
+end

--- a/app/controllers/spree/api/v2/tenant/cms_pages_controller.rb
+++ b/app/controllers/spree/api/v2/tenant/cms_pages_controller.rb
@@ -1,0 +1,41 @@
+module Spree
+  module Api
+    module V2
+      module Tenant
+        class CmsPagesController < BaseController
+          private
+
+          def model_class
+            Spree::CmsPage
+          end
+
+          def resource
+            @resource ||= scope.find_by(slug: params[:id]) || scope.find(params[:id])
+          end
+
+          def resource_serializer
+            Spree::Api::Dependencies.storefront_cms_page_serializer.constantize
+          end
+
+          def collection_serializer
+            Spree::Api::Dependencies.storefront_cms_page_serializer.constantize
+          end
+
+          def collection_finder
+            Spree::Api::Dependencies.storefront_cms_page_finder.constantize
+          end
+
+          def scope
+            model_class.by_locale(I18n.locale).where(tenant_id: MultiTenant.current_tenant_id)
+          end
+
+          def scope_includes
+            {
+              cms_sections: :linked_resource
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/spree_cm_commissioner/api/v2/storefront/cms_pages_controller_decorator.rb
+++ b/app/controllers/spree_cm_commissioner/api/v2/storefront/cms_pages_controller_decorator.rb
@@ -1,0 +1,18 @@
+module SpreeCmCommissioner
+  module Api
+    module V2
+      module Storefront
+        module CmsPagesControllerDecorator
+          def scope
+            super.by_locale(I18n.locale).where(tenant_id: nil)
+          end
+        end
+      end
+    end
+  end
+end
+
+# Prepend the decorator to the CmsPagesController
+unless Spree::Api::V2::Storefront::CmsPagesController.ancestors.include?(SpreeCmCommissioner::Api::V2::Storefront::CmsPagesControllerDecorator)
+  Spree::Api::V2::Storefront::CmsPagesController.prepend(SpreeCmCommissioner::Api::V2::Storefront::CmsPagesControllerDecorator)
+end

--- a/app/models/spree_cm_commissioner/cms_page_decorator.rb
+++ b/app/models/spree_cm_commissioner/cms_page_decorator.rb
@@ -1,0 +1,9 @@
+module SpreeCmCommissioner
+  module CmsPageDecorator
+    def self.prepended(base)
+      base.multi_tenant :tenant, class_name: 'SpreeCmCommissioner::Tenant'
+    end
+  end
+end
+
+Spree::CmsPage.prepend(SpreeCmCommissioner::CmsPageDecorator) unless Spree::CmsPage.included_modules.include?(SpreeCmCommissioner::CmsPageDecorator)

--- a/app/overrides/spree/admin/cms_pages/_form/tenant_fields.html.erb.deface
+++ b/app/overrides/spree/admin/cms_pages/_form/tenant_fields.html.erb.deface
@@ -1,0 +1,7 @@
+<!-- insert_before "erb[loud]:contains('f.field_container :title')" -->
+
+<%= f.field_container :tenant_id, class: ['col-12'] do %>
+  <%= f.label :tenant_id, raw(Spree.t(:tenant) + ' (optional)') %>
+  <%= f.collection_select :tenant_id, SpreeCmCommissioner::Tenant.all, :id, :name, { prompt: Spree.t('select_tenant') }, { class: 'form-control select2' } %>
+  <%= f.error_message_on :tenant_id %>
+<% end %>

--- a/app/overrides/spree/admin/cms_pages/index/cms_pages_tabs.html.erb.deface
+++ b/app/overrides/spree/admin/cms_pages/index/cms_pages_tabs.html.erb.deface
@@ -1,0 +1,21 @@
+<!-- insert_before "erb[silent]:contains('content_for :page_actions')" -->
+
+<%= render partial: 'spree/admin/shared/cms_pages_tabs' %>
+
+<% if params[:tab] == 'default' %>
+  <div class="alert alert-info mb-3">
+    <%= svg_icon name: "info-circle.svg", classes: 'mr-2', width: '16', height: '16' %>
+    CMS Pages for the default store. These pages are shared globally and are not tied to any specific tenant.
+  </div>
+<% elsif params[:tab] == 'tenants' && params[:tenant_id].present? %>
+  <div class="alert alert-info mb-3">
+    <%= svg_icon name: "info-circle.svg", classes: 'mr-2', width: '16', height: '16' %>
+    CMS Pages for the tenant: <strong><%= SpreeCmCommissioner::Tenant.find(params[:tenant_id]).name %></strong>.
+    These pages are displayed only to users associated with this tenant.
+  </div>
+<% elsif params[:tab] == 'tenants' %>
+  <div class="alert alert-info mb-3">
+    <%= svg_icon name: "info-circle.svg", classes: 'mr-2', width: '16', height: '16' %>
+    CMS Pages for all tenants. These pages are displayed only to users associated with specific tenants.
+  </div>
+<% end %>

--- a/app/views/spree/admin/shared/_cms_pages_tabs.html.erb
+++ b/app/views/spree/admin/shared/_cms_pages_tabs.html.erb
@@ -1,0 +1,20 @@
+<% content_for(:page_tabs) do %>
+  <% if can?(:admin, Spree::CmsPage) %>
+    <%= content_tag :li, class: 'nav-item' do %>
+      <%= link_to_with_icon 'building.svg',
+        Spree::Store.default&.name || Spree.t(:store),
+        admin_cms_pages_url(tab: :default),
+        class: "nav-link #{'active' if params[:tab].blank? || params[:tab] == 'default'}" %>
+    <% end %>
+
+    <!-- Tenant Tabs -->
+    <% SpreeCmCommissioner::Tenant.all.each do |tenant| %>
+      <%= content_tag :li, class: 'nav-item' do %>
+        <%= link_to_with_icon 'building.svg',
+          tenant.name,
+          admin_cms_pages_url(tab: :tenants, tenant_id: tenant.id),
+          class: "nav-link #{'active' if params[:tenant_id].to_s == tenant.id.to_s}" %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -516,6 +516,8 @@ Spree::Core::Engine.add_routes do
         resource :reset_passwords, only: [:update]
         resource :change_passwords, only: [:update]
         resource :user_contacts, only: [:update]
+
+        resources :cms_pages, only: %i[index show]
       end
 
       namespace :storefront do

--- a/db/migrate/20250512075319_add_tenant_id_to_spree_cms_pages.rb
+++ b/db/migrate/20250512075319_add_tenant_id_to_spree_cms_pages.rb
@@ -1,0 +1,6 @@
+class AddTenantIdToSpreeCmsPages < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_cms_pages, :tenant_id, :integer, if_not_exists: true
+    add_index :spree_cms_pages, :tenant_id, if_not_exists: true
+  end
+end


### PR DESCRIPTION
The CmsPagesControllerDecorator is used to extend the existing storefront API to handle global CMS pages (tenant_id: nil), while the new CmsPagesController under the tenant namespace is created to handle tenant-specific CMS pages (tenant_id: MultiTenant.current_tenant_id).

Tenant API: 
- {{BASE_URL}}/api/v2/tenant/cms_pages
- {{BASE_URL}}/api/v2/tenant/cms_pages/:cms_page_slug?include=cms_sections.linked_resource
- 
This separation ensures:

- Clear API Design: Different endpoints for global and tenant-specific data.
- Separation of Concerns: Each controller focuses on its specific responsibility.
- Maintainability: Avoids overloading a single controller with mixed logic.

## Enhance Cms Page Dashboard
https://github.com/user-attachments/assets/3ce44c44-402a-45ea-86ca-d4d88f485149

