### PR TITLE
Close #2630 allow reset each inventory item

### DIFF
--- a/app/finders/spree_cm_commissioner/accommodations/find.rb
+++ b/app/finders/spree_cm_commissioner/accommodations/find.rb
@@ -13,7 +13,7 @@ module SpreeCmCommissioner
       def execute
         scope
           .where(default_state_id: state_id)
-          .where(inventory_items: { inventory_date: date_range_excluding_checkout })
+          .where(inventory_items: { inventory_date: stay_dates })
           .where('CAST(spree_variants.public_metadata->\'cm_options\'->>\'number-of-adults\' AS INTEGER) +
                   CAST(spree_variants.public_metadata->\'cm_options\'->>\'number-of-kids\' AS INTEGER) >= ?', number_of_guests
           )
@@ -29,11 +29,8 @@ module SpreeCmCommissioner
           .where(primary_product_type: :accommodation, state: :active)
       end
 
-      # Why? check_out date is not considered to be charged
-      # For example, if you check in on 2023-10-01 and check out on 2023-10-02,
-      # you will be charged for one night (2023-10-01).
-      def date_range_excluding_checkout
-        from_date..to_date.prev_day
+      def stay_dates
+        from_date..to_date
       end
     end
   end

--- a/app/finders/spree_cm_commissioner/accommodations/find_variant.rb
+++ b/app/finders/spree_cm_commissioner/accommodations/find_variant.rb
@@ -14,7 +14,7 @@ module SpreeCmCommissioner
         Spree::Variant
           .joins(:inventory_items)
           .where(vendor_id: vendor_id)
-          .where(inventory_items: { inventory_date: date_range_excluding_checkout })
+          .where(inventory_items: { inventory_date: stay_dates })
           .where('CAST(public_metadata->\'cm_options\'->>\'number-of-adults\' AS INTEGER) +
                   CAST(public_metadata->\'cm_options\'->>\'number-of-kids\' AS INTEGER) >= ?', number_of_guests
           )
@@ -24,11 +24,8 @@ module SpreeCmCommissioner
 
       private
 
-      # Why? check_out date is not considered to be charged
-      # For example, if you check in on 2023-10-01 and check out on 2023-10-02,
-      # you will be charged for one night (2023-10-01).
-      def date_range_excluding_checkout
-        from_date..to_date.prev_day
+      def stay_dates
+        from_date..to_date
       end
     end
   end

--- a/app/interactors/spree_cm_commissioner/stock/inventory_item_resetter.rb
+++ b/app/interactors/spree_cm_commissioner/stock/inventory_item_resetter.rb
@@ -1,0 +1,44 @@
+module SpreeCmCommissioner
+  module Stock
+    class InventoryItemResetter < BaseInteractor
+      delegate :inventory_item, to: :context
+
+      def call
+        max_capacity = variant_total_inventory
+        total_purchases = variant_total_purchases
+        quantity_available = [max_capacity - total_purchases, 0].max
+
+        updated = inventory_item.update(max_capacity: max_capacity, quantity_available: quantity_available)
+        return context.fail!(message: 'Failed to update inventory item', errors: inventory_item.errors.full_messages) unless updated
+
+        clear_inventory_cache
+      end
+
+      def variant_total_inventory
+        # for shipment, total_on_hand is not orignal stock. shipment does subtract the stock.
+        # to get desire result, we need to add to total_purchase.
+        if inventory_item.variant.delivery_required?
+          inventory_item.variant.total_on_hand.to_i + variant_total_purchases
+        else
+          inventory_item.variant.total_on_hand.to_i
+        end
+      end
+
+      def variant_total_purchases
+        scope = inventory_item.variant.complete_line_items
+
+        if inventory_item.permanent_stock?
+          scope.where('? BETWEEN from_date AND to_date', inventory_item.inventory_date).sum(:quantity).to_i
+        else
+          scope.sum(:quantity).to_i
+        end
+      end
+
+      def clear_inventory_cache
+        SpreeCmCommissioner.redis_pool.with do |redis|
+          redis.del(inventory_item.redis_key)
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/spree_cm_commissioner/line_item_durationable.rb
+++ b/app/models/concerns/spree_cm_commissioner/line_item_durationable.rb
@@ -17,29 +17,23 @@ module SpreeCmCommissioner
     def date_unit
       return nil unless permanent_stock?
 
-      date_range_excluding_checkout.size if accommodation?
+      date_range.size
     end
 
-    def date_range_excluding_checkout
-      return [] unless date_present?
-
-      date_range = (from_date.to_date..to_date.to_date).to_a
-      date_range.pop if date_range.size > 1
-      date_range
-    end
-
-    def date_range_including_checkout
+    def date_range
       return [] unless date_present?
 
       (from_date.to_date..to_date.to_date).to_a
     end
 
-    def date_range
-      if accommodation?
-        date_range_excluding_checkout
-      else
-        date_range_including_checkout
-      end
+    def checkin_date
+      from_date&.to_date
+    end
+
+    def checkout_date
+      return to_date ? to_date.to_date - 1.day : nil if accommodation?
+
+      to_date&.to_date
     end
 
     def event

--- a/app/models/spree_cm_commissioner/redis_stock/cached_inventory_items_builder.rb
+++ b/app/models/spree_cm_commissioner/redis_stock/cached_inventory_items_builder.rb
@@ -28,6 +28,7 @@ module SpreeCmCommissioner
 
       def cache_inventory(key, inventory_item, count_in_redis)
         return count_in_redis.to_i if count_in_redis.present?
+        return inventory_item.quantity_available unless inventory_item.active?
 
         SpreeCmCommissioner.redis_pool.with do |redis|
           redis.set(key, inventory_item.quantity_available, ex: inventory_item.redis_expired_in)

--- a/app/models/spree_cm_commissioner/redis_stock/variant_cached_inventory_items_builder.rb
+++ b/app/models/spree_cm_commissioner/redis_stock/variant_cached_inventory_items_builder.rb
@@ -1,12 +1,11 @@
 module SpreeCmCommissioner
   module RedisStock
     class VariantCachedInventoryItemsBuilder
-      attr_reader :variant_id, :from_date, :to_date
+      attr_reader :variant_id, :dates
 
-      def initialize(variant_id:, from_date: nil, to_date: nil)
+      def initialize(variant_id:, dates: [])
         @variant_id = variant_id
-        @from_date = from_date
-        @to_date = to_date
+        @dates = dates
       end
 
       # output: [ CachedInventoryItem(...), CachedInventoryItem(...) ]
@@ -18,8 +17,7 @@ module SpreeCmCommissioner
         variant = Spree::Variant.find(variant_id)
 
         inventory_items = variant.inventory_items
-        inventory_items.where(inventory_date: from_date..to_date) if variant.permanent_stock?
-
+        inventory_items = inventory_items.where(inventory_date: dates) if variant.permanent_stock?
         inventory_items
       end
     end

--- a/app/models/spree_cm_commissioner/stock/availability_checker.rb
+++ b/app/models/spree_cm_commissioner/stock/availability_checker.rb
@@ -32,11 +32,10 @@ module SpreeCmCommissioner
         if variant.permanent_stock?
           return [] if options[:from_date].blank? || options[:to_date].blank?
 
-          @cached_inventory_items = builder_klass.new(
-            variant_id: variant.id,
-            from_date: options[:from_date].to_date,
-            to_date: options[:to_date].to_date
-          ).call
+          dates = options[:from_date].to_date..options[:to_date].to_date
+          @cached_inventory_items = builder_klass.new(variant_id: variant.id, dates: dates).call
+          @cached_inventory_items = [] if @cached_inventory_items.size != dates.count
+          @cached_inventory_items
         else
           @cached_inventory_items = builder_klass.new(variant_id: variant.id).call
         end

--- a/app/serializers/spree/v2/storefront/line_item_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/line_item_serializer_decorator.rb
@@ -4,6 +4,7 @@ module Spree
       module LineItemSerializerDecorator
         def self.prepended(base)
           base.attributes :from_date, :to_date, :need_confirmation, :product_type, :event_status, :amount, :display_amount,
+                          :checkin_date, :checkout_date,
                           :number, :qr_data,
                           :kyc, :kyc_fields, :remaining_total_guests, :number_of_guests,
                           :completion_steps, :available_social_contact_platforms, :allow_anonymous_booking, :discontinue_on,

--- a/app/views/spree/admin/stock_managements/_events.html.erb
+++ b/app/views/spree/admin/stock_managements/_events.html.erb
@@ -4,6 +4,7 @@
 
     <div class="mb-3">
       <h6><%= inventory_item.variant.options_text %></h6>
+
       <ul class="list-group mt-1 mb-1">
         <li class="list-group-item d-flex justify-content-between align-items-center">
           Max capacity
@@ -18,6 +19,13 @@
       <small class="text-muted">
         <%= inventory_item_message(inventory_item, @cached_inventory_items[inventory_item.id]) %>
       </small>
+
+      <%= link_to_with_icon('arrow-counterclockwise.svg', "Reset Inventory Item", reset_inventory_item_admin_product_stock_managements_path(@product, inventory_item_id: inventory_item.id),
+        method: :patch,
+        remote: false,
+        class: 'icon_link btn btn-sm outline text-dark',
+        data: { confirm: "Only reset if stock is incorrect. Are you sure?" }, no_text: true
+      ) %>
     </div>
   <% end %>
 </div>

--- a/app/views/spree/admin/stock_managements/_variant_stock_items.html.erb
+++ b/app/views/spree/admin/stock_managements/_variant_stock_items.html.erb
@@ -34,7 +34,10 @@
           <td class="text-center">
             <% if item.persisted? && can?(:update, item) %>
               <%= form_tag admin_stock_item_path(item), method: :put, class: 'toggle_stock_item_backorderable' do %>
-                <%= check_box_tag 'stock_item[backorderable]', true, item.backorderable?, class: 'stock_item_backorderable', id: "stock_item_backorderable_#{stock_location.id}" %>
+                <%= check_box_tag 'stock_item[backorderable]', true, item.backorderable?,
+                  class: 'stock_item_backorderable',
+                  id: "stock_item_backorderable_#{stock_location.id}",
+                  onclick: "if (!confirm('Are you sure to change backorderable status?')) { this.checked = !this.checked; }" %>
               <% end %>
             <% else %>
               <%= 'N/A' %>

--- a/app/views/spree/admin/stock_managements/calendar.html.erb
+++ b/app/views/spree/admin/stock_managements/calendar.html.erb
@@ -8,14 +8,10 @@
       <% (1..12).each do |month| %>
         <%= month_calendar(start_date: Date.new(@year, month, 1), attribute: :from_date, end_attribute: :to_date, events: @events) do |date, events| %>
           <div class="c-annual-day"
-            data-date="<%= date.strftime '%Y-%m-%d' %>"
             type="button"
-            tabindex="0"
-            data-toggle="popover"
-            data-trigger="hover"
-            data-placement="right"
-            data-html="true"
-            data-content="<%= raw render_escape_html partial: "events_popover", locals: { events: events } if events.any? %>">
+            data-date="<%= date.strftime '%Y-%m-%d' %>"
+            data-toggle="modal"
+            data-target="#inventory-<%= date %>">
             <%= date.day %>
             <ul class="p-0 m-0 list-unstyled">
               <% events.each do |event| %>
@@ -27,6 +23,16 @@
                 </li>
               <% end %>
             </ul>
+          </div>
+
+          <div class="modal fade" id="inventory-<%= date %>" tabindex="-1" role="dialog">
+            <div class="modal-dialog" role="document">
+              <div class="modal-content">
+                <div class="modal-body">
+                  <%= render partial: "events", locals: { events: events } if events.any? %>
+                </div>
+              </div>
+            </div>
           </div>
         <% end %>
       <% end %>

--- a/app/views/spree/admin/stock_managements/index.html.erb
+++ b/app/views/spree/admin/stock_managements/index.html.erb
@@ -26,7 +26,10 @@
             <%= form_tag admin_product_variants_including_master_path(@product, variant, format: :js), method: :put, class: 'toggle_variant_track_inventory mt-2' do %>
               <div class="checkbox">
                 <%= label_tag "track_inventory_#{ variant.id }", class: 'm-0' do %>
-                  <%= check_box_tag 'track_inventory', 1, variant.track_inventory?, class: 'track_inventory_checkbox', id: "track_inventory_#{ variant.id }" %>
+                  <%= check_box_tag 'track_inventory', 1, variant.track_inventory?,
+                    class: 'track_inventory_checkbox',
+                    id: "track_inventory_#{ variant.id }",
+                    onclick: "if (!confirm('Are you sure to change track inventory status?')) { this.checked = !this.checked; }" %>
                   <%= Spree.t(:track_inventory) %>
                   <%= hidden_field_tag 'variant[track_inventory]', variant.track_inventory?, class: 'variant_track_inventory', id: "variant_track_inventory_#{variant.id}" %>
                 <% end %>
@@ -35,10 +38,14 @@
 
             <% if defined?(@reserved_stocks) %>
               <div>
-                <span type="button" data-toggle="popover" data-trigger="hover" data-placement="right" data-content="This product stock will renew every day">
-                  <%= svg_icon name: "cart-check.svg", width: '14', height: '14' %>
-                </span>
+                <%= svg_icon name: "cart-check.svg", width: '14', height: '14' %>
                 <%= label_tag "reserved_stock#{variant.id}", "Reserved Stock: #{@reserved_stocks[variant.id] || 0}", class: "m-0" %>
+                <%= link_to_with_icon('capture.svg', "Create Inventory Item", create_inventory_item_admin_product_stock_managements_path(@product, variant_id: variant.id),
+                  method: :post,
+                  remote: false,
+                  class: 'icon_link btn btn-sm btn-outline-primary ml-2',
+                  no_text: true
+                ) unless @inventory_items[variant.id].present? %>
               </div>
             <% end %>
 
@@ -69,6 +76,13 @@
                       <%= svg_icon name: "cloud-slash.svg", width: '14', height: '14', classes: 'text-danger' %>
                     <% end %>
                   </span>
+
+                  <%= link_to_with_icon('arrow-counterclockwise.svg', "Reset Inventory Item", reset_inventory_item_admin_product_stock_managements_path(@product, inventory_item_id: inventory_item.id),
+                    method: :patch,
+                    remote: false,
+                    class: 'icon_link btn btn-sm outline text-dark',
+                    data: { confirm: "Only reset if stock is incorrect. Are you sure?" }, no_text: true
+                  ) %>
                 </div>
               <% end %>
             <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,6 +141,9 @@ Spree::Core::Engine.add_routes do
       resources :stock_managements do
         collection do
           get :calendar
+
+          patch :reset_inventory_item
+          post :create_inventory_item
         end
       end
 

--- a/lib/spree_cm_commissioner/test_helper/factories/variant_factory.rb
+++ b/lib/spree_cm_commissioner/test_helper/factories/variant_factory.rb
@@ -32,6 +32,7 @@ FactoryBot.define do
     transient do
       number_of_adults { nil }
       number_of_kids { nil }
+      delivery_required { nil }
     end
 
     after(:create) do |variant, evaluator|
@@ -45,6 +46,12 @@ FactoryBot.define do
         number_of_kids = create(:cm_option_type, :number_of_kids)
         variant.product.option_types << number_of_kids
         variant.option_values << create(:cm_option_value, presentation: evaluator.number_of_kids, name: evaluator.number_of_kids, option_type: number_of_kids)
+      end
+
+      if evaluator.delivery_required == true
+        delivery_option = create(:cm_option_type, :delivery_option)
+        variant.product.option_types << delivery_option
+        variant.option_values << create(:cm_option_value, presentation: 'Delivery', name: 'delivery', option_type: delivery_option)
       end
 
       variant.save!

--- a/spec/finders/spree_cm_commissioner/accommodations/find_spec.rb
+++ b/spec/finders/spree_cm_commissioner/accommodations/find_spec.rb
@@ -264,25 +264,4 @@ RSpec.describe SpreeCmCommissioner::Accommodations::Find do
       end
     end
   end
-
-  describe '#date_range_excluding_checkout' do
-    let(:from_date) { Time.zone.today }
-    let(:to_date) { Time.zone.today + 2 }
-
-    subject do
-      described_class.new(
-        state_id: 1,
-        from_date: from_date,
-        to_date: to_date,
-        number_of_adults: 2,
-        number_of_kids: 1
-      )
-    end
-
-    it 'returns range from from_date to day before to_date' do
-      range = subject.send(:date_range_excluding_checkout)
-      expect(range).to eq(from_date..(to_date - 1))
-      expect(range).not_to include(to_date)
-    end
-  end
 end

--- a/spec/finders/spree_cm_commissioner/accommodations/find_variant_spec.rb
+++ b/spec/finders/spree_cm_commissioner/accommodations/find_variant_spec.rb
@@ -179,25 +179,4 @@ RSpec.describe SpreeCmCommissioner::Accommodations::FindVariant do
       end
     end
   end
-
-  describe '#date_range_excluding_checkout' do
-    let(:from_date) { Time.zone.today }
-    let(:to_date) { Time.zone.today + 2 }
-
-    subject do
-      described_class.new(
-        vendor_id: 1,
-        from_date: from_date,
-        to_date: to_date,
-        number_of_adults: 2,
-        number_of_kids: 1
-      )
-    end
-
-    it 'returns range from from_date to day before to_date' do
-      range = subject.send(:date_range_excluding_checkout)
-      expect(range).to eq(from_date..(to_date - 1))
-      expect(range).not_to include(to_date)
-    end
-  end
 end

--- a/spec/interactors/spree_cm_commissioner/stock/inventory_item_resetter_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/stock/inventory_item_resetter_spec.rb
@@ -1,0 +1,150 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::Stock::InventoryItemResetter, type: :interactor do
+  describe '.call' do
+    context 'mock test' do
+      let(:product) { create(:cm_product, product_type: :ecommerce) }
+      let(:variant) { create(:cm_variant, product: product, pregenerate_inventory_items: true, total_inventory: 5) }
+      let(:inventory_item) { variant.inventory_items.first }
+
+      it 'update inventory_item base on value of :variant_total_inventory & :variant_total_purchases' do
+        inventory_item.update(max_capacity: 2, quantity_available: 20) # update to incorrect value to make it out of sync.
+
+        expect_any_instance_of(described_class).to receive(:variant_total_inventory).and_return(20)
+        expect_any_instance_of(described_class).to receive(:variant_total_purchases).and_return(13)
+
+        described_class.call(inventory_item: inventory_item)
+
+        expect(inventory_item.max_capacity).to eq 20
+        expect(inventory_item.quantity_available).to eq(20 - 13)
+      end
+    end
+
+    context 'no mock test' do
+      let(:product) { create(:cm_product, product_type: :ecommerce) }
+      let(:variant) { create(:cm_variant, product: product, pregenerate_inventory_items: true, total_inventory: 5) }
+      let(:inventory_item) { variant.inventory_items.first }
+
+      let(:line_item1) { create(:line_item, variant: variant, quantity: 2, price: 0) }
+      let(:line_item2) { create(:line_item, variant: variant, quantity: 1, price: 0) }
+
+      let!(:order1) { create(:order, line_items: [line_item1], state: :complete, completed_at: Time.now) }
+      let!(:order2) { create(:order, line_items: [line_item2], state: :complete, completed_at: Time.now) }
+
+      # make some purchase for variant.
+      # perform enqueued jobs to make sure it unstock from redis & sync to inventory item
+      before do
+        perform_enqueued_jobs do
+          order1.send(:unstock_inventory_in_redis!)
+          order2.send(:unstock_inventory_in_redis!)
+        end
+
+        SpreeCmCommissioner.redis_pool.with do |redis|
+          expect(variant.total_on_hand).to eq 5
+          expect(variant.inventory_items.size).to eq 1
+          expect(inventory_item.reload.quantity_available).to eq(5 - 2 - 1)
+          expect(redis.get(inventory_item.redis_key).to_i).to eq(5 - 2 - 1)
+        end
+      end
+
+      it 'reset inventory :max_capacity & :quantity_available to correct value base on orders' do
+        inventory_item.update(max_capacity: 2, quantity_available: 20) # update to incorrect value to make it out of sync.
+        described_class.call(inventory_item: inventory_item)
+
+        expect(inventory_item.max_capacity).to eq variant.total_on_hand
+        expect(inventory_item.quantity_available).to eq(5 - 2 - 1)
+
+        # it remove key from redis after resetted
+        SpreeCmCommissioner.redis_pool.with do |redis|
+          expect(redis.get(inventory_item.redis_key)).to eq nil
+        end
+      end
+    end
+  end
+
+  describe '#variant_total_inventory' do
+    context 'for ecommerce with shipment' do
+      let(:product) { create(:cm_product, product_type: :ecommerce) }
+      let(:variant) { create(:cm_variant, product: product, delivery_required: true, pregenerate_inventory_items: true, total_inventory: 5) }
+      let(:inventory_item) { variant.inventory_items.first }
+
+      let(:line_item1) { create(:line_item, variant: variant, quantity: 2, price: 0) }
+      let(:line_item2) { create(:line_item, variant: variant, quantity: 1, price: 0) }
+
+      let(:order_with_shipment_1) { create(:shipped_order, line_items: [line_item1], state: :confirm) }
+      let(:order_with_shipment_2) { create(:shipped_order, line_items: [line_item2], state: :confirm) }
+
+      subject { described_class.new(inventory_item: inventory_item.reload) }
+
+      # make some purchase for variant which make shipment subtract the stock.
+      before do
+        expect(variant.stock_items.first.count_on_hand).to eq 5
+
+        order_with_shipment_1.next
+        order_with_shipment_2.next
+
+        expect(variant.stock_items.first.count_on_hand).to eq(5 - 2 - 1)
+      end
+
+      it 'return total inventory total_on_hand + purchase total' do
+        expect(variant.total_on_hand).to eq(2)
+        expect(variant.complete_line_items.sum(:quantity)).to eq(3)
+
+        expect(subject.variant_total_inventory).to eq 5
+      end
+    end
+
+    context 'for ecommerce with no shipment (event, digital product)' do
+      let(:product) { create(:cm_product, product_type: :ecommerce) }
+      let(:variant) { create(:cm_variant, product: product, pregenerate_inventory_items: true, total_inventory: 5) }
+      let(:inventory_item) { variant.inventory_items.first }
+
+      let(:line_item1) { create(:line_item, variant: variant, quantity: 2, price: 0) }
+      let!(:order1) { create(:order, line_items: [line_item1], state: :complete, completed_at: Time.now) }
+
+      subject { described_class.new(inventory_item: inventory_item) }
+
+      it 'just return total_on_hand of stock item directly' do
+        expect(subject.variant_total_inventory).to eq variant.total_on_hand
+      end
+    end
+  end
+
+  describe '#variant_total_purchases' do
+    context 'for permanent stock' do
+      let(:accommodation_variant) { create(:cm_variant, product_type: :accommodation, pregenerate_inventory_items: true, total_inventory: 5, pre_inventory_days: 1) }
+      let(:service_variant) { create(:cm_variant, product_type: :service, pregenerate_inventory_items: true, total_inventory: 5, pre_inventory_days: 1) }
+      let(:ecommerce_variant) { create(:cm_variant, product_type: :ecommerce, pregenerate_inventory_items: true, total_inventory: 5) }
+
+      let(:accommodation_inventory_item) { accommodation_variant.inventory_items[0] }
+      let(:service_inventory_item) { service_variant.inventory_items[0] }
+      let(:ecommerce_inventory_item) { ecommerce_variant.inventory_items[0] }
+
+      let(:accommodation_line_item1) { create(:line_item, quantity: 2, variant: accommodation_variant, from_date: Time.zone.tomorrow, to_date: Time.zone.tomorrow) }
+      let(:service_line_item1) { create(:line_item, quantity: 2, variant: service_variant, from_date: Time.zone.tomorrow, to_date: Time.zone.tomorrow) }
+      let(:ecommerce_line_item1) { create(:line_item, quantity: 2, variant: ecommerce_variant) }
+
+      let(:accommodation_line_item2) { create(:line_item, quantity: 1, variant: accommodation_variant, from_date: Time.zone.tomorrow, to_date: Time.zone.tomorrow) }
+      let(:service_line_item2) { create(:line_item, quantity: 1, variant: service_variant, from_date: Time.zone.tomorrow, to_date: Time.zone.tomorrow) }
+      let(:ecommerce_line_item2) { create(:line_item, quantity: 1, variant: ecommerce_variant) }
+
+      # create transit line item is impossible now some old validation. We need to work on that first.
+      # let(:transit_line_item) { create(:line_item, variant: service_variant, from_date: Time.zone.tomorrow, to_date: Time.zone.tomorrow + 1) }
+
+      before do
+        create(:order, line_items: [accommodation_line_item1, service_line_item1, ecommerce_line_item1], state: :complete, completed_at: Time.now)
+        create(:order, line_items: [accommodation_line_item2, service_line_item2, ecommerce_line_item2], state: :complete, completed_at: Time.now)
+      end
+
+      it 'return total purchase on line item total' do
+        subject1 = described_class.new(inventory_item: accommodation_inventory_item)
+        subject2 = described_class.new(inventory_item: service_inventory_item)
+        subject3 = described_class.new(inventory_item: ecommerce_inventory_item)
+
+        expect(subject1.variant_total_purchases).to eq(3)
+        expect(subject2.variant_total_purchases).to eq(3)
+        expect(subject3.variant_total_purchases).to eq(3)
+      end
+    end
+  end
+end

--- a/spec/models/concerns/spree_cm_commissioner/line_item_durationable_spec.rb
+++ b/spec/models/concerns/spree_cm_commissioner/line_item_durationable_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::LineItemDurationable do
+  describe '#date_range' do
+    let(:accommodation_line_item) { build(:line_item, product_type: :accommodation, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
+    let(:transit_line_item) { build(:line_item, product_type: :transit, from_date: '2023-01-10'.to_date, to_date: '2023-01-10'.to_date) }
+    let(:event_line_item) { build(:line_item, product_type: :ecommerce, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
+    let(:no_date_line_item) { build(:line_item, product_type: :ecommerce) }
+
+    it 'return date range base on from_date to to_date' do
+      # for accomodation, from_date to to_date is stay date (no checkout date here.)
+      expect(accommodation_line_item.date_range).to eq(['2023-01-10'.to_date, '2023-01-11'.to_date, '2023-01-12'.to_date])
+      expect(transit_line_item.date_range).to eq(['2023-01-10'.to_date])
+      expect(event_line_item.date_range).to eq(['2023-01-10'.to_date, '2023-01-11'.to_date, '2023-01-12'.to_date])
+      expect(no_date_line_item.date_range).to eq([])
+    end
+  end
+
+  describe '#date_unit' do
+    let(:accommodation_line_item) { build(:line_item, product_type: :accommodation, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
+    let(:transit_line_item) { build(:line_item, product_type: :transit, from_date: '2023-01-10'.to_date, to_date: '2023-01-10'.to_date) }
+    let(:service_line_item) { build(:line_item, product_type: :service, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
+    let(:event_line_item) { build(:line_item, product_type: :ecommerce, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
+    let(:no_date_line_item) { build(:line_item, product_type: :ecommerce) }
+
+    it 'return 3 days / unit for permanent stock & nil for other type' do
+      expect(accommodation_line_item.date_unit).to eq 3
+      expect(transit_line_item.date_unit).to eq 1
+      expect(service_line_item.date_unit).to eq 3
+      expect(event_line_item.date_unit).to eq nil
+      expect(no_date_line_item.date_unit).to eq nil
+    end
+  end
+
+  describe '#checkin_date' do
+    let(:accommodation_line_item) { build(:line_item, product_type: :accommodation, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
+    let(:transit_line_item) { build(:line_item, product_type: :transit, from_date: '2023-01-10'.to_date, to_date: '2023-01-10'.to_date) }
+    let(:service_line_item) { build(:line_item, product_type: :service, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
+    let(:event_line_item) { build(:line_item, product_type: :ecommerce, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
+    let(:no_date_line_item) { build(:line_item, product_type: :ecommerce) }
+
+    it 'just return from_date or nil if not provided' do
+      expect(accommodation_line_item.checkin_date).to eq '2023-01-10'.to_date
+      expect(transit_line_item.checkin_date).to eq '2023-01-10'.to_date
+      expect(service_line_item.checkin_date).to eq '2023-01-10'.to_date
+      expect(event_line_item.checkin_date).to eq '2023-01-10'.to_date
+      expect(no_date_line_item.checkin_date).to eq nil
+    end
+  end
+
+  describe '#checkout_date' do
+    let(:accommodation_line_item) { build(:line_item, product_type: :accommodation, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
+    let(:transit_line_item) { build(:line_item, product_type: :transit, from_date: '2023-01-10'.to_date, to_date: '2023-01-10'.to_date) }
+    let(:service_line_item) { build(:line_item, product_type: :service, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
+    let(:event_line_item) { build(:line_item, product_type: :ecommerce, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
+    let(:no_date_line_item) { build(:line_item, product_type: :ecommerce) }
+
+    it 'return to_date exclude checkout for accommodation, while just return to_date for other product_type' do
+      expect(accommodation_line_item.checkout_date).to eq '2023-01-11'.to_date # exclude checkout date
+      expect(transit_line_item.checkout_date).to eq '2023-01-10'.to_date
+      expect(service_line_item.checkout_date).to eq '2023-01-12'.to_date
+      expect(event_line_item.checkout_date).to eq '2023-01-12'.to_date
+      expect(no_date_line_item.checkout_date).to eq nil
+    end
+  end
+end

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Spree::LineItem, type: :model do
     context 'when product_type is accommodation' do
       let(:product) { create(:cm_product, product_type: :accommodation) }
       let(:variant) { create(:cm_variant, product: product, total_inventory: 10) }
-      let(:line_item) { create(:line_item, variant: variant, quantity: 1, from_date: Time.zone.tomorrow, to_date: Time.zone.tomorrow + 3) }
+      let(:line_item) { create(:line_item, variant: variant, quantity: 1, from_date: Time.zone.tomorrow, to_date: Time.zone.tomorrow + 2) }
 
       # generate inventory items for 10 days
       before do
@@ -198,7 +198,7 @@ RSpec.describe Spree::LineItem, type: :model do
   describe '#amount' do
     context 'product type: accommodation' do
       let(:product) { create(:cm_accommodation_product, price: BigDecimal('10.0'), total_inventory: 4) }
-      let(:line_item) { create(:line_item, price: BigDecimal('10.0'), quantity: 2, product: product, from_date: '2023-01-10'.to_date, to_date: '2023-01-13'.to_date) }
+      let(:line_item) { create(:line_item, price: BigDecimal('10.0'), quantity: 2, product: product, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
 
       it 'calculates amount based on price, quantity & number of nights' do
         expect(line_item.amount).to eq BigDecimal('60.0') # 10.0 * 2 * 3 nights

--- a/spec/models/spree_cm_commissioner/promotion/actions/create_date_specific_item_adjustments_spec.rb
+++ b/spec/models/spree_cm_commissioner/promotion/actions/create_date_specific_item_adjustments_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SpreeCmCommissioner::Promotion::Actions::CreateDateSpecificItemAd
       price: BigDecimal('10.0'),
       product: product,
       from_date: '2023-01-10'.to_date,
-      to_date: '2023-01-13'.to_date
+      to_date: '2023-01-12'.to_date
     )
   }
 
@@ -22,7 +22,7 @@ RSpec.describe SpreeCmCommissioner::Promotion::Actions::CreateDateSpecificItemAd
       price: BigDecimal('10.0'),
       product: product,
       from_date: '2023-01-13'.to_date,
-      to_date: '2023-01-15'.to_date
+      to_date: '2023-01-14'.to_date
     )
   }
 

--- a/spec/models/spree_cm_commissioner/redis_stock/line_items_cached_inventory_items_builder_spec.rb
+++ b/spec/models/spree_cm_commissioner/redis_stock/line_items_cached_inventory_items_builder_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SpreeCmCommissioner::RedisStock::LineItemsCachedInventoryItemsBui
   let(:variant) { create(:cm_variant, product: product, total_inventory: 10, pregenerate_inventory_items: true, pre_inventory_days: 3) }
 
   describe '#call' do
-    let(:line_item) { create(:line_item, variant: variant, quantity: 1, from_date: Time.zone.tomorrow, to_date: Time.zone.tomorrow + 3) }
+    let(:line_item) { create(:line_item, variant: variant, quantity: 1, from_date: Time.zone.tomorrow, to_date: Time.zone.tomorrow + 2) }
     let(:inventory_items) { variant.reload.inventory_items }
 
     before do

--- a/spec/models/spree_cm_commissioner/redis_stock/variant_cached_inventory_items_builder_spec.rb
+++ b/spec/models/spree_cm_commissioner/redis_stock/variant_cached_inventory_items_builder_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe SpreeCmCommissioner::RedisStock::VariantCachedInventoryItemsBuild
     end
 
     it 'return inventory keys of variant.inventory_items base on checkin/checkout date' do
-      result = described_class.new(variant_id: variant.id, from_date: Time.zone.tomorrow, to_date: Time.zone.today + 4).call # +4 because it exclude checkout date
+      result = described_class.new(variant_id: variant.id, dates: Time.zone.tomorrow..(Time.zone.tomorrow + 3)).call
 
       expect(result.map(&:to_h)).to eq([
         {:inventory_key => "inventory:#{inventory_items[0].id}", active: true, :quantity_available => 2, :inventory_item_id => inventory_items[0].id, :variant_id => variant.id},

--- a/spec/serializers/spree/v2/storefront/line_item_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/line_item_serializer_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe Spree::V2::Storefront::LineItemSerializer, type: :serializer do
         :display_pre_tax_amount,
         :amount,
         :display_amount,
+        :checkin_date,
+        :checkout_date,
         :public_metadata,
         :from_date,
         :to_date,


### PR DESCRIPTION
## What in this PR?
- [x] Allow reset of each inventory item
  - Add InventoryItemResetter
  - Add UI to trigger that class for specific inventory item

> Use for backup when inventory item is out of sync.

## Demo

### 1. Normal stock
| |
| - |
| ![image1](https://github.com/user-attachments/assets/54ece5a6-494e-47ad-8070-a4f48af46aac) |
| ![image2](https://github.com/user-attachments/assets/bc112778-5441-4dbc-bf00-e74850255482) |

### 2. Permanent stock
| |
| - |
| <img width="1728" alt="image" src="https://github.com/user-attachments/assets/8439d291-e3c4-430b-82ae-059ac0a315d3" /> |
| <img width="1729" alt="image" src="https://github.com/user-attachments/assets/60d4a2dd-e243-48fb-831a-637bca656f66" /> |
| <img width="1729" alt="image" src="https://github.com/user-attachments/assets/17b1a31b-a988-4b5b-9ef7-1790638925ce" /> |

