### PR TITLE
Close #2674 fix bug link_to base_header_mailer

### DIFF
--- a/app/mailers/spree_cm_commissioner/pin_code_mailer.rb
+++ b/app/mailers/spree_cm_commissioner/pin_code_mailer.rb
@@ -4,6 +4,7 @@ module SpreeCmCommissioner
 
     def send_pin_code(pin_code_id, action, tenant)
       @pin_code = SpreeCmCommissioner::PinCode.find(pin_code_id)
+      @tenant = tenant
 
       @sender_name = sender_name(tenant)
       @sender_email = sender_email(tenant)

--- a/app/views/spree/shared/_base_mailer_header.html.erb
+++ b/app/views/spree/shared/_base_mailer_header.html.erb
@@ -1,11 +1,19 @@
 <!-- override base_mailer_header.html.erb -->
 <tr>
   <td class="email-masthead">
-    <%= link_to @sender_name, class: 'template-label' do %>
+    <% if defined?(@tenant) && @tenant.present? %>
       <% if @logo_path.present? %>
         <%= image_tag @logo_path, class: 'logo', alt: @sender_name, title: @sender_name %>
       <% else %>
-        <%= @sender_name %>
+        <span class="template-label"><%= @sender_name %></span>
+      <% end %>
+    <% else %>
+      <%= link_to current_store.url, class: 'template-label' do %>
+        <% if @logo_path.present? %>
+          <%= image_tag @logo_path, class: 'logo', alt: current_store.name, title: current_store.name %>
+        <% else %>
+          <%= current_store.name %>
+        <% end %>
       <% end %>
     <% end %>
   </td>


### PR DESCRIPTION
## 🐞 Bug Fix: Mailer Header Error When Vendor Has No URL

In this PR, I fixed a bug in **`base_mailer_header.html.erb`**, specifically on **line 4**, which caused an error when rendering email headers for tenants (vendors).

### 🔍 Problem

The issue was due to using the `link_to` helper with `@sender_name` as the URL. The `link_to` helper requires a valid URL, but vendors (`tenant.active_vendor`) do not have a URL attribute.

- ✅ `current_store.url` is valid and works fine.
- ❌ `vendor` (from tenant) does **not** have a URL, leading to an exception.

### ✅ Solution

- Introduced a `@tenant` instance variable in the mailer to determine the context (tenant vs store).
- Updated `base_mailer_header.html.erb`:
  - If `@tenant` is present, display a plain logo or sender name (no link).
  - If no tenant (fallback to `current_store`), wrap logo/sender name in a valid `link_to current_store.url`.

### 🧩 Sentry Error

| Screenshot 1 | Screenshot 2 |
|--------------|--------------|
| ![Screenshot 1](https://github.com/user-attachments/assets/70a5dbb8-82cf-4c21-9ad1-40eecd6795c3) | ![Screenshot 2](https://github.com/user-attachments/assets/250f14fd-985f-4bb0-82ce-86a5d6ccf748) |


### 📬 Result After Fix

#### 🏷️ HangMeas Tenant (No link – safe rendering)
![HangMeas Tenant](https://github.com/user-attachments/assets/7fe92714-f694-45fc-a58c-908a1000c076)

#### 🏪 Current Store (Uses `current_store.url` correctly)
![Current Store](https://github.com/user-attachments/assets/a7594ea5-989b-45c9-aae0-a5d91df2b0ec)
