### PR TITLE
Close #2676 CMS Page Enhancement

### DIFF
--- a/app/models/spree_cm_commissioner/cms_page_decorator.rb
+++ b/app/models/spree_cm_commissioner/cms_page_decorator.rb
@@ -1,7 +1,7 @@
 module SpreeCmCommissioner
   module CmsPageDecorator
     def self.prepended(base)
-      base.multi_tenant :tenant, class_name: 'SpreeCmCommissioner::Tenant'
+      base.belongs_to :tenant, class_name: 'SpreeCmCommissioner::Tenant'
     end
   end
 end

--- a/app/overrides/spree/admin/cms_pages/_form/tenant_fields.html.erb.deface
+++ b/app/overrides/spree/admin/cms_pages/_form/tenant_fields.html.erb.deface
@@ -2,6 +2,8 @@
 
 <%= f.field_container :tenant_id, class: ['col-12'] do %>
   <%= f.label :tenant_id, raw(Spree.t(:tenant) + ' (optional)') %>
-  <%= f.collection_select :tenant_id, SpreeCmCommissioner::Tenant.all, :id, :name, { prompt: Spree.t('select_tenant') }, { class: 'form-control select2' } %>
+  <%= f.collection_select :tenant_id, SpreeCmCommissioner::Tenant.all, :id, :name,
+        { prompt: Spree.t('select_tenant'), include_blank: Spree.t('default_store') },
+        { class: 'form-control select2' } %>
   <%= f.error_message_on :tenant_id %>
 <% end %>


### PR DESCRIPTION
This PR Is a Enhancement of CMS Page:
- Allow To Update CMS tenant_id to Null (Default Store) or other Tenant.
- Use belongs_to instead of multi_tenant to avoid tenant immutable.

### Result
<img width="1270" alt="Screenshot 2025-05-22 at 12 23 10 in the afternoon" src="https://github.com/user-attachments/assets/68d4aa82-67d3-4569-bfbb-c7cae0915bc2" />

