### PR TITLE
Close #2638 migrate to not store checkout date

### DIFF
--- a/app/finders/spree_cm_commissioner/accommodations/find.rb
+++ b/app/finders/spree_cm_commissioner/accommodations/find.rb
@@ -13,7 +13,7 @@ module SpreeCmCommissioner
       def execute
         scope
           .where(default_state_id: state_id)
-          .where(inventory_items: { inventory_date: date_range_excluding_checkout })
+          .where(inventory_items: { inventory_date: stay_dates })
           .where('CAST(spree_variants.public_metadata->\'cm_options\'->>\'number-of-adults\' AS INTEGER) +
                   CAST(spree_variants.public_metadata->\'cm_options\'->>\'number-of-kids\' AS INTEGER) >= ?', number_of_guests
           )
@@ -29,11 +29,8 @@ module SpreeCmCommissioner
           .where(primary_product_type: :accommodation, state: :active)
       end
 
-      # Why? check_out date is not considered to be charged
-      # For example, if you check in on 2023-10-01 and check out on 2023-10-02,
-      # you will be charged for one night (2023-10-01).
-      def date_range_excluding_checkout
-        from_date..to_date.prev_day
+      def stay_dates
+        from_date..to_date
       end
     end
   end

--- a/app/finders/spree_cm_commissioner/accommodations/find_variant.rb
+++ b/app/finders/spree_cm_commissioner/accommodations/find_variant.rb
@@ -14,7 +14,7 @@ module SpreeCmCommissioner
         Spree::Variant
           .joins(:inventory_items)
           .where(vendor_id: vendor_id)
-          .where(inventory_items: { inventory_date: date_range_excluding_checkout })
+          .where(inventory_items: { inventory_date: stay_dates })
           .where('CAST(public_metadata->\'cm_options\'->>\'number-of-adults\' AS INTEGER) +
                   CAST(public_metadata->\'cm_options\'->>\'number-of-kids\' AS INTEGER) >= ?', number_of_guests
           )
@@ -24,11 +24,8 @@ module SpreeCmCommissioner
 
       private
 
-      # Why? check_out date is not considered to be charged
-      # For example, if you check in on 2023-10-01 and check out on 2023-10-02,
-      # you will be charged for one night (2023-10-01).
-      def date_range_excluding_checkout
-        from_date..to_date.prev_day
+      def stay_dates
+        from_date..to_date
       end
     end
   end

--- a/app/models/concerns/spree_cm_commissioner/line_item_durationable.rb
+++ b/app/models/concerns/spree_cm_commissioner/line_item_durationable.rb
@@ -17,29 +17,23 @@ module SpreeCmCommissioner
     def date_unit
       return nil unless permanent_stock?
 
-      date_range_excluding_checkout.size if accommodation?
+      date_range.size
     end
 
-    def date_range_excluding_checkout
-      return [] unless date_present?
-
-      date_range = (from_date.to_date..to_date.to_date).to_a
-      date_range.pop if date_range.size > 1
-      date_range
-    end
-
-    def date_range_including_checkout
+    def date_range
       return [] unless date_present?
 
       (from_date.to_date..to_date.to_date).to_a
     end
 
-    def date_range
-      if accommodation?
-        date_range_excluding_checkout
-      else
-        date_range_including_checkout
-      end
+    def checkin_date
+      from_date&.to_date
+    end
+
+    def checkout_date
+      return to_date ? to_date.to_date - 1.day : nil if accommodation?
+
+      to_date&.to_date
     end
 
     def event

--- a/app/models/spree_cm_commissioner/redis_stock/cached_inventory_items_builder.rb
+++ b/app/models/spree_cm_commissioner/redis_stock/cached_inventory_items_builder.rb
@@ -28,6 +28,7 @@ module SpreeCmCommissioner
 
       def cache_inventory(key, inventory_item, count_in_redis)
         return count_in_redis.to_i if count_in_redis.present?
+        return inventory_item.quantity_available unless inventory_item.active?
 
         SpreeCmCommissioner.redis_pool.with do |redis|
           redis.set(key, inventory_item.quantity_available, ex: inventory_item.redis_expired_in)

--- a/app/models/spree_cm_commissioner/redis_stock/variant_cached_inventory_items_builder.rb
+++ b/app/models/spree_cm_commissioner/redis_stock/variant_cached_inventory_items_builder.rb
@@ -1,12 +1,11 @@
 module SpreeCmCommissioner
   module RedisStock
     class VariantCachedInventoryItemsBuilder
-      attr_reader :variant_id, :from_date, :to_date
+      attr_reader :variant_id, :dates
 
-      def initialize(variant_id:, from_date: nil, to_date: nil)
+      def initialize(variant_id:, dates: [])
         @variant_id = variant_id
-        @from_date = from_date
-        @to_date = to_date
+        @dates = dates
       end
 
       # output: [ CachedInventoryItem(...), CachedInventoryItem(...) ]
@@ -18,8 +17,7 @@ module SpreeCmCommissioner
         variant = Spree::Variant.find(variant_id)
 
         inventory_items = variant.inventory_items
-        inventory_items.where(inventory_date: from_date..to_date) if variant.permanent_stock?
-
+        inventory_items = inventory_items.where(inventory_date: dates) if variant.permanent_stock?
         inventory_items
       end
     end

--- a/app/models/spree_cm_commissioner/stock/availability_checker.rb
+++ b/app/models/spree_cm_commissioner/stock/availability_checker.rb
@@ -32,11 +32,10 @@ module SpreeCmCommissioner
         if variant.permanent_stock?
           return [] if options[:from_date].blank? || options[:to_date].blank?
 
-          @cached_inventory_items = builder_klass.new(
-            variant_id: variant.id,
-            from_date: options[:from_date].to_date,
-            to_date: options[:to_date].to_date
-          ).call
+          dates = options[:from_date].to_date..options[:to_date].to_date
+          @cached_inventory_items = builder_klass.new(variant_id: variant.id, dates: dates).call
+          @cached_inventory_items = [] if @cached_inventory_items.size != dates.count
+          @cached_inventory_items
         else
           @cached_inventory_items = builder_klass.new(variant_id: variant.id).call
         end

--- a/app/serializers/spree/v2/storefront/line_item_serializer_decorator.rb
+++ b/app/serializers/spree/v2/storefront/line_item_serializer_decorator.rb
@@ -4,6 +4,7 @@ module Spree
       module LineItemSerializerDecorator
         def self.prepended(base)
           base.attributes :from_date, :to_date, :need_confirmation, :product_type, :event_status, :amount, :display_amount,
+                          :checkin_date, :checkout_date,
                           :number, :qr_data,
                           :kyc, :kyc_fields, :remaining_total_guests, :number_of_guests,
                           :completion_steps, :available_social_contact_platforms, :allow_anonymous_booking, :discontinue_on,

--- a/spec/finders/spree_cm_commissioner/accommodations/find_spec.rb
+++ b/spec/finders/spree_cm_commissioner/accommodations/find_spec.rb
@@ -264,25 +264,4 @@ RSpec.describe SpreeCmCommissioner::Accommodations::Find do
       end
     end
   end
-
-  describe '#date_range_excluding_checkout' do
-    let(:from_date) { Time.zone.today }
-    let(:to_date) { Time.zone.today + 2 }
-
-    subject do
-      described_class.new(
-        state_id: 1,
-        from_date: from_date,
-        to_date: to_date,
-        number_of_adults: 2,
-        number_of_kids: 1
-      )
-    end
-
-    it 'returns range from from_date to day before to_date' do
-      range = subject.send(:date_range_excluding_checkout)
-      expect(range).to eq(from_date..(to_date - 1))
-      expect(range).not_to include(to_date)
-    end
-  end
 end

--- a/spec/finders/spree_cm_commissioner/accommodations/find_variant_spec.rb
+++ b/spec/finders/spree_cm_commissioner/accommodations/find_variant_spec.rb
@@ -179,25 +179,4 @@ RSpec.describe SpreeCmCommissioner::Accommodations::FindVariant do
       end
     end
   end
-
-  describe '#date_range_excluding_checkout' do
-    let(:from_date) { Time.zone.today }
-    let(:to_date) { Time.zone.today + 2 }
-
-    subject do
-      described_class.new(
-        vendor_id: 1,
-        from_date: from_date,
-        to_date: to_date,
-        number_of_adults: 2,
-        number_of_kids: 1
-      )
-    end
-
-    it 'returns range from from_date to day before to_date' do
-      range = subject.send(:date_range_excluding_checkout)
-      expect(range).to eq(from_date..(to_date - 1))
-      expect(range).not_to include(to_date)
-    end
-  end
 end

--- a/spec/models/concerns/spree_cm_commissioner/line_item_durationable_spec.rb
+++ b/spec/models/concerns/spree_cm_commissioner/line_item_durationable_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::LineItemDurationable do
+  describe '#date_range' do
+    let(:accommodation_line_item) { build(:line_item, product_type: :accommodation, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
+    let(:transit_line_item) { build(:line_item, product_type: :transit, from_date: '2023-01-10'.to_date, to_date: '2023-01-10'.to_date) }
+    let(:event_line_item) { build(:line_item, product_type: :ecommerce, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
+    let(:no_date_line_item) { build(:line_item, product_type: :ecommerce) }
+
+    it 'return date range base on from_date to to_date' do
+      # for accomodation, from_date to to_date is stay date (no checkout date here.)
+      expect(accommodation_line_item.date_range).to eq(['2023-01-10'.to_date, '2023-01-11'.to_date, '2023-01-12'.to_date])
+      expect(transit_line_item.date_range).to eq(['2023-01-10'.to_date])
+      expect(event_line_item.date_range).to eq(['2023-01-10'.to_date, '2023-01-11'.to_date, '2023-01-12'.to_date])
+      expect(no_date_line_item.date_range).to eq([])
+    end
+  end
+
+  describe '#date_unit' do
+    let(:accommodation_line_item) { build(:line_item, product_type: :accommodation, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
+    let(:transit_line_item) { build(:line_item, product_type: :transit, from_date: '2023-01-10'.to_date, to_date: '2023-01-10'.to_date) }
+    let(:service_line_item) { build(:line_item, product_type: :service, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
+    let(:event_line_item) { build(:line_item, product_type: :ecommerce, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
+    let(:no_date_line_item) { build(:line_item, product_type: :ecommerce) }
+
+    it 'return 3 days / unit for permanent stock & nil for other type' do
+      expect(accommodation_line_item.date_unit).to eq 3
+      expect(transit_line_item.date_unit).to eq 1
+      expect(service_line_item.date_unit).to eq 3
+      expect(event_line_item.date_unit).to eq nil
+      expect(no_date_line_item.date_unit).to eq nil
+    end
+  end
+
+  describe '#checkin_date' do
+    let(:accommodation_line_item) { build(:line_item, product_type: :accommodation, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
+    let(:transit_line_item) { build(:line_item, product_type: :transit, from_date: '2023-01-10'.to_date, to_date: '2023-01-10'.to_date) }
+    let(:service_line_item) { build(:line_item, product_type: :service, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
+    let(:event_line_item) { build(:line_item, product_type: :ecommerce, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
+    let(:no_date_line_item) { build(:line_item, product_type: :ecommerce) }
+
+    it 'just return from_date or nil if not provided' do
+      expect(accommodation_line_item.checkin_date).to eq '2023-01-10'.to_date
+      expect(transit_line_item.checkin_date).to eq '2023-01-10'.to_date
+      expect(service_line_item.checkin_date).to eq '2023-01-10'.to_date
+      expect(event_line_item.checkin_date).to eq '2023-01-10'.to_date
+      expect(no_date_line_item.checkin_date).to eq nil
+    end
+  end
+
+  describe '#checkout_date' do
+    let(:accommodation_line_item) { build(:line_item, product_type: :accommodation, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
+    let(:transit_line_item) { build(:line_item, product_type: :transit, from_date: '2023-01-10'.to_date, to_date: '2023-01-10'.to_date) }
+    let(:service_line_item) { build(:line_item, product_type: :service, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
+    let(:event_line_item) { build(:line_item, product_type: :ecommerce, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
+    let(:no_date_line_item) { build(:line_item, product_type: :ecommerce) }
+
+    it 'return to_date exclude checkout for accommodation, while just return to_date for other product_type' do
+      expect(accommodation_line_item.checkout_date).to eq '2023-01-11'.to_date # exclude checkout date
+      expect(transit_line_item.checkout_date).to eq '2023-01-10'.to_date
+      expect(service_line_item.checkout_date).to eq '2023-01-12'.to_date
+      expect(event_line_item.checkout_date).to eq '2023-01-12'.to_date
+      expect(no_date_line_item.checkout_date).to eq nil
+    end
+  end
+end

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Spree::LineItem, type: :model do
     context 'when product_type is accommodation' do
       let(:product) { create(:cm_product, product_type: :accommodation) }
       let(:variant) { create(:cm_variant, product: product, total_inventory: 10) }
-      let(:line_item) { create(:line_item, variant: variant, quantity: 1, from_date: Time.zone.tomorrow, to_date: Time.zone.tomorrow + 3) }
+      let(:line_item) { create(:line_item, variant: variant, quantity: 1, from_date: Time.zone.tomorrow, to_date: Time.zone.tomorrow + 2) }
 
       # generate inventory items for 10 days
       before do
@@ -198,7 +198,7 @@ RSpec.describe Spree::LineItem, type: :model do
   describe '#amount' do
     context 'product type: accommodation' do
       let(:product) { create(:cm_accommodation_product, price: BigDecimal('10.0'), total_inventory: 4) }
-      let(:line_item) { create(:line_item, price: BigDecimal('10.0'), quantity: 2, product: product, from_date: '2023-01-10'.to_date, to_date: '2023-01-13'.to_date) }
+      let(:line_item) { create(:line_item, price: BigDecimal('10.0'), quantity: 2, product: product, from_date: '2023-01-10'.to_date, to_date: '2023-01-12'.to_date) }
 
       it 'calculates amount based on price, quantity & number of nights' do
         expect(line_item.amount).to eq BigDecimal('60.0') # 10.0 * 2 * 3 nights

--- a/spec/models/spree_cm_commissioner/promotion/actions/create_date_specific_item_adjustments_spec.rb
+++ b/spec/models/spree_cm_commissioner/promotion/actions/create_date_specific_item_adjustments_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SpreeCmCommissioner::Promotion::Actions::CreateDateSpecificItemAd
       price: BigDecimal('10.0'),
       product: product,
       from_date: '2023-01-10'.to_date,
-      to_date: '2023-01-13'.to_date
+      to_date: '2023-01-12'.to_date
     )
   }
 
@@ -22,7 +22,7 @@ RSpec.describe SpreeCmCommissioner::Promotion::Actions::CreateDateSpecificItemAd
       price: BigDecimal('10.0'),
       product: product,
       from_date: '2023-01-13'.to_date,
-      to_date: '2023-01-15'.to_date
+      to_date: '2023-01-14'.to_date
     )
   }
 

--- a/spec/models/spree_cm_commissioner/redis_stock/line_items_cached_inventory_items_builder_spec.rb
+++ b/spec/models/spree_cm_commissioner/redis_stock/line_items_cached_inventory_items_builder_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SpreeCmCommissioner::RedisStock::LineItemsCachedInventoryItemsBui
   let(:variant) { create(:cm_variant, product: product, total_inventory: 10, pregenerate_inventory_items: true, pre_inventory_days: 3) }
 
   describe '#call' do
-    let(:line_item) { create(:line_item, variant: variant, quantity: 1, from_date: Time.zone.tomorrow, to_date: Time.zone.tomorrow + 3) }
+    let(:line_item) { create(:line_item, variant: variant, quantity: 1, from_date: Time.zone.tomorrow, to_date: Time.zone.tomorrow + 2) }
     let(:inventory_items) { variant.reload.inventory_items }
 
     before do

--- a/spec/models/spree_cm_commissioner/redis_stock/variant_cached_inventory_items_builder_spec.rb
+++ b/spec/models/spree_cm_commissioner/redis_stock/variant_cached_inventory_items_builder_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe SpreeCmCommissioner::RedisStock::VariantCachedInventoryItemsBuild
     end
 
     it 'return inventory keys of variant.inventory_items base on checkin/checkout date' do
-      result = described_class.new(variant_id: variant.id, from_date: Time.zone.tomorrow, to_date: Time.zone.today + 4).call # +4 because it exclude checkout date
+      result = described_class.new(variant_id: variant.id, dates: Time.zone.tomorrow..(Time.zone.tomorrow + 3)).call
 
       expect(result.map(&:to_h)).to eq([
         {:inventory_key => "inventory:#{inventory_items[0].id}", active: true, :quantity_available => 2, :inventory_item_id => inventory_items[0].id, :variant_id => variant.id},

--- a/spec/serializers/spree/v2/storefront/line_item_serializer_spec.rb
+++ b/spec/serializers/spree/v2/storefront/line_item_serializer_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe Spree::V2::Storefront::LineItemSerializer, type: :serializer do
         :display_pre_tax_amount,
         :amount,
         :display_amount,
+        :checkin_date,
+        :checkout_date,
         :public_metadata,
         :from_date,
         :to_date,


### PR DESCRIPTION
## Problem
Previously, to actual from_date or to_date of line_item, we do conditioning as following:
- For accommodation: from_date...to_date - 1 day (exclude the checkout date)
- For other product type: from_date...to_date

This looks good at the start, but in code base, we will see us checking this condition everywhere just to date the actual date. 

## Solution
Store actual date in from_date & to_date
- For accommodation: from_date & to_date are stay date
- For transit: from_date & to_date are the same date
- For service: from_date & to_date are service date

So purpose from_date & to_date is now unify and easy to use, no need to check condition everywhere.

## Next
- We need to search hotel by stay date instead of check-in & checkout date
- We also need to pass stay date to create line item instead of checkin/out date
- After purchase, we also have to display :checkout_date instead of :to_date.