### PR TITLE
Close #2643 fix passing wrong send_name which cause sms to not send

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ GIT
 PATH
   remote: .
   specs:
-    spree_cm_commissioner (1.8.10)
+    spree_cm_commissioner (1.10.0.pre.hotfix.pre.sms)
       activerecord-multi-tenant
       activerecord_json_validator (~> 2.1, >= 2.1.3)
       aws-sdk-cloudfront

--- a/app/interactors/spree_cm_commissioner/pin_code_sender.rb
+++ b/app/interactors/spree_cm_commissioner/pin_code_sender.rb
@@ -1,5 +1,7 @@
 module  SpreeCmCommissioner
   class PinCodeSender < BaseInteractor
+    include SpreeCmCommissioner::PinCodeSenderHelper
+
     def call
       context.fail!(message: I18n.t('pincode_sender.pincode.blank')) if context.pin_code.nil?
 
@@ -15,10 +17,8 @@ module  SpreeCmCommissioner
     private
 
     def send_sms
-      from = context.tenant || Spree::Store.default
-
       options = {
-        from: from,
+        from: sender_name(context.tenant),
         to: context.pin_code.contact,
         body: I18n.t('pincode_sender.sms.body', code: context.pin_code.code, readable_type: context.pin_code.readable_type)
       }

--- a/app/interactors/spree_cm_commissioner/sms.rb
+++ b/app/interactors/spree_cm_commissioner/sms.rb
@@ -11,6 +11,8 @@ module  SpreeCmCommissioner
         context.sms_log.error = e.message
         context.sms_log.save
         context.fail!(message: e.message)
+
+        log_error_to_telegram(e.message)
       end
     end
 
@@ -56,6 +58,18 @@ module  SpreeCmCommissioner
 
       result = SpreeCmCommissioner::InternationalMobileFormatter.call(phone_number: number)
       result.formatted_phone_number
+    end
+
+    def log_error_to_telegram(message)
+      return unless ENV['PIN_CODE_DEBUG_NOTIFIY_TELEGRAM_ENABLE'] == 'yes'
+
+      options = {
+        pin_code_id: context.pin_code.id,
+        tenant_id: context.tenant&.id,
+        error_message: message
+      }
+
+      SpreeCmCommissioner::TelegramDebugPinCodeSenderJob.perform_later(options)
     end
   end
 end

--- a/app/interactors/spree_cm_commissioner/telegram_debug_pin_code_sender.rb
+++ b/app/interactors/spree_cm_commissioner/telegram_debug_pin_code_sender.rb
@@ -1,6 +1,6 @@
 module SpreeCmCommissioner
   class TelegramDebugPinCodeSender < BaseInteractor
-    delegate :pin_code, :name, to: :context
+    delegate :pin_code, :name, :error_message, to: :context
 
     def call
       telegram_client.send_message(
@@ -16,6 +16,7 @@ module SpreeCmCommissioner
       text << "<b>From: #{name}</b>"
       text << "<b>PIN CODE sent to #{pin_code.contact}</b>"
       text << "<code>#{pin_code.code}</code> is your #{pin_code.readable_type}"
+      text << "⚠️ Error: <code>#{error_message}<code> ⚠️" if error_message.present?
 
       text.compact.join("\n")
     end

--- a/app/jobs/spree_cm_commissioner/telegram_debug_pin_code_sender_job.rb
+++ b/app/jobs/spree_cm_commissioner/telegram_debug_pin_code_sender_job.rb
@@ -5,12 +5,14 @@ module SpreeCmCommissioner
     def perform(options)
       pin_code = SpreeCmCommissioner::PinCode.find(options[:pin_code_id])
       tenant = SpreeCmCommissioner::Tenant.find_by(id: options[:tenant_id])
+      error_message = options[:error_message]
 
       name = sender_name(tenant)
 
       SpreeCmCommissioner::TelegramDebugPinCodeSender.call(
         pin_code: pin_code,
-        name: name
+        name: name,
+        error_message: error_message
       )
     end
   end

--- a/lib/spree_cm_commissioner/version.rb
+++ b/lib/spree_cm_commissioner/version.rb
@@ -1,5 +1,5 @@
 module SpreeCmCommissioner
-  VERSION = '1.9.0'.freeze
+  VERSION = '1.10.0-hotfix-sms'.freeze
 
   module_function
 

--- a/spec/interactors/spree_cm_commissioner/pin_code_sender_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/pin_code_sender_spec.rb
@@ -5,38 +5,37 @@ RSpec.describe SpreeCmCommissioner::PinCodeSender do
     context 'when contact_type is email' do
       it 'send code to the given email' do
         code = create(:pin_code, contact: 'admin@gmail.com', contact_type: :email, type: 'SpreeCmCommissioner::PinCodeLogin')
-        
-        allow_any_instance_of(SpreeCmCommissioner::PinCodeSender).to receive(:send_email)
-        
+
+        expect(SpreeCmCommissioner::PinCodeMailer).to receive(:send_pin_code).with(code.id, code.readable_type, nil).and_call_original
+
         SpreeCmCommissioner::PinCodeSender.call(pin_code: code)
       end
     end
-    
+
     context 'contact type is mobile number' do
       it 'send sms' do
         pin_code = create(:pin_code, contact: '087420441', contact_type: :phone_number,
           type: 'SpreeCmCommissioner::PinCodeLogin')
-          
+
           options = {
+            from: 'Spree Test Store',
             to: pin_code.contact,
             body: "#{pin_code.code} is your #{pin_code.readable_type}"
           }
-          
-          allow_any_instance_of(SpreeCmCommissioner::PinCodeSender).to receive(:send_sms)
-          allow_any_instance_of(SpreeCmCommissioner::SmsPinCodeJob).to receive(:perform_now).with(options)
-          
+
+          expect(SpreeCmCommissioner::SmsPinCodeJob).to receive(:perform_later).with(options)
+
           SpreeCmCommissioner::PinCodeSender.call(pin_code: pin_code)
         end
       end
-      
+
       context 'when pin code is nil' do
         it 'return error' do
           send_pin_code_context = SpreeCmCommissioner::PinCodeSender.call(pin_code: nil)
-          
+
           expect(send_pin_code_context.success?).to eq false
           expect(send_pin_code_context.message).to eq I18n.t('pincode_sender.pincode.blank')
         end
       end
     end
   end
-  

--- a/spec/interactors/spree_cm_commissioner/telegram_debug_pin_code_sender_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/telegram_debug_pin_code_sender_spec.rb
@@ -41,5 +41,24 @@ RSpec.describe SpreeCmCommissioner::TelegramDebugPinCodeSender do
 
       described_class.call(pin_code: pin_code, name: store.name)
     end
+
+    context 'with error_message' do
+      it 'sends phone PIN code to Telegram channel' do
+        allow(ENV).to receive(:fetch).with('EXCEPTION_NOTIFIER_TELEGRAM_CHANNEL_ID', nil).and_return('channel-id')
+
+        expect_any_instance_of(Telegram::Bot::Client).to receive(:send_message).with(
+          chat_id: 'channel-id',
+          parse_mode: 'HTML',
+          text: <<~TEXT.chomp
+            <b>From: Test Store</b>
+            <b>PIN CODE sent to #{pin_code.contact}</b>
+            <code>#{pin_code.code}</code> is your login code
+            ⚠️ Error: <code>{"message": { "sender": "Not a valid string." }}<code> ⚠️
+          TEXT
+        )
+
+        described_class.call(pin_code: pin_code, name: store.name, error_message: '{"message": { "sender": "Not a valid string." }}')
+      end
+    end
   end
 end

--- a/spec/jobs/spree_cm_commissioner/telegram_debug_pin_code_sender_job_spec.rb
+++ b/spec/jobs/spree_cm_commissioner/telegram_debug_pin_code_sender_job_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe SpreeCmCommissioner::TelegramDebugPinCodeSenderJob do
     it 'calls TelegramDebugPinCodeSender with correct pin_code and name' do
       expect(SpreeCmCommissioner::TelegramDebugPinCodeSender)
         .to receive(:call)
-        .with(pin_code: SpreeCmCommissioner::PinCode.find(pin_code.id), name: vendor.name)
+        .with(pin_code: SpreeCmCommissioner::PinCode.find(pin_code.id), name: vendor.name, error_message: nil)
 
-      subject.perform({ pin_code_id: pin_code.id, tenant_id: tenant.id })
+      subject.perform({ pin_code_id: pin_code.id, tenant_id: tenant.id, error_message: nil })
     end
   end
 end


### PR DESCRIPTION
- Fix the bug
- Alert the error to telegram so that we will have quicker action.