### PR TITLE
Close #2664 filter only vendor roles

### DIFF
--- a/app/overrides/spree/admin/users/_form/roles_fields.html.erb.deface
+++ b/app/overrides/spree/admin/users/_form/roles_fields.html.erb.deface
@@ -1,0 +1,2 @@
+<!-- replace 'erb[loud]:contains("f.collection_check_boxes :spree_role_ids")' -->
+<%= f.collection_check_boxes :spree_role_ids, Spree::Role.non_vendor, :id, :name do |role_form| %>


### PR DESCRIPTION
- In last PR i delete this deface file for testing and i accident push that code now i add it back.  
- It filter show only vendor roles in edit user
<img width="539" alt="CleanShot 2025-05-21 at 14 49 31@2x" src="https://github.com/user-attachments/assets/1509bbf8-4ec4-4f45-a684-1eb93aa549ee" />
