### PR TITLE
Close #2670 update github action config file

### DIFF
--- a/.github/workflows/test_and_build_gem.yml
+++ b/.github/workflows/test_and_build_gem.yml
@@ -37,6 +37,8 @@ jobs:
               console.log("PR title format is correct.");
             }
       - name: Check commit messages format
+        # skip validation if the PR is from the milestone-77-scalable-design branch for temporary
+        if: github.head_ref != 'milestone-77-scalable-design'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
**Why?**
The current problem is that
1. We already mege branch **develop** into branch **milestone-77-scalable-design**
2. There is a commit that wrong format because it use ":"

**How?**
- Update the GitHub action file to skip the validation temporarily.