### PR TITLE
Close #2672 sync updated event date to old line items

### DIFF
--- a/app/interactors/spree_cm_commissioner/event_line_items_date_syncer.rb
+++ b/app/interactors/spree_cm_commissioner/event_line_items_date_syncer.rb
@@ -1,0 +1,19 @@
+module SpreeCmCommissioner
+  class EventLineItemsDateSyncer < BaseInteractor
+    delegate :event, to: :context
+
+    def call
+      return unless event.event?
+      return unless event.depth == 1
+
+      event.event_line_items.includes(:variant).find_each do |line_item|
+        new_from = line_item.variant.start_date_time || event.from_date
+        new_to = line_item.variant.end_date_time || event.to_date
+
+        # Update could be failed here if case line item does not allowed to change or no longer available.
+        # We can ignore this line item in this case.
+        line_item.update(from_date: new_from, to_date: new_to) if line_item.from_date != new_from || line_item.to_date != new_to
+      end
+    end
+  end
+end

--- a/app/jobs/spree_cm_commissioner/event_line_items_date_syncer_job.rb
+++ b/app/jobs/spree_cm_commissioner/event_line_items_date_syncer_job.rb
@@ -1,0 +1,8 @@
+module SpreeCmCommissioner
+  class EventLineItemsDateSyncerJob < ApplicationJob
+    def perform(event_id)
+      event = Spree::Taxon.event.find(event_id)
+      SpreeCmCommissioner::EventLineItemsDateSyncer.call(event: event)
+    end
+  end
+end

--- a/app/models/concerns/spree_cm_commissioner/line_item_durationable.rb
+++ b/app/models/concerns/spree_cm_commissioner/line_item_durationable.rb
@@ -3,6 +3,7 @@ module SpreeCmCommissioner
     extend ActiveSupport::Concern
 
     included do
+      before_validation :set_event_id
       before_validation :set_duration
     end
 
@@ -44,6 +45,13 @@ module SpreeCmCommissioner
 
     private
 
+    def set_event_id
+      self.event_id ||= product.event_id
+    end
+
+    # Line item date now depends directly on the event date and variant date.
+    # No longer depend on the event section date.
+    # This keeps the setup simple for the organizer and consistent for users.
     def set_duration
       self.from_date ||= variant.start_date_time || event&.from_date
       self.to_date ||= variant.end_date_time || event&.to_date

--- a/app/models/spree_cm_commissioner/line_item_decorator.rb
+++ b/app/models/spree_cm_commissioner/line_item_decorator.rb
@@ -16,8 +16,6 @@ module SpreeCmCommissioner
       base.has_many :product_completion_steps, class_name: 'SpreeCmCommissioner::ProductCompletionStep', through: :product
       base.has_many :line_item_seats, class_name: 'SpreeCmCommissioner::LineItemSeat', dependent: :destroy
 
-      base.before_validation :set_event_id
-
       base.before_save :update_vendor_id
       base.before_save :update_quantity, if: :transit?
 
@@ -207,10 +205,6 @@ module SpreeCmCommissioner
       return if line_item_seats.blank?
 
       self.quantity = line_item_seats.size
-    end
-
-    def set_event_id
-      self.event_id ||= product.event_id
     end
 
     def update_vendor_id

--- a/app/overrides/spree/admin/taxons/_form/assets_form.html.erb.deface
+++ b/app/overrides/spree/admin/taxons/_form/assets_form.html.erb.deface
@@ -1,7 +1,8 @@
 <!-- replace "erb[loud]:contains('assets_form')" -->
 
+<%# Sections don't use assets, so we hide the form here to avoid confusing admin. %>
 
-<div class="row">
+<div class="row <%= "d-none" unless @taxon.depth == 1 %>">
   <%# "@taxon.icon is not used yet" %>
   <%# render 'shared/asset_field',
     field: :icon,
@@ -67,4 +68,3 @@
     <% end %>
   <% end %>
 </div>
-

--- a/app/overrides/spree/admin/taxons/_form/available_on.html.erb.deface
+++ b/app/overrides/spree/admin/taxons/_form/available_on.html.erb.deface
@@ -1,6 +1,8 @@
 <!-- insert_before "erb[loud]:contains('field_container :parent_id')" -->
 
-<div class="form-group">
+<%# Sections don't use available_on, so we hide the form here to avoid confusing admin. %>
+
+<div class="form-group <%= "d-none" unless @taxon.depth == 1 %>">
   <%= label_tag nil, Spree.t(:available_on) %>
   <div class="input-group datePickerFrom"
           data-wrap="true"

--- a/app/overrides/spree/admin/taxons/_form/background_color_and_foreground_color.html.erb.deface
+++ b/app/overrides/spree/admin/taxons/_form/background_color_and_foreground_color.html.erb.deface
@@ -1,6 +1,8 @@
 <!-- insert_before "erb[loud]:contains('field_container :meta_title')" -->
 
-<div class="row">
+<%# Sections don't use colors, so we hide the form here to avoid confusing admin. %>
+
+<div class="row <%= "d-none" unless @taxon.depth == 1 %>">
   <div class="col-md-6">
     <%= f.label :preferred_background_color, Spree.t('background_color'), class: 'form-label' %>
     <%= f.text_field :preferred_background_color, class: 'form-control color-picker', placeholder: '#FFFFFF', value: @object.preferred_background_color %>

--- a/app/overrides/spree/admin/taxons/_form/custom_redirect_url.html.erb.deface
+++ b/app/overrides/spree/admin/taxons/_form/custom_redirect_url.html.erb.deface
@@ -1,6 +1,8 @@
 <!-- insert_after "erb[loud]:contains('field_container :permalink')" -->
 
+<%# Sections don't use custom_redirect_url, so we hide the form here to avoid confusing admin. %>
+
 <%= f.field_container :custom_redirect_url do %>
   <%= f.label :custom_redirect_url, Spree.t(:custom_redirect_url) %>
   <%= f.text_field :custom_redirect_url, class: 'form-control', rows: 6 %>
-<% end %>
+<% end if @taxon.depth == 1 %>

--- a/app/overrides/spree/admin/taxons/_form/hide_video_banner.html.erb.deface
+++ b/app/overrides/spree/admin/taxons/_form/hide_video_banner.html.erb.deface
@@ -1,7 +1,9 @@
 <!-- insert_before "erb[loud]:contains('field_container :hide_from_nav')" -->
 
+<%# Sections don't use video banner, so we hide the form here to avoid confusing admin. %>
+
 <%= f.field_container :hide_video_banner, class: ['custom-control', 'custom-checkbox', 'my-4'] do %>
   <%= f.check_box :hide_video_banner, class: 'custom-control-input' %>
   <%= f.label :hide_video_banner, Spree.t(:hide_video_banner), class: 'custom-control-label' %>
   <%= f.error_message_on :hide_video_banner %>
-<% end %>
+<% end if @taxon.depth == 1 %> %>

--- a/app/overrides/spree/admin/taxons/_form/purchasable_on_status.html.erb.deface
+++ b/app/overrides/spree/admin/taxons/_form/purchasable_on_status.html.erb.deface
@@ -1,5 +1,7 @@
 <!-- insert_before "erb[loud]:contains('field_container :parent_id')" -->
 
+<%# Sections don't use purchasable_on, so we hide the form here to avoid confusing admin. %>
+
 <%= f.field_container :purchasable_on do %>
   <%= f.label :purchasable_on, Spree.t('purchasable_on'), class: 'form-label' %>
   <%= f.select :purchasable_on,
@@ -7,4 +9,4 @@
         {  },
         { class: 'select2 form-control' } %>
   <%= f.error_message_on :purchasable_on, class: 'text-danger' %>
-<% end %>
+<% end if @taxon.depth == 1 %>

--- a/app/overrides/spree/admin/taxons/_form/show_badge_status.html.erb.deface
+++ b/app/overrides/spree/admin/taxons/_form/show_badge_status.html.erb.deface
@@ -1,5 +1,7 @@
 <!-- insert_before "erb[loud]:contains('field_container :parent_id')" -->
 
+<%# Sections don't use show_badge_status, so we hide the form here to avoid confusing admin. %>
+
 <%= f.field_container :show_badge_status do %>
   <%= f.label :show_badge_status, Spree.t('show_badge_status'), class: 'form-label' %>
   <%= f.select :show_badge_status,
@@ -7,5 +9,5 @@
         {  },
         { class: 'select2 form-control' } %>
   <%= f.error_message_on :show_badge_status, class: 'text-danger' %>
-<% end %>
+<% end if @taxon.depth == 1 %>
 

--- a/app/overrides/spree/admin/taxons/_form/to_date_form_date.html.erb.deface
+++ b/app/overrides/spree/admin/taxons/_form/to_date_form_date.html.erb.deface
@@ -1,6 +1,8 @@
 <!-- insert_after "erb[loud]:contains('field_container :permalink')" -->
 
-<div class="form-group date-range-filter">
+<%# Beside event, from_date & to_date aren't used inside the system elsewhere. Hide them from UI to avoid confusion %>
+
+<div class="form-group date-range-filter <%= "d-none" unless @object.event? && @object.depth == 1 %>">
   <div class="date-range-filter row">
     <div class="col-12 col-md-6 mb-3 mb-md-0">
       <%= label_tag nil, Spree.t(:from_date) %>
@@ -35,6 +37,3 @@
     </div>
   </div>
 </div>
-
-
-

--- a/app/overrides/spree/admin/variants/edit/variant_status.html.erb.deface
+++ b/app/overrides/spree/admin/variants/edit/variant_status.html.erb.deface
@@ -2,12 +2,15 @@
 
 <% unless f.object.accommodation? %>
   <div class="m-3 mb-0">
-    <% valid_duration = f.object.start_date_time.present? && f.object.end_date_time.present? %>
+    <% from_date = f.object.start_date_time || f.object.event.from_date %>
+    <% to_date = f.object.end_date_time || f.object.event.to_date %>
+
+    <% valid_duration = from_date.present? && to_date.present? %>
     <% alert_class = valid_duration ? 'alert-success' : 'alert-warning' %>
 
     <div class="alert <%= alert_class %> mb-0">
       <%= svg_icon(name: valid_duration ? "check2-circle.svg" : 'cancel.svg', width: '16', height: '16') %>
-      This variant have start date: <strong><%= pretty_time(f.object.start_date_time).presence || 'N/A' %></strong> and end date: <strong><%= pretty_time(f.object.end_date_time).presence || 'N/A' %></strong>
+      This variant have start date: <strong><%= pretty_time(from_date).presence || 'N/A' %></strong> and end date: <strong><%= pretty_time(to_date).presence || 'N/A' %></strong>
     </div>
 
     <div class="mb-1"></div>
@@ -16,7 +19,7 @@
       <% option_types = Spree::OptionType.where(name: ["start-date", "end-date", "start-time", "end-time", "reminder-in-hours", "duration-in-hours", "duration-in-minutes", "duration-in-seconds"]) %>
       <% event_link = f.object.event.present? ? edit_admin_taxonomy_taxon_url(f.object.event.taxonomy.id, f.object.event.id) : edit_admin_product_url(f.object.product) %>
 
-      Duration can be set by either adding <%= link_to 'event section date', event_link, target: '_blank' %> or add option type such as <%= option_types.pluck(:presentation).to_sentence %>
+      Duration can be set by either adding <%= link_to 'event date', event_link, target: '_blank' %> or add option type such as <%= option_types.pluck(:presentation).to_sentence %>
     </small>
   </div>
 <% end %>

--- a/app/views/spree/admin/shared/_taxon_tabs.html.erb
+++ b/app/views/spree/admin/shared/_taxon_tabs.html.erb
@@ -5,43 +5,43 @@
       Spree.t(:details),
       edit_admin_taxonomy_taxon_url(@taxonomy.id, @taxon.id),
       class: "nav-link #{'active' if current == :details}" %>
-  <% end if can?(:admin, Spree::Taxonomy) %>
+  <% end if can?(:manage, Spree::Taxonomy) %>
 
   <%= content_tag :li, class: 'nav-item' do %>
     <%= link_to_with_icon 'store.svg',
       Spree.t(:vendors),
       admin_taxonomy_taxon_taxon_vendors_url(@taxonomy.id, @taxon.id),
       class: "nav-link #{'active' if current == :vendors}" %>
-  <% end if can?(:admin,SpreeCmCommissioner::TaxonVendor)%>
+  <% end if can?(:manage, SpreeCmCommissioner::TaxonVendor) && @taxon.depth == 2 %>
+
   <% if @taxon.depth != 1 %>
-
- <%= content_tag :li, class: 'nav-item' do %>
-    <%= link_to_with_icon 'inbox.svg',
-      Spree.t(:products),
-      admin_taxonomy_taxon_classifications_url(@taxonomy.id, @taxon.id),
-      class: "nav-link #{'active' if current == :products}" %>
-  <% end if can?(:admin, Spree::Classification)%>
-  <%else%>
     <%= content_tag :li, class: 'nav-item' do %>
-        <%= link_to_with_icon 'store.svg',
-          Spree.t(:sections),
-          admin_taxonomy_taxon_taxon_childrens_url(@taxonomy.id, @taxon.id),
-          class: "nav-link #{'active' if current == :sections}" %>
-    <% end if can?(:admin,Spree::Taxon)%>
-    <%end%>
+      <%= link_to_with_icon 'inbox.svg',
+        Spree.t(:products),
+        admin_taxonomy_taxon_classifications_url(@taxonomy.id, @taxon.id),
+        class: "nav-link #{'active' if current == :products}" %>
+    <% end if can?(:manage, Spree::Classification)%>
+  <% else %>
+    <%= content_tag :li, class: 'nav-item' do %>
+      <%= link_to_with_icon 'store.svg',
+        Spree.t(:sections),
+        admin_taxonomy_taxon_taxon_childrens_url(@taxonomy.id, @taxon.id),
+        class: "nav-link #{'active' if current == :sections}" %>
+      <% end if can?(:manage, Spree::Taxon)%>
+  <% end %>
 
+  <%# user event only show for event %>
   <%= content_tag :li, class: 'nav-item' do %>
     <%= link_to_with_icon 'user.svg',
       Spree.t(:user_events),
-      # admin_taxonomy_taxon_user_taxons_url(@taxonomy, @taxon.id),
       admin_user_events_path(params: {taxon_id: @taxon.id, taxonomy_id: @taxonomy}),
       class: "nav-link #{'active' if current == :user_events}" %>
-  <% end if can?(:admin, SpreeCmCommissioner::UserTaxon) %>
+  <% end if can?(:manage, SpreeCmCommissioner::UserTaxon) && @taxon.event? && @taxon.depth == 1 %>
 
  <%= content_tag :li, class: 'nav-item' do %>
     <%= link_to_with_icon 'store.svg',
       Spree.t(:guest_card_classes),
       admin_taxonomy_taxon_guest_card_classes_url(@taxonomy.id, @taxon.id),
       class: "nav-link #{'active' if current == :guest_card_classes}" %>
-      <% end if can?(:admin,SpreeCmCommissioner::GuestCardClasses)%>
+      <% end if can?(:manage, SpreeCmCommissioner::GuestCardClasses) && @taxon.event? && @taxon.depth == 1 %>
 <% end %>

--- a/spec/interactors/spree_cm_commissioner/event_line_items_date_syncer_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/event_line_items_date_syncer_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::EventLineItemsDateSyncer do
+  describe '.call' do
+    let!(:taxonomy) { create(:taxonomy, kind: :event) }
+    let!(:event) { create(:taxon, name: 'BunPhum', taxonomy: taxonomy, kind: :event, from_date: '2001-01-01'.to_date, to_date: '2001-01-02'.to_date) }
+    let!(:section) { create(:taxon, parent: event, taxonomy: taxonomy, name: 'Section A', kind: :event) }
+
+
+    context 'when variant does not has :start_date_time' do
+      let!(:product) { create(:product, taxons: [section]) }
+      let!(:variant) { create(:cm_variant, product: product) }
+      let!(:line_item) { create(:line_item, variant: variant) }
+
+      before do
+        # make sure data correct
+        expect(line_item.from_date).to eq '2001-01-01'.to_date
+        expect(line_item.to_date).to eq '2001-01-02'.to_date
+        expect(line_item.event_id).to eq event.id
+
+        # avoid it taxon to run callback, which will trigger this class.
+        # we want to trigger them manually in this instead.
+        allow(event).to receive(:sync_event_line_item_dates).and_return(true)
+      end
+
+      it 'update previous line item to new event date' do
+        event.update!(from_date: '2050-01-01'.to_date, to_date: '2050-01-02'.to_date)
+        described_class.call(event: event.reload)
+
+        expect(line_item.reload.from_date).to eq '2050-01-01'.to_date
+        expect(line_item.reload.to_date).to eq '2050-01-02'.to_date
+      end
+    end
+
+    context 'when variant has :start_date_time' do
+      let(:start_date) { create(:cm_option_type, :start_date) }
+      let(:start_date_value) { create(:cm_option_value, name: '2020-01-01', option_type: start_date) }
+
+      let(:end_date) { create(:cm_option_type, :end_date) }
+      let(:end_date_value) { create(:cm_option_value, name: '2020-01-05', option_type: end_date) }
+
+      let!(:product) { create(:product, taxons: [section], option_types: [start_date, end_date]) }
+      let!(:variant) { create(:cm_variant, product: product, option_values: [start_date_value, end_date_value]) }
+      let!(:line_item) { create(:line_item, variant: variant) }
+
+      before do
+        # make sure data correct
+        expect(line_item.from_date).to eq '2020-01-01'.to_date
+        expect(line_item.to_date).to eq '2020-01-05'.to_date
+        expect(line_item.event_id).to eq event.id
+
+        # avoid it taxon to run callback, which will trigger this class.
+        # we want to trigger them manually in this instead.
+        allow(event).to receive(:sync_event_line_item_dates).and_return(true)
+      end
+
+      it 'keep variant date instead of using new date' do
+        event.update!(from_date: '2050-01-01'.to_date, to_date: '2050-01-02'.to_date)
+        described_class.call(event: event.reload)
+
+        expect(line_item.reload.from_date).to eq '2020-01-01'.to_date
+        expect(line_item.reload.to_date).to eq '2020-01-05'.to_date
+      end
+    end
+  end
+end

--- a/spec/jobs/spree_cm_commissioner/event_line_items_date_syncer_job_spec.rb
+++ b/spec/jobs/spree_cm_commissioner/event_line_items_date_syncer_job_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::EventLineItemsDateSyncerJob, type: :job do
+  describe '#perform' do
+    let(:taxonomy) { create(:taxonomy, kind: :event) }
+    let(:event) { create(:taxon, name: 'BunPhum', taxonomy: taxonomy) }
+
+    it 'calls EventLineItemsDateSyncer with the correct event' do
+      expect(SpreeCmCommissioner::EventLineItemsDateSyncer).to receive(:call).with(event: event)
+      described_class.new.perform(event.id)
+    end
+  end
+end


### PR DESCRIPTION
## Problem
When an event changes the date, previous line items still keep the old date, our solution is to manually update the date for all line items.

## Solution
When event dates change, sync them to previous line items.

## In this PR
- [x] Sync new event date to previous line items
- [x] Line item no longer use section dates
  - We use event date directly, and if admin want to override, we can override in variant
  - Hide date fields & other related fields from admin section UI to avoid confusion.

| |
| - |
| Section UI Before |
| <img width="1728" alt="image" src="https://github.com/user-attachments/assets/8e14d176-5e17-46bf-93c1-b8f69fa08e5c" /> |
| Section UI Now |
| <img width="1728" alt="image" src="https://github.com/user-attachments/assets/0d2848b1-cfb5-4423-bc23-923d354ae591" /> |

