### PR TITLE
Close #2656 add jobs to update invalid nested places

### DIFF
--- a/lib/tasks/update_invalid_self_root_places.rake
+++ b/lib/tasks/update_invalid_self_root_places.rake
@@ -1,0 +1,9 @@
+namespace :spree_cm_commissioner do
+  desc 'Update invalid self-root places...'
+  task update_invalid_self_root_places: :environment do
+    SpreeCmCommissioner::Place.where('id = parent_id').find_each do |place|
+      place.update_columns(parent_id: nil) # rubocop:disable Rails/SkipsModelValidations
+    end
+    puts '✓ Fixed self-root places'
+  end
+end

--- a/lib/tasks/update_orphan_root_places.rake
+++ b/lib/tasks/update_orphan_root_places.rake
@@ -2,6 +2,7 @@ namespace :spree_cm_commissioner do
   desc 'Update orphan root places...'
   task update_orphan_root_places: :environment do
     count = SpreeCmCommissioner::Place.where(parent_id: 0).update_all(parent_id: nil) # rubocop:disable Rails/SkipsModelValidations
+    SpreeCmCommissioner::Place.where(parent_id: nil).update_all(depth: 0) # rubocop:disable Rails/SkipsModelValidations
     puts "#{count} orphan root places updated."
   end
 end


### PR DESCRIPTION
In this PR, I have added the jobs to run once when 
- `update_invalid_self_root_places.rake`: The places are created with invalid or circular parents. Example: 
`Place_id: 1`, `parent_id: 1` (This case happens in staging before adding nestedset)
- `update_orphan_root_places.rake`: makes sure it won't remain depth > 0 for parent_id: nil. (When updating the circular parent, the depth will be > 0, so we have to reset it)