### PR TITLE
Close #2645 skip PR check if it is a tag

### DIFF
--- a/.github/workflows/test_and_build_gem.yml
+++ b/.github/workflows/test_and_build_gem.yml
@@ -19,6 +19,7 @@ jobs:
 
     steps:
       - name: Check PR title format
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
@@ -36,6 +37,7 @@ jobs:
               console.log("PR title format is correct.");
             }
       - name: Check commit messages format
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
@@ -67,6 +69,7 @@ jobs:
               console.log("All commit messages are correctly formatted.");
             }
       - name: Check for unresolved review threads
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Problem is when pushing tag, it check the PR comment, title which does not have in an tag. This cause error during build gem.