### PR TITLE
Close #2677 fix waiting room no method error

### DIFF
--- a/app/interactors/spree_cm_commissioner/waiting_room_session_creator.rb
+++ b/app/interactors/spree_cm_commissioner/waiting_room_session_creator.rb
@@ -44,19 +44,10 @@ module SpreeCmCommissioner
     end
 
     def log_to_firebase
-      current_date = Time.zone.now.strftime('%Y-%m-%d')
-
-      document = firestore.col('waiting_guests')
-                          .doc(current_date)
-                          .col('records')
-                          .doc(waiting_guest_firebase_doc_id)
-
-      data = document.get.data.dup
-      data[:entered_room_at] = Time.zone.now
-      data[:page_path] = page_path
-      data[:tenant_id] = tenant_id
-
-      document.update(data)
+      SpreeCmCommissioner::WaitingRoomSessionFirebaseLoggerJob.perform_later(
+        room_session_id: context.room_session.id,
+        waiting_guest_firebase_doc_id: waiting_guest_firebase_doc_id
+      )
     end
 
     def call_other_waiting_guests

--- a/app/interactors/spree_cm_commissioner/waiting_room_session_firebase_logger.rb
+++ b/app/interactors/spree_cm_commissioner/waiting_room_session_firebase_logger.rb
@@ -1,0 +1,30 @@
+require 'google/cloud/firestore'
+
+module SpreeCmCommissioner
+  class WaitingRoomSessionFirebaseLogger < BaseInteractor
+    delegate :room_session, :waiting_guest_firebase_doc_id, to: :context
+
+    def call
+      current_date = room_session.created_at.strftime('%Y-%m-%d')
+      document = firestore.col('waiting_guests')
+                          .doc(current_date)
+                          .col('records')
+                          .doc(waiting_guest_firebase_doc_id)
+
+      data = document.get.data.dup
+      data[:entered_room_at] = room_session.created_at
+      data[:page_path] = room_session.page_path
+      data[:tenant_id] = room_session.tenant_id
+
+      document.update(data)
+    end
+
+    def firestore
+      @firestore ||= Google::Cloud::Firestore.new(project_id: service_account[:project_id], credentials: service_account)
+    end
+
+    def service_account
+      Rails.application.credentials.cloud_firestore_service_account
+    end
+  end
+end

--- a/app/jobs/spree_cm_commissioner/waiting_room_session_firebase_logger_job.rb
+++ b/app/jobs/spree_cm_commissioner/waiting_room_session_firebase_logger_job.rb
@@ -1,0 +1,13 @@
+module SpreeCmCommissioner
+  class WaitingRoomSessionFirebaseLoggerJob < ApplicationJob
+    def perform(options)
+      room_session = SpreeCmCommissioner::WaitingRoomSession.find(options[:room_session_id])
+      waiting_guest_firebase_doc_id = options[:waiting_guest_firebase_doc_id]
+
+      SpreeCmCommissioner::WaitingRoomSessionFirebaseLogger.call(
+        room_session: room_session,
+        waiting_guest_firebase_doc_id: waiting_guest_firebase_doc_id
+      )
+    end
+  end
+end

--- a/spec/interactors/spree_cm_commissioner/waiting_room_session_creator_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/waiting_room_session_creator_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe SpreeCmCommissioner::WaitingRoomSessionCreator do
   describe '.call', :vcr do
     it 'generate jwt token, record session to db & log it in user firebase document' do
       ENV['WAITING_ROOM_SESSION_SIGNATURE'] = '4234f0a3-c42f-40b5-9057-7c006793cea4'
-      allow_any_instance_of(described_class).to receive(:log_to_firebase)
-      allow_any_instance_of(described_class).to receive(:full?).and_return(false)
+      expect_any_instance_of(described_class).to receive(:log_to_firebase).and_call_original
+      expect_any_instance_of(described_class).to receive(:full?).and_return(false)
 
       # https://github.com/channainfo/commissioner/issues/2185
       expect_any_instance_of(described_class).not_to receive(:call_other_waiting_guests)

--- a/spec/interactors/spree_cm_commissioner/waiting_room_session_firebase_logger_spec.rb
+++ b/spec/interactors/spree_cm_commissioner/waiting_room_session_firebase_logger_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::WaitingRoomSessionFirebaseLogger do
+  let(:mock_firestore) { instance_double(Google::Cloud::Firestore::Client) }
+  let(:mock_doc_ref)   { instance_double(Google::Cloud::Firestore::DocumentReference) }
+  let(:mock_col_ref)   { instance_double(Google::Cloud::Firestore::CollectionReference) }
+  let(:mock_doc_snap)  { instance_double(Google::Cloud::Firestore::DocumentSnapshot) }
+
+  let(:waiting_guest_firebase_doc_id) { 'L0y4wEEKowOI4eWqAW3f' }
+
+  let(:room_session) do
+    SpreeCmCommissioner::WaitingRoomSession.create!(
+      guest_identifier: 'guest_identifier',
+      jwt_token: 'jwt_token',
+      created_at: Time.zone.parse('2025-05-22T10:00:00Z'),
+      updated_at: '2025-05-22'.to_date,
+      expired_at: Date.tomorrow,
+      remote_ip: '168.0.0.1',
+      page_path: '/some/path'
+    )
+  end
+
+  before do
+    allow_any_instance_of(described_class).to receive(:service_account).and_return({ project_id: 'your-mocked-project-id' })
+    allow(Google::Cloud::Firestore).to receive(:new).and_return(mock_firestore)
+
+    # Firestore doc chain: firestore.col(...).doc(...).col(...).doc(...)
+    allow(mock_firestore).to receive(:col).with('waiting_guests').and_return(mock_col_ref)
+    allow(mock_col_ref).to receive(:doc).with('2025-05-22').and_return(mock_doc_ref)
+
+    allow(mock_doc_ref).to receive(:col).with('records').and_return(mock_col_ref)
+    allow(mock_col_ref).to receive(:doc).with(waiting_guest_firebase_doc_id).and_return(mock_doc_ref)
+
+    # Simulate getting existing Firestore data
+    allow(mock_doc_ref).to receive(:get).and_return(mock_doc_snap)
+    allow(mock_doc_snap).to receive(:data).and_return({ name: 'Guest' })
+
+    # Expect update to be called with added `entered_room_at` and `page_path`
+    allow(mock_doc_ref).to receive(:update)
+  end
+
+  it 'logs session info into Firestore' do
+    expect(mock_doc_ref).to receive(:update).with(
+      hash_including(
+        name: 'Guest',
+        entered_room_at: room_session.created_at,
+        page_path: room_session.page_path
+      )
+    )
+
+    described_class.call(
+      room_session: room_session,
+      waiting_guest_firebase_doc_id: waiting_guest_firebase_doc_id,
+    )
+  end
+end

--- a/spec/jobs/spree_cm_commissioner/waiting_room_session_firebase_logger_job_spec.rb
+++ b/spec/jobs/spree_cm_commissioner/waiting_room_session_firebase_logger_job_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe SpreeCmCommissioner::WaitingRoomSessionFirebaseLoggerJob, type: :job do
+  describe '#perform' do
+    let(:room_session) { SpreeCmCommissioner::WaitingRoomSession.create(guest_identifier: 'guest_identifier', jwt_token: 'jwt_token', expired_at: Date.tomorrow, remote_ip: '168.0.0.1') }
+    let(:waiting_guest_firebase_doc_id) { 'firebase_doc_123' }
+
+    let(:options) do
+      {
+        room_session_id: room_session.id,
+        waiting_guest_firebase_doc_id: waiting_guest_firebase_doc_id
+      }
+    end
+
+    it 'calls WaitingRoomSessionFirebaseLogger with correct arguments' do
+      expect(SpreeCmCommissioner::WaitingRoomSessionFirebaseLogger).to receive(:call).with(
+        room_session: room_session,
+        waiting_guest_firebase_doc_id: waiting_guest_firebase_doc_id
+      )
+
+      described_class.perform_now(options)
+    end
+  end
+end


### PR DESCRIPTION
## Problem
```
NoMethodError
[Events](https://bookmeplus.sentry.io/issues/6381804302/events/?query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=3)
Users (90d)
Level: Error
undefined method `[]=' for nil:NilClass (NoMethodError) data[:entered_room_at] = Time.zone.now ^^^^^^^^^^^^^^^^^^^^

      data[:entered_room_at] = Time.zone.now
          ^^^^^^^^^^^^^^^^^^^^
  from spree_cm_commissioner (1.10.0.pre.hotfix.pre.sms) app/interactors/spree_cm_commissioner/waiting_room_session_creator.rb:54:in `log_to_firebase'
  from spree_cm_commissioner (1.10.0.pre.hotfix.pre.sms) app/interactors/spree_cm_commissioner/waiting_room_session_creator.rb:14:in `call'
```

This problem happen when create session for user. It may has problem connection to firebase that why document is null

## Solution
Move logging to firebase to job instead, so it can retry. It didn't affect the current app.